### PR TITLE
Add stringData to Secret's sensitive fields

### DIFF
--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -265,7 +265,7 @@ metadata:
 			if hasSensitiveFields {
 				sensitiveFields = expandStringList(sensitiveFieldsRaw.([]interface{}))
 			} else if parsedYaml.GetKind() == "Secret" && parsedYaml.GetAPIVersion() == "v1" {
-				sensitiveFields = []string{"data"}
+				sensitiveFields = []string{"data", "stringData"}
 			}
 
 			for _, s := range sensitiveFields {


### PR DESCRIPTION
By default, if no sensitive fields are provided in the resource, the controller will mark the Secrets' *data* field as sensitive.

But often, it is way less work to provide data through the *stringData* field that accept non base64 encoded values.
The provider display their content in plain text during the diff.

This pull request add the *stringData* field to the default ones. 