### PR TITLE
Extend wait_for with optional condition blocks

### DIFF
--- a/internal/types/wait_for.go
+++ b/internal/types/wait_for.go
@@ -2,9 +2,14 @@ package types
 
 type WaitFor struct {
 	Field []WaitForField
+	Condition []WaitForStatusCondition
 }
 type WaitForField struct {
 	Key       string
 	Value     string
 	ValueType string `mapstructure:"value_type"`
+}
+type WaitForStatusCondition struct {
+	Type   string
+	Status string
 }


### PR DESCRIPTION
Addresses #155.

- Extends `wait_for` to also support waiting for `status.Conditions` with a `condition` block.
- Two acceptance tests to cover the addition

Can be used as below, with or without the existing `field` block.

```hcl
resource "kubectl_manifest" "test" {
	wait_for {
		condition {
			type = "ContainersReady"
			status = "True"
		}
		condition {
			type = "Ready"
			status = "True"
		}
		field {
			key = "status.containerStatuses.[0].ready"
			value = "true"
		}
		field {
			key = "status.phase"
			value = "Running"
		}
		field {
			key = "status.podIP"
			value = "^(\\d+(\\.|$)){4}"
			value_type = "regex"
		}
	}
	yaml_body = <<YAML
apiVersion: v1
kind: Pod
metadata:
  name: nginx
spec:
  containers:
  - name: nginx
    image: nginx:1.14.2
    readinessProbe:
      httpGet:
        path: "/"
        port: 80			
      initialDelaySeconds: 10
YAML
}
```