### PR TITLE
Removed usage of sergi/go-diff 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/icza/dyno v0.0.0-20200205103839-49cb13720835
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/sergi/go-diff v1.3.1
 	github.com/stretchr/testify v1.9.0
 	github.com/thedevsaddam/gojsonq/v2 v2.5.2
 	github.com/zclconf/go-cty v1.15.0
@@ -102,6 +101,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect

--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sergi/go-diff/diffmatchpatch"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	k8sdelete "k8s.io/kubectl/pkg/cmd/delete"
 
@@ -308,10 +307,11 @@ metadata:
 			liveStateYaml := d.Get("live_manifest_incluster").(string)
 			if stateYaml != liveStateYaml {
 				log.Printf("[TRACE] DETECTED YAML STATE DIFFERENCE %s vs %s", stateYaml, liveStateYaml)
-				dmp := diffmatchpatch.New()
-				patches := dmp.PatchMake(stateYaml, liveStateYaml)
-				patchText := dmp.PatchToText(patches)
-				log.Printf("[DEBUG] DETECTED YAML INCLUSTER STATE DIFFERENCE. Patch diff: %s", patchText)
+				// disabled due to a bug in go-diff library. See https://github.com/alekc/terraform-provider-kubectl/issues/181
+				//dmp := diffmatchpatch.New()
+				//patches := dmp.PatchMake(stateYaml, liveStateYaml)
+				//patchText := dmp.PatchToText(patches)
+				//log.Printf("[DEBUG] DETECTED YAML INCLUSTER STATE DIFFERENCE. Patch diff: %s", patchText)
 				_ = d.SetNewComputed("yaml_incluster")
 			}
 


### PR DESCRIPTION
Removed due to due to a https://github.com/alekc/terraform-provider-kubectl/issues/181

Since its used only for trace, its safe to drop it for now until a fix/replacement is found 