### PR TITLE
Added clarifiction in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ terraform {
 }
 ```
 
-#### Install manually
+### Install manually
 
 If you don't want to use the one-liner above, you can download a binary for your system from the [release page](https://github.com/alekc/terraform-provider-kubectl/releases), 
 then either place it at the root of your Terraform folder or in the Terraform plugin folder on your system.
@@ -76,6 +76,18 @@ YAML
 ```
 
 See [User Guide](https://registry.terraform.io/providers/alekc/kubectl/latest) for details on installation and all the provided data and resource types.
+
+## Changing providers for existing resources
+
+When you used another fork of this provider in the past, it is possible to change the provider on all existing resources within your state. A common use-case of this is to switch from `gavinbunney/kubectl` towards this fork.
+
+Change the `required_providers` sections in your main code and in all used modules to reflect the usage of `alekc/kubectl` as shown above. Once this is done, use the `state replace-provider` to make the switch on all existing resources in your state.
+
+```
+terraform state replace-provider gavinbunney/kubectl alekc/kubectl
+```
+
+You should then `terraform init`, and the next terraform actions will use this provider.
 
 ---
 

--- a/docs/resources/kubectl_manifest.md
+++ b/docs/resources/kubectl_manifest.md
@@ -119,8 +119,8 @@ Optional:
 * `namespace` - Extracted object namespace from `yaml_body`.
 * `uid` - Kubernetes unique identifier from last run.
 * `live_uid` - Current uuid from Kubernetes.
-* `yaml_incluster` - Current yaml within Kubernetes.
-* `live_manifest_incluster` - Current manifest within Kubernetes.
+* `yaml_incluster` - A fingerprint of the current yaml within Kubernetes.
+* `live_manifest_incluster` - A fingerprint of the current manifest within Kubernetes.
 
 ## Sensitive Fields
 


### PR DESCRIPTION
- Added a section in the readme on how to switch existing resources towards the use of this provider
- Clarified that the `yaml_incluster` and `live_manifest_incluster` are actually fingerprints

Closes https://github.com/alekc/terraform-provider-kubectl/issues/77