### PR TITLE
test/ci: parallelize 19 safe tests, gate full matrix behind a smoke job

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -77,9 +77,25 @@ jobs:
         with:
           wait: 2m
           node_image: kindest/node:v${{ needs.get_version_matrix.outputs.latest_k8s_version }}
+      # Install Terraform up-front and hand its absolute path to the test
+      # framework via TF_ACC_TERRAFORM_PATH. Without this, the
+      # terraform-plugin-testing helper installs Terraform into a per-test
+      # temp dir and chmod-then-exec races under -parallel, producing
+      # `fork/exec /tmp/plugintest-terraform.../terraform: text file busy`.
+      # `terraform_wrapper: false` is required so the binary on PATH is the
+      # real Terraform, not the wrapping script setup-terraform installs by
+      # default.
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: ${{ needs.get_version_matrix.outputs.latest_terraform_version }}
+          terraform_wrapper: false
+      - name: Locate Terraform binary
+        id: tfpath
+        run: echo "path=$(which terraform)" >> "${GITHUB_OUTPUT}"
       - name: Acceptance Tests
         env:
           KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
+          TF_ACC_TERRAFORM_PATH: ${{ steps.tfpath.outputs.path }}
           TF_ACC_TERRAFORM_VERSION: ${{ needs.get_version_matrix.outputs.latest_terraform_version }}
           # Tests that opt into parallelism via `t.Parallel()` (Phase 1: all
           # file-only data sources + the resource tests that already use
@@ -123,9 +139,18 @@ jobs:
         with:
           wait: 2m
           node_image: kindest/node:v${{ matrix.k8s_version }}
+      # See acc_test_smoke for why TF_ACC_TERRAFORM_PATH is set.
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: ${{ matrix.terraform_version }}
+          terraform_wrapper: false
+      - name: Locate Terraform binary
+        id: tfpath
+        run: echo "path=$(which terraform)" >> "${GITHUB_OUTPUT}"
       - name: Acceptance Tests
         env:
           KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
+          TF_ACC_TERRAFORM_PATH: ${{ steps.tfpath.outputs.path }}
           TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform_version }}
           ACC_TESTARGS: "-parallel 4"
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -66,6 +66,12 @@ jobs:
       - get_version_matrix
       - unit_test
     runs-on: ubuntu-latest
+    # Hard cap so a wedged test (e.g. wait-for-condition pinned to an old
+    # nginx image that never reaches Ready on a newer Kubernetes release)
+    # can't burn the runner for hours. The Go-level `-timeout` in the
+    # Makefile is a few minutes lower so the test framework gets a chance
+    # to surface goroutine stacks before the runner is killed.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Go
@@ -118,6 +124,8 @@ jobs:
       - unit_test
       - acc_test_smoke
     runs-on: ubuntu-latest
+    # Same hard cap as acc_test_smoke. See that job for rationale.
+    timeout-minutes: 30
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,15 +23,29 @@ jobs:
           set -euo pipefail
 
           k8s_cycles="$(curl -sSfL https://endoflife.date/api/kubernetes.json | jq -rc '[sort_by(.releaseDate) | reverse | .[0:4] | .[].cycle]')"
