### PR TITLE
feat: Changed to use watch for wait rollout

### DIFF
--- a/docs/resources/kubectl_manifest.md
+++ b/docs/resources/kubectl_manifest.md
@@ -88,7 +88,7 @@ YAML
 * `override_namespace` - Optional. Override the namespace to apply the kubernetes resource to, ignoring any declared namespace in the `yaml_body`.
 * `validate_schema` - Optional. Setting to `false` will mimic `kubectl apply --validate=false` mode. Default `true`.
 * `wait` - Optional. Set this flag to wait or not for finalized to complete for deleted objects. Default `false`.
-* `wait_for_rollout` - Optional. Set this flag to wait or not for Deployments and APIService to complete rollout. Default `true`.
+* `wait_for_rollout` - Optional. Set this flag to wait or not for `Deployment`, `DaemonSet`, `StatefulSet` & `APIService`  resources to complete rollout. Default `true`.
 * `wait_for` - Optional. If set, will wait until either all conditions are satisfied, or until timeout is reached (see [below for nested schema](#wait_for)). Under the hood [gojsonq](https://github.com/thedevsaddam/gojsonq) is used for querying, see the related syntax and examples.
 * `delete_cascade` - Optional; `Background` or `Foreground` are valid options. If set this overrides the default provider behaviour which is to use `Background` unless `wait` is `true` when `Foreground` will be used. To duplicate the default behaviour of `kubectl` this should be explicitly set to `Background`.
 
@@ -210,7 +210,7 @@ More examples can be found in the provider tests.
 
 ## Waiting for Rollout
 
-By default, this resource will wait for Deployments and APIServices to complete their rollout before proceeding.
+By default, this resource will wait for `Deployment`, `DaemonSet`, `StatefulSet` & `APIService` to complete their rollout before proceeding.
 You can disable this behavior by setting the `wait_for_rollout` field to `false`.
 
 ## Import

--- a/kubernetes/resource_kubectl_manifest_test.go
+++ b/kubernetes/resource_kubectl_manifest_test.go
@@ -224,6 +224,156 @@ YAML
 	})
 }
 
+func TestAccKubectl_WaitForRolloutDeployment(t *testing.T) {
+	//language=hcl
+	config := `
+resource "kubectl_manifest" "test" {
+  wait_for_rollout = true
+	yaml_body = <<YAML
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: 80
+            initialDelaySeconds: 10
+YAML
+}
+`
+
+	//start := time.Now()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckkubectlDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+		},
+	})
+}
+
+func TestAccKubectl_WaitForRolloutDaemonSet(t *testing.T) {
+	//language=hcl
+	config := `
+resource "kubectl_manifest" "test" {
+  wait_for_rollout = true
+	yaml_body = <<YAML
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: 80
+            initialDelaySeconds: 10
+YAML
+}
+`
+
+	//start := time.Now()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckkubectlDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+		},
+	})
+}
+
+func TestAccKubectl_WaitForRolloutStatefulSet(t *testing.T) {
+	//language=hcl
+	config := `
+resource "kubectl_manifest" "test" {
+  wait_for_rollout = true
+	yaml_body = <<YAML
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: 80
+            initialDelaySeconds: 10
+YAML
+}
+`
+
+	//start := time.Now()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckkubectlDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+		},
+	})
+}
+
 func TestAccKubectl_RequireWaitForFieldOrCondition(t *testing.T) {
 	//language=hcl
 	config := `
@@ -255,14 +405,13 @@ YAML
 		CheckDestroy: testAccCheckkubectlDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config:      config,
 				ExpectError: expectedError,
 				//todo: improve checking
 			},
 		},
 	})
 }
-
 
 func TestAccKubectl_WaitForField(t *testing.T) {
 	//language=hcl
@@ -315,7 +464,6 @@ YAML
 	})
 }
 
-
 func TestAccKubectl_WaitForConditions(t *testing.T) {
 	//language=hcl
 	config := `
@@ -342,7 +490,7 @@ spec:
     readinessProbe:
       httpGet:
         path: "/"
-        port: 80			
+        port: 80
       initialDelaySeconds: 10
 YAML
 }
@@ -401,7 +549,7 @@ spec:
     readinessProbe:
       httpGet:
         path: "/"
-        port: 80			
+        port: 80
       initialDelaySeconds: 10
 YAML
 }
@@ -420,7 +568,6 @@ YAML
 		},
 	})
 }
-
 
 //func TestAccKubect_Debug(t *testing.T) {
 //	//language=hcl


### PR DESCRIPTION
This PR switches the logic for `wait_for_rollout` to use a watch and adds the missing functionality for `DaemonSet` & `StatefulSet` resources.