### PR TITLE
ci: add CodeRabbit config — review on demand only

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# CodeRabbit configuration. Reviews are opt-in only — they do NOT trigger on
+# PR open or on subsequent pushes. To request a review, comment on the PR:
+#
+#   @coderabbitai review            # incremental review of changes since last
+#   @coderabbitai full review       # re-review the whole PR from scratch
+#
+# See https://docs.coderabbit.ai/guides/commands for the full command list.
+
+language: en
+
+reviews:
+  auto_review:
+    enabled: false
+    auto_incremental_review: false


### PR DESCRIPTION
## What does it do ?

Adds `.coderabbit.yaml` at the repo root with `reviews.auto_review.enabled: false` (and `auto_incremental_review: false` for good measure). CodeRabbit reviews now fire only when a maintainer comments on a PR:

- `@coderabbitai review` — incremental review of changes since the last one.
- `@coderabbitai full review` — re-review the whole PR from scratch.

## Motivation

Default CodeRabbit behaviour is to review every PR on open and on every subsequent push, which produces a lot of noise on dependabot bumps and work-in-progress branches. Restricting to manual triggers reserves the AI review compute for cases where a human actually wants the second opinion.

## More

- [x] Yes, this PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] N/A — no production code touched
- [ ] N/A — no end-user behaviour changes