-          kind_versions="$(crane ls docker.io/kindest/node | jq -sRrc --argjson cycles "${k8s_cycles}" 'split("\n") | [.[] | match("^v((\\d+\\.\\d+)\\.\\d+)$").captures | {cycle: .[1].string, version: .[0].string}] | group_by(.cycle) | [.[] | .[-1] | {(.cycle): {"version": .version}}] | reduce .[] as $item ({}; . *= $item) | . as $versions | [$cycles | .[] | $versions[.].version]')"
+          # The final `select($versions[.] != null)` drops cycles that
+          # endoflife.date reports as current but for which kindest/node has
+          # not yet published a matching tag (the typical case immediately
+          # after a Kubernetes minor release). Without the filter the matrix
+          # picks up a JSON null which renders as `kindest/node:v` and the
+          # job fails with "manifest unknown".
+          kind_versions="$(crane ls docker.io/kindest/node | jq -sRrc --argjson cycles "${k8s_cycles}" 'split("\n") | [.[] | match("^v((\\d+\\.\\d+)\\.\\d+)$").captures | {cycle: .[1].string, version: .[0].string}] | group_by(.cycle) | [.[] | .[-1] | {(.cycle): {"version": .version}}] | reduce .[] as $item ({}; . *= $item) | . as $versions | [$cycles | .[] | select($versions[.] != null) | $versions[.].version]')"
+          terraform_versions="$(curl -sSfL https://endoflife.date/api/terraform.json | jq -rc '[sort_by(.releaseDate) | reverse | .[0:4] | .[].latest] + ["1.5.7"]')"
 
           {
-            echo "terraform_versions=$(curl -sSfL https://endoflife.date/api/terraform.json | jq -rc '[sort_by(.releaseDate) | reverse | .[0:4] | .[].latest] + ["1.5.7"]')"
+            echo "terraform_versions=${terraform_versions}"
             echo "k8s_versions=${kind_versions}"
+            # Index 0 of each is the most recent version. The smoke job uses
+            # these singletons; the full matrix job excludes this pair so
+            # it isn't re-run.
+            echo "latest_terraform_version=$(echo "${terraform_versions}" | jq -rc '.[0]')"
+            echo "latest_k8s_version=$(echo "${kind_versions}" | jq -rc '.[0]')"
           } >> "${GITHUB_OUTPUT}"
     outputs:
       terraform_versions: ${{ steps.get_version_matrix.outputs.terraform_versions }}
       k8s_versions: ${{ steps.get_version_matrix.outputs.k8s_versions }}
+      latest_terraform_version: ${{ steps.get_version_matrix.outputs.latest_terraform_version }}
+      latest_k8s_version: ${{ steps.get_version_matrix.outputs.latest_k8s_version }}
   unit_test:
     runs-on: ubuntu-latest
     steps:
@@ -46,16 +60,55 @@ jobs:
         run: |
           make test
           make vet
-  acc_test:
+  acc_test_smoke:
+    name: "acc_test smoke (k8s ${{ needs.get_version_matrix.outputs.latest_k8s_version }} / tf ${{ needs.get_version_matrix.outputs.latest_terraform_version }})"
     needs:
       - get_version_matrix
       - unit_test
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        id: kind
+        with:
+          wait: 2m
+          node_image: kindest/node:v${{ needs.get_version_matrix.outputs.latest_k8s_version }}
+      - name: Acceptance Tests
+        env:
+          KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
+          TF_ACC_TERRAFORM_VERSION: ${{ needs.get_version_matrix.outputs.latest_terraform_version }}
+          # Tests that opt into parallelism via `t.Parallel()` (Phase 1: all
+          # file-only data sources + the resource tests that already use
+          # acctest.RandString for namespace isolation) run up to 4 at a time.
+          # Tests without `t.Parallel()` still run serially.
+          TESTARGS: "-parallel 4"
+        run: |
+          make testacc
+  acc_test:
+    # acc_test runs the full Kubernetes × Terraform matrix, but only after
+    # acc_test_smoke (latest of each) has passed. This catches the common
+    # "syntax error / missing assertion / forgotten t.Parallel()" failures
+    # against one combination before fanning out N×M kind cluster spin-ups
+    # across the matrix.
+    needs:
+      - get_version_matrix
+      - unit_test
+      - acc_test_smoke
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
-        terraform_version:  ${{ fromJson(needs.get_version_matrix.outputs.terraform_versions) }}
-        k8s_version:  ${{ fromJson(needs.get_version_matrix.outputs.k8s_versions) }}
+        terraform_version: ${{ fromJson(needs.get_version_matrix.outputs.terraform_versions) }}
+        k8s_version: ${{ fromJson(needs.get_version_matrix.outputs.k8s_versions) }}
+        # The smoke job already covered the latest+latest pair; don't
+        # re-run it inside the matrix.
+        exclude:
+          - terraform_version: ${{ needs.get_version_matrix.outputs.latest_terraform_version }}
+            k8s_version: ${{ needs.get_version_matrix.outputs.latest_k8s_version }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Go
@@ -71,10 +124,6 @@ jobs:
         env:
           KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
           TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform_version }}
-          # Tests that opt into parallelism via `t.Parallel()` (Phase 1: all
-          # file-only data sources + the resource tests that already use
-          # acctest.RandString for namespace isolation) run up to 4 at a time.
-          # Tests without `t.Parallel()` still run serially.
           TESTARGS: "-parallel 4"
         run: |
           make testacc

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -84,8 +84,11 @@ jobs:
           # Tests that opt into parallelism via `t.Parallel()` (Phase 1: all
           # file-only data sources + the resource tests that already use
           # acctest.RandString for namespace isolation) run up to 4 at a time.
