### PR TITLE
Allow upgrading api_version

### DIFF
--- a/docs/resources/kubectl_manifest.md
+++ b/docs/resources/kubectl_manifest.md
@@ -88,6 +88,7 @@ YAML
 * `yaml_body` - Required. YAML to apply to kubernetes.
 * `sensitive_fields` - Optional. List of fields (dot-syntax) which are sensitive and should be obfuscated in output. Defaults to `["data"]` for Secrets.
 * `force_new` - Optional. Forces delete & create of resources if the `yaml_body` changes. Default `false`.
+* `upgrade_api_version` - Optional. When `true`, changing the `apiVersion` in `yaml_body` will update the resource in-place rather than forcing a delete and recreate. This leverages Kubernetes' ability to represent the same object across multiple API versions. Default `false`.
 * `server_side_apply` - Optional. Allow using server-side-apply method. Default `false`.
 * `field_manager` - Optional. Override the default field manager name. This is only relevent when using server-side apply. Default `kubectl`.
 * `force_conflicts` - Optional. Allow using force_conflicts. Default `false`.

--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -196,6 +196,7 @@ metadata:
 				_ = d.Set("force_new", false)
 				_ = d.Set("server_side_apply", false)
 				_ = d.Set("apply_only", false)
+				_ = d.Set("upgrade_api_version", false)
 
 				// clear out fields user can't set to try and get parity with yaml_body
 				meta_v1_unstruct.RemoveNestedField(metaObjLive.Raw.Object, "metadata", "creationTimestamp")
@@ -247,6 +248,13 @@ metadata:
 			_ = d.SetNew("kind", parsedYaml.GetKind())
 			_ = d.SetNew("namespace", parsedYaml.GetNamespace())
 			_ = d.SetNew("name", parsedYaml.GetName())
+
+			// If upgrade_api_version is not set, force recreation when api_version changes
+			// (preserving the default behavior). When upgrade_api_version is true, allow
+			// the api_version change to go through the update path instead.
+			if !d.Get("upgrade_api_version").(bool) && d.HasChange("api_version") {
+				_ = d.ForceNew("api_version")
+			}
 
 			// set the yaml_body_parsed field to provided value and obfuscate the yaml_body values manually
 			// this allows us to show a nice diff to the users with specific fields obfuscated, whilst storing the
@@ -362,7 +370,6 @@ var (
 		"api_version": {
 			Type:     schema.TypeString,
 			Computed: true,
-			ForceNew: true,
 		},
 		"kind": {
 			Type:     schema.TypeString,
@@ -403,6 +410,12 @@ var (
 		"force_new": {
 			Type:        schema.TypeBool,
 			Description: "Default to update in-place. Setting to true will delete and create the kubernetes instead.",
+			Optional:    true,
+			Default:     false,
+		},
+		"upgrade_api_version": {
+			Type:        schema.TypeBool,
+			Description: "When true, changing the api_version in yaml_body will update the resource in-place rather than forcing a delete and recreate. This leverages Kubernetes' ability to represent the same object across multiple API versions.",
 			Optional:    true,
 			Default:     false,
 		},
@@ -616,6 +629,9 @@ func resourceKubectlManifestApply(ctx context.Context, d *schema.ResourceData, m
 	d.SetId(response.GetSelfLink())
 	log.Printf("[DEBUG] %v fetched successfully, set id to: %v", manifest, d.Id())
 
+	// Preserve config-only computed fields in state
+	_ = d.Set("upgrade_api_version", d.Get("upgrade_api_version").(bool))
+
 	// Capture the UID at time of update
 	// this allows us to diff these against the actual values
 	// read in by the 'resourceKubectlManifestRead'
@@ -732,6 +748,9 @@ func resourceKubectlManifestReadUsingClient(ctx context.Context, d *schema.Resou
 
 	// Capture the UID from the cluster at the current time
 	_ = d.Set("live_uid", metaObjLive.GetUID())
+
+	// Preserve config-only computed fields in state
+	_ = d.Set("upgrade_api_version", d.Get("upgrade_api_version").(bool))
 
 	liveManifestFingerprint := getLiveManifestFingerprint(d, manifest, metaObjLive)
 	_ = d.Set("live_manifest_incluster", liveManifestFingerprint)

--- a/kubernetes/resource_kubectl_manifest_test.go
+++ b/kubernetes/resource_kubectl_manifest_test.go
@@ -1989,3 +1989,155 @@ status:
 
 	return manifest
 }
+
+// TestAccKubectl_UpgradeApiVersion_InPlaceUpdate verifies that changing the
+// apiVersion with upgrade_api_version=true updates the resource in-place
+// (preserving its UID) rather than forcing a delete and recreate.
+func TestAccKubectl_UpgradeApiVersion_InPlaceUpdate(t *testing.T) {
+	name := "test-upgrade-api-version-" + acctest.RandString(10)
+
+	configV1 := fmt.Sprintf(`
+resource "kubectl_manifest" "test" {
+	upgrade_api_version = true
+	yaml_body = <<YAML
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: %s
+spec:
+  maxReplicas: 5
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: does-not-exist
+YAML
+}
+`, name)
+
+	configV2 := fmt.Sprintf(`
+resource "kubectl_manifest" "test" {
+	upgrade_api_version = true
+	yaml_body = <<YAML
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: %s
+spec:
+  maxReplicas: 5
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: does-not-exist
+YAML
+}
+`, name)
+
+	var uid string
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckkubectlDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configV1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("kubectl_manifest.test", "api_version", "autoscaling/v1"),
+					resource.TestCheckResourceAttr("kubectl_manifest.test", "upgrade_api_version", "true"),
+					// Capture the UID after initial creation
+					resource.TestCheckResourceAttrWith("kubectl_manifest.test", "uid", func(value string) error {
+						uid = value
+						return nil
+					}),
+				),
+			},
+			{
+				Config: configV2,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("kubectl_manifest.test", "api_version", "autoscaling/v2"),
+					resource.TestCheckResourceAttr("kubectl_manifest.test", "upgrade_api_version", "true"),
+					// Verify UID is unchanged — proves in-place update, not recreate
+					resource.TestCheckResourceAttrWith("kubectl_manifest.test", "uid", func(value string) error {
+						if value != uid {
+							return fmt.Errorf("resource was recreated: UID changed from %s to %s", uid, value)
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
+// TestAccKubectl_UpgradeApiVersion_ForceNewByDefault verifies that changing the
+// apiVersion WITHOUT upgrade_api_version (default false) forces a delete and
+// recreate, resulting in a new UID.
+func TestAccKubectl_UpgradeApiVersion_ForceNewByDefault(t *testing.T) {
+	name := "test-upgrade-api-version-" + acctest.RandString(10)
+
+	configV1 := fmt.Sprintf(`
+resource "kubectl_manifest" "test" {
+	yaml_body = <<YAML
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: %s
+spec:
+  maxReplicas: 5
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: does-not-exist
+YAML
+}
+`, name)
+
+	configV2 := fmt.Sprintf(`
+resource "kubectl_manifest" "test" {
+	yaml_body = <<YAML
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: %s
+spec:
+  maxReplicas: 5
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: does-not-exist
+YAML
+}
+`, name)
+
+	var uid string
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckkubectlDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configV1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("kubectl_manifest.test", "api_version", "autoscaling/v1"),
+					resource.TestCheckResourceAttr("kubectl_manifest.test", "upgrade_api_version", "false"),
+					resource.TestCheckResourceAttrWith("kubectl_manifest.test", "uid", func(value string) error {
+						uid = value
+						return nil
+					}),
+				),
+			},
+			{
+				Config: configV2,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("kubectl_manifest.test", "api_version", "autoscaling/v2"),
+					// Verify UID changed — proves resource was recreated
+					resource.TestCheckResourceAttrWith("kubectl_manifest.test", "uid", func(value string) error {
+						if value == uid {
+							return fmt.Errorf("resource was NOT recreated: UID remained %s", uid)
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
**Summary**

- Add `upgrade_api_version` option to `kubectl_manifest` that allows in-place API version migration instead
of forcing resource deletion and recreation
- When `upgrade_api_version = true`, changing the `apiVersion` in` yaml_body` (e.g. v1beta1 → v1) flows through
 the update path (kubectl apply) rather than destroy+create
- Default is false, preserving existing behavior

**Motivation**

Kubernetes can represent the same object across multiple API versions simultaneously. When migrating a
manifest from one API version to another (e.g. v1beta1 → v1), the underlying resource doesn't change —
only the API endpoint used to address it does.

The current provider behavior forces a complete replacement (delete + create) when the API version
changes. This is dangerous for stateful resources where deletion can cause real data loss. The only
workaround today is to manually remove the resource from Terraform state and re-import it at the new API
version, which is cumbersome and error-prone.

**Usage**
```hcl
resource "kubectl_manifest" "example" {
  upgrade_api_version = true
  yaml_body = <<YAML
apiVersion: v1  # changed from v1beta1
kind: MyResource
metadata:
  name: example
spec:
  ...
YAML
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional upgrade_api_version parameter for Kubernetes manifest resources to allow in-place API version updates when enabled; default behavior remains recreate-on-change.
* **Documentation**
  * Updated resource docs to describe the new upgrade_api_version option and its behavior.
* **Tests**
  * Added acceptance tests verifying in-place updates when enabled and recreate behavior by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->