### PR TITLE
fix: exec authentication requires interactiveMode

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -282,6 +282,7 @@ func initializeConfiguration(d *schema.ResourceData) (*restclient.Config, error)
 	if v, ok := d.GetOk("exec"); ok {
 		exec := &clientcmdapi.ExecConfig{}
 		if spec, ok := v.([]interface{})[0].(map[string]interface{}); ok {
+			exec.InteractiveMode = clientcmdapi.IfAvailableExecInteractiveMode
 			exec.APIVersion = spec["api_version"].(string)
 			exec.Command = spec["command"].(string)
 			exec.Args = expandStringSlice(spec["args"].([]interface{}))


### PR DESCRIPTION
Updating client-go introduced a regression: `interactiveMode` must be set on the exec struct.

Currently, when using exec authentication, terraform operations will fail trying to reach Kubernetes on localhost:
```
Error: failed to create kubernetes rest client for read of resource: Get "http://localhost/api?timeout=32s": dial tcp [::1]:80: connect: connection refused
```
The real reason is only visible in provider logs:
```
[WARN] Invalid provider configuration was supplied. Provider operations likely to fail: invalid configuration: interactiveMode must be specified for  to use exec authentication plugin
```

Related: hashicorp/terraform-provider-helm#797