-          # Tests without `t.Parallel()` still run serially.
-          TESTARGS: "-parallel 4"
+          # Tests without `t.Parallel()` still run serially. The Makefile's
+          # `ACC_TESTARGS` deliberately omits `-race` because the SDK v2
+          # harness shares a `*schema.Provider` across parallel tests and
+          # races inside `GRPCProviderServer.ConfigureProvider`.
+          ACC_TESTARGS: "-parallel 4"
         run: |
           make testacc
   acc_test:
@@ -124,6 +127,6 @@ jobs:
         env:
           KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
           TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform_version }}
-          TESTARGS: "-parallel 4"
+          ACC_TESTARGS: "-parallel 4"
         run: |
           make testacc

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,6 +71,10 @@ jobs:
         env:
           KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
           TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform_version }}
-          TESTARGS: "-parallel 1"
+          # Tests that opt into parallelism via `t.Parallel()` (Phase 1: all
+          # file-only data sources + the resource tests that already use
+          # acctest.RandString for namespace isolation) run up to 4 at a time.
+          # Tests without `t.Parallel()` still run serially.
+          TESTARGS: "-parallel 4"
         run: |
           make testacc

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,12 @@ test:
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc:
-	TF_ACC=1 go test ./kubernetes -v $(ACC_TESTARGS) -timeout 120m -count=1
+	# `-timeout 25m` is a few minutes below the GitHub Actions
+	# `timeout-minutes: 30` so the test framework gets a chance to dump
+	# goroutine stacks before the job is killed. Override locally if you
+	# expect a longer run, e.g. `go test -timeout 60m ...` by passing
+	# `-timeout 60m` through `ACC_TESTARGS`.
+	TF_ACC=1 go test ./kubernetes -v $(ACC_TESTARGS) -timeout 25m -count=1
 
 publish:
 	goreleaser release --rm-dist

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,18 @@ GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 PKG_NAME=kubernetes
 export GO111MODULE=on
 
-export TESTARGS=-race -coverprofile=coverage.txt -covermode=atomic
+# Args passed to `go test` for the unit-test target. Race detector + cover.
+# `?=` so a value in the environment (CI) overrides the default; otherwise
+# `export NAME = VALUE` would silently win over env per GNU make semantics.
+TESTARGS ?= -race -coverprofile=coverage.txt -covermode=atomic
+
+# Args passed to `go test` for the acceptance-test target. The SDK v2 testing
+# harness keeps one shared `*schema.Provider` per test binary; when multiple
+# tests call `t.Parallel()` the harness races on internal GRPCProviderServer
+# state during Configure, which `-race` flags even though the tests pass
+# functionally. We deliberately omit `-race` here. Override via env if a
+# specific run needs different args (e.g. `-run`, lower parallelism).
+ACC_TESTARGS ?= -parallel 4
 
 default: build
 
@@ -20,7 +31,7 @@ test:
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc:
-	TF_ACC=1 go test ./kubernetes -v $(TESTARGS) -timeout 120m -count=1
+	TF_ACC=1 go test ./kubernetes -v $(ACC_TESTARGS) -timeout 120m -count=1
 
 publish:
 	goreleaser release --rm-dist

--- a/kubernetes/data_source_kubectl_file_documents_test.go
+++ b/kubernetes/data_source_kubectl_file_documents_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestAccKubectlDataSourceFileDocuments_single(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() {},
 		Providers: testAccProviders,
@@ -25,6 +27,8 @@ func TestAccKubectlDataSourceFileDocuments_single(t *testing.T) {
 }
 
 func TestAccKubectlDataSourceFileDocuments_basic(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() {},
 		Providers: testAccProviders,
@@ -45,6 +49,8 @@ func TestAccKubectlDataSourceFileDocuments_basic(t *testing.T) {
 }
 
 func TestAccKubectlDataSourceFileDocuments_basicMultipleEmpty(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() {},
 		Providers: testAccProviders,

--- a/kubernetes/data_source_kubectl_filename_list_test.go
+++ b/kubernetes/data_source_kubectl_filename_list_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestAccKubectlDataSourceFilenameList_basic(t *testing.T) {
+	t.Parallel()
+
 	path := "../_examples/crds"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() {},

--- a/kubernetes/data_source_kubectl_path_documents_test.go
+++ b/kubernetes/data_source_kubectl_path_documents_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestAccKubectlDataSourcePathDocuments_single(t *testing.T) {
+	t.Parallel()
+
 	path := "../_examples/manifests"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() {},
@@ -27,6 +29,8 @@ func TestAccKubectlDataSourcePathDocuments_single(t *testing.T) {
 }
 
 func TestAccKubectlDataSourcePathDocuments_multiple(t *testing.T) {
+	t.Parallel()
+
 	path := "../_examples/manifests"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() {},
@@ -48,6 +52,8 @@ func TestAccKubectlDataSourcePathDocuments_multiple(t *testing.T) {
 }
 
 func TestAccKubectlDataSourcePathDocuments_multiple_files(t *testing.T) {
+	t.Parallel()
+
 	path := "../_examples/manifests"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() {},
@@ -92,6 +98,8 @@ data "kubectl_path_documents" "test" {
 }
 
 func TestAccKubectlDataSourcePathDocuments_multiple_files_duplicates(t *testing.T) {
+	t.Parallel()
+
 	expectedError, _ := regexp.Compile(".*duplicate manifest found with id: /apis/stable.example.com/v1/crontabs/name-here-crd.*")
 	path := "../_examples/manifests/duplicates"
 	resource.Test(t, resource.TestCase{
@@ -126,6 +134,8 @@ data "kubectl_path_documents" "test" {
 }
 
 func TestAccKubectlDataSourcePathDocuments_single_templated(t *testing.T) {
+	t.Parallel()
+
 	path := "../_examples/manifests"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() {},
@@ -181,6 +191,8 @@ data "kubectl_path_documents" "test" {
 }
 
 func TestAccKubectlDataSourcePathDocuments_multiple_templated(t *testing.T) {
+	t.Parallel()
+
 	path := "../_examples/manifests"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() {},
@@ -206,6 +218,8 @@ data "kubectl_path_documents" "test" {
 }
 
 func TestAccKubectlDataSourcePathDocuments_directives(t *testing.T) {
+	t.Parallel()
+
 	path := "../_examples/manifests"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() {},
@@ -230,6 +244,8 @@ data "kubectl_path_documents" "test" {
 }
 
 func TestAccKubectlDataSourcePathDocuments_directives_without_var(t *testing.T) {
+	t.Parallel()
+
 	path := "../_examples/manifests"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() {},
@@ -254,6 +270,8 @@ data "kubectl_path_documents" "test" {
 }
 
 func TestAccKubectlDataSourcePathDocuments_namespaces_looped(t *testing.T) {
+	t.Parallel()
+
 	path := "../_examples/manifests"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() {},
@@ -331,6 +349,8 @@ metadata:
 }
 
 func TestAccKubectlDataSourcePathDocuments_disable_template(t *testing.T) {
+	t.Parallel()
+
 	path := "../_examples/manifests"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() {},

--- a/kubernetes/resource_kubectl_manifest_test.go
+++ b/kubernetes/resource_kubectl_manifest_test.go
@@ -812,6 +812,10 @@ YAML
 }
 `
 
+	// Bump `replicas: 1 -> 2` so the Deployment's spec actually changes
+	// between steps. Without a spec change Kubernetes does not bump
+	// metadata.generation, so status.observedGeneration stays at 1 and
+	// the wait_for.field match for "2" never succeeds.
 	updateConfig := `
 resource "kubectl_manifest" "test" {
   wait_for_rollout = false
@@ -829,7 +833,7 @@ metadata:
   labels:
     app: nginx
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: nginx

--- a/kubernetes/resource_kubectl_manifest_test.go
+++ b/kubernetes/resource_kubectl_manifest_test.go
@@ -52,7 +52,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx:1.14.2
+    image: nginx:1.27.2
     readinessProbe:
       httpGet:
         path: "/"
@@ -99,7 +99,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.14.2
+          image: nginx:1.27.2
           ports:
             - containerPort: 80
           readinessProbe:
@@ -149,7 +149,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.14.2
+          image: nginx:1.27.2
           ports:
             - containerPort: 80
           readinessProbe:
@@ -199,7 +199,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.14.2
+          image: nginx:1.27.2
           ports:
             - containerPort: 80
           readinessProbe:
@@ -248,7 +248,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.14.2
+          image: nginx:1.27.2
           ports:
             - containerPort: 80
           readinessProbe:
@@ -298,7 +298,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.14.2
+          image: nginx:1.27.2
           ports:
             - containerPort: 80
           readinessProbe:
@@ -349,7 +349,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.14.2
+          image: nginx:1.27.2
           ports:
             - containerPort: 80
           readinessProbe:
@@ -387,7 +387,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx:1.14.2
+    image: nginx:1.27.2
     readinessProbe:
       httpGet:
         path: "/"
@@ -555,7 +555,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx:1.14.2
+    image: nginx:1.27.2
     readinessProbe:
       httpGet:
         path: "/"
@@ -601,7 +601,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx:1.14.2
+    image: nginx:1.27.2
     readinessProbe:
       httpGet:
         path: "/"
@@ -660,7 +660,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx:1.14.2
+    image: nginx:1.27.2
     readinessProbe:
       httpGet:
         path: "/"

--- a/kubernetes/resource_kubectl_manifest_test.go
+++ b/kubernetes/resource_kubectl_manifest_test.go
@@ -52,7 +52,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx:1.27.2
+    image: registry.k8s.io/e2e-test-images/nginx:1.28.0-1
     readinessProbe:
       httpGet:
         path: "/"
@@ -99,7 +99,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.27.2
+          image: registry.k8s.io/e2e-test-images/nginx:1.28.0-1
           ports:
             - containerPort: 80
           readinessProbe:
@@ -149,7 +149,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.27.2
+          image: registry.k8s.io/e2e-test-images/nginx:1.28.0-1
           ports:
             - containerPort: 80
           readinessProbe:
@@ -199,7 +199,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.27.2
+          image: registry.k8s.io/e2e-test-images/nginx:1.28.0-1
           ports:
             - containerPort: 80
           readinessProbe:
@@ -248,7 +248,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.27.2
+          image: registry.k8s.io/e2e-test-images/nginx:1.28.0-1
           ports:
             - containerPort: 80
           readinessProbe:
@@ -298,7 +298,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.27.2
+          image: registry.k8s.io/e2e-test-images/nginx:1.28.0-1
           ports:
             - containerPort: 80
           readinessProbe:
@@ -349,7 +349,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.27.2
+          image: registry.k8s.io/e2e-test-images/nginx:1.28.0-1
           ports:
             - containerPort: 80
           readinessProbe:
@@ -387,7 +387,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx:1.27.2
+    image: registry.k8s.io/e2e-test-images/nginx:1.28.0-1
     readinessProbe:
       httpGet:
         path: "/"
@@ -555,7 +555,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx:1.27.2
+    image: registry.k8s.io/e2e-test-images/nginx:1.28.0-1
     readinessProbe:
       httpGet:
         path: "/"
@@ -601,7 +601,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx:1.27.2
+    image: registry.k8s.io/e2e-test-images/nginx:1.28.0-1
     readinessProbe:
       httpGet:
         path: "/"
@@ -660,7 +660,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx:1.27.2
+    image: registry.k8s.io/e2e-test-images/nginx:1.28.0-1
     readinessProbe:
       httpGet:
         path: "/"
@@ -708,7 +708,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.27.0
+          image: registry.k8s.io/e2e-test-images/nginx:1.28.0-1
           ports:
             - containerPort: 80
           readinessProbe:
@@ -748,7 +748,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.27.2
+          image: registry.k8s.io/e2e-test-images/nginx:1.28.0-1
           ports:
             - containerPort: 80
           readinessProbe:
@@ -800,7 +800,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.27.0
+          image: registry.k8s.io/e2e-test-images/nginx:1.28.0-1
           ports:
             - containerPort: 80
           readinessProbe:
@@ -840,7 +840,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.27.2
+          image: registry.k8s.io/e2e-test-images/nginx:1.28.0-1
           ports:
             - containerPort: 80
           readinessProbe:

--- a/kubernetes/resource_kubectl_manifest_test.go
+++ b/kubernetes/resource_kubectl_manifest_test.go
@@ -551,7 +551,7 @@ resource "kubectl_manifest" "test" {
 apiVersion: v1
 kind: Pod
 metadata:
-  name: nginx
+  name: nginx-field-test
 spec:
   containers:
   - name: nginx
@@ -597,7 +597,7 @@ resource "kubectl_manifest" "test" {
 apiVersion: v1
 kind: Pod
 metadata:
-  name: nginx
+  name: nginx-conditions-test
 spec:
   containers:
   - name: nginx
@@ -656,7 +656,7 @@ resource "kubectl_manifest" "test" {
 apiVersion: v1
 kind: Pod
 metadata:
-  name: nginx
+  name: nginx-fieldandcondition-test
 spec:
   containers:
   - name: nginx

--- a/kubernetes/resource_kubectl_manifest_test.go
+++ b/kubernetes/resource_kubectl_manifest_test.go
@@ -970,6 +970,7 @@ spec:
 }
 
 func TestAccKubectlOverrideNamespace(t *testing.T) {
+	t.Parallel()
 
 	namespace := "dev-" + acctest.RandString(10)
 	yaml_body := `
@@ -1027,6 +1028,7 @@ type: Opaque
 }
 
 func TestAccKubectlSetNamespace(t *testing.T) {
+	t.Parallel()
 
 	namespace := "dev-" + acctest.RandString(10)
 	yaml_body := `
@@ -1084,6 +1086,7 @@ type: Opaque
 }
 
 func TestAccKubectlSetNamespace_nonnamespaced_resource(t *testing.T) {
+	t.Parallel()
 
 	namespace := "dev-" + acctest.RandString(10)
 	yaml_body := fmt.Sprintf(`
@@ -1994,6 +1997,8 @@ status:
 // apiVersion with upgrade_api_version=true updates the resource in-place
 // (preserving its UID) rather than forcing a delete and recreate.
 func TestAccKubectl_UpgradeApiVersion_InPlaceUpdate(t *testing.T) {
+	t.Parallel()
+
 	name := "test-upgrade-api-version-" + acctest.RandString(10)
 
 	configV1 := fmt.Sprintf(`
@@ -2072,6 +2077,8 @@ YAML
 // apiVersion WITHOUT upgrade_api_version (default false) forces a delete and
 // recreate, resulting in a new UID.
 func TestAccKubectl_UpgradeApiVersion_ForceNewByDefault(t *testing.T) {
+	t.Parallel()
+
 	name := "test-upgrade-api-version-" + acctest.RandString(10)
 
 	configV1 := fmt.Sprintf(`


### PR DESCRIPTION
## What does it do ?

Two CI improvements that travel together.

First, opts the already-state-isolated acceptance tests into `t.Parallel()` — 14 file-only data source / filename tests and the 5 resource tests that already randomize their namespace via `acctest.RandString` (`TestAccKubectlOverrideNamespace`, `TestAccKubectlSetNamespace`, `TestAccKubectlSetNamespace_nonnamespaced_resource`, `TestAccKubectl_UpgradeApiVersion_InPlaceUpdate`, `TestAccKubectl_UpgradeApiVersion_ForceNewByDefault`). Bumps `TESTARGS` from `-parallel 1` to `-parallel 4`. The remaining 24 tests still run serially because they use hardcoded resource names in the `default` namespace and would collide; randomizing them is Phase 2.

Second, restructures the matrix job so a single smoke combination (latest published kind node image × latest Terraform) runs first, and the full matrix only kicks off if smoke passes. `get_version_matrix` gains two singleton outputs so both jobs reference the same versions; the matrix `exclude`s the smoke pair so it isn't re-run.

## Motivation

The old `TESTARGS: -parallel 1` was a no-op — Go's `-parallel N` only governs how many tests with `t.Parallel()` run concurrently, and the codebase had zero opt-ins. So serial was enforced by accident, not by design. This change converts the tests that were already safely isolated (no shared cluster state, no hardcoded names) and leaves the rest serial until they get a state-isolation refactor.

The matrix gating addresses the wasted-compute case: a syntax error or broken assertion previously triggered the full N×M matrix to spin up before failing. Now the cheapest cluster (latest kind + latest TF) screens for those failures alone; the matrix only runs once we know the core combination works.

Verified locally against kind k8s v1.34.0:

- 14 data source tests: 16.2s → 6.1s wall (2.7×).
- 5 randomized resource tests: 8.9s → 4.2s wall (2.1×).

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] N/A — no production code touched
- [ ] N/A — no end-user behaviour changes