### PR TITLE
docs: refresh README and provider docs after data-source/ephemeral merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+Release notes are maintained on GitHub.
+
+See [GitHub Releases](https://github.com/alekc/terraform-provider-kubectl/releases) for the full per-release notes, including changelog entries, asset checksums, and the auto-generated commit list.

--- a/README.md
+++ b/README.md
@@ -2,21 +2,43 @@
 
 ![Build Status](https://github.com/alekc/terraform-provider-kubectl/actions/workflows/tests.yaml/badge.svg) [![user guide](https://img.shields.io/badge/-user%20guide-blue)](https://registry.terraform.io/providers/alekc/kubectl)
 
-This provider offers the most effective method for handling Kubernetes resources in Terraform. It empowers you to leverage what Kubernetes values most - YAML!
+This provider offers the most effective method for handling Kubernetes resources in Terraform. It empowers you to leverage what Kubernetes values most — YAML.
 
-At the heart of this provider lies the kubectl_manifest resource, enabling the processing and application of free-form YAML directly to Kubernetes. This YAML object is meticulously monitored and manages the entire lifecycle, from creation and updates to seamless deletion, including drift detection.
+At the heart of this provider lies the `kubectl_manifest` resource, enabling the processing and application of free-form YAML directly to Kubernetes. This YAML object is monitored across its full lifecycle — creation, updates, drift detection and deletion.
 
-The terraform-provider-kubectl has gained widespread adoption in numerous extensive Kubernetes installations, serving as the primary tool for orchestrating the complete lifecycle of Kubernetes resources.
+The `terraform-provider-kubectl` has gained widespread adoption in numerous large Kubernetes installations, serving as the primary tool for orchestrating the complete lifecycle of Kubernetes resources.
+
+## What's in this provider
+
+| Type               | Name                                                                                 | Purpose                                                                                              |
+| ------------------ | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| Resource           | [`kubectl_manifest`](./docs/resources/kubectl_manifest.md)                           | Apply a raw YAML manifest to the cluster (full create / update / delete + drift detection).          |
+| Resource           | [`kubectl_server_version`](./docs/resources/kubectl_server_version.md)               | Read API-server version info, with `triggers` for use in `depends_on` chains.                        |
+| Data source        | [`kubectl_manifest`](./docs/data-sources/kubectl_manifest.md)                        | Read any object from the cluster by GVK + name (+ namespace) and extract fields by dot-path.         |
+| Data source        | [`kubectl_server_version`](./docs/data-sources/kubectl_server_version.md)            | Read API-server version info.                                                                        |
+| Data source        | [`kubectl_file_documents`](./docs/data-sources/kubectl_file_documents.md)            | Split a multi-document YAML string into individual documents.                                        |
+| Data source        | [`kubectl_filename_list`](./docs/data-sources/kubectl_filename_list.md)              | Glob a directory for YAML files.                                                                     |
+| Data source        | [`kubectl_path_documents`](./docs/data-sources/kubectl_path_documents.md)            | Glob a directory and split every matched file into individual documents.                             |
+| Ephemeral resource | [`kubectl_manifest`](./docs/ephemeral-resources/kubectl_manifest.md)                 | Same shape as the data source, but the fetched value is **never written to state**. Terraform 1.10+. |
 
 ## Supported Kubernetes and Terraform versions
-At the moment, the acceptance tests cover a combination of the last 7 Kubernetes releases and the last 4 stable 
-Terraform versions (plus 0.15). This doesn't necessarily mean it won't work with other combinations, but your mileage may vary
+
+Every PR is exercised against the matrix below on `kind`. The matrix is regenerated from [endoflife.date](https://endoflife.date) on each CI run, so it tracks the four most recent active Kubernetes release cycles and the four most recent stable Terraform minors, plus a legacy `1.5.7` cell (the last MPL-licensed Terraform release).
+
+|                 | Terraform 1.15 | Terraform 1.14 | Terraform 1.13 | Terraform 1.12 | Terraform 1.5.7 |
+| --------------- | :------------: | :------------: | :------------: | :------------: | :-------------: |
+| Kubernetes 1.36 | smoke + ✅      | ✅              | ✅              | ✅              | ✅               |
+| Kubernetes 1.35 | ✅              | ✅              | ✅              | ✅              | ✅               |
+| Kubernetes 1.34 | ✅              | ✅              | ✅              | ✅              | ✅               |
+| Kubernetes 1.33 | ✅              | ✅              | ✅              | ✅              | ✅               |
+
+The versions in the table are the snapshot resolved at the time of writing; the live matrix moves with the upstream release cadence. The newest pair (latest Kubernetes × latest Terraform) is run first as a single **smoke** job; the remaining 19 combinations fan out only after smoke passes. Combinations outside this grid may still work — your mileage may vary.
 
 ## Installation
 
 ### Terraform 0.13+
 
-The provider can be installed and managed automatically by Terraform. Sample `versions.tf` file :
+The provider can be installed and managed automatically by Terraform. Sample `versions.tf` file:
 
 ```hcl
 terraform {
@@ -33,8 +55,7 @@ terraform {
 
 ### Install manually
 
-If you don't want to use the one-liner above, you can download a binary for your system from the [release page](https://github.com/alekc/terraform-provider-kubectl/releases), 
-then either place it at the root of your Terraform folder or in the Terraform plugin folder on your system.
+If you don't want to use the one-liner above, you can download a binary for your system from the [release page](https://github.com/alekc/terraform-provider-kubectl/releases), then either place it at the root of your Terraform folder or in the Terraform plugin folder on your system.
 
 ## Quick Start
 
@@ -75,86 +96,114 @@ YAML
 }
 ```
 
-See [User Guide](https://registry.terraform.io/providers/alekc/kubectl/latest) for details on installation and all the provided data and resource types.
+See the [User Guide](https://registry.terraform.io/providers/alekc/kubectl/latest) for details on installation and all the provided data and resource types.
 
-## Changing providers for existing resources
+### Reading existing objects
 
-When you used another fork of this provider in the past, it is possible to change the provider on all existing resources within your state. A common use-case of this is to switch from `gavinbunney/kubectl` towards this fork.
+A `data "kubectl_manifest"` block reads any cluster object by `api_version` + `kind` + `name` (+ `namespace`) and extracts user-named fields via gojsonq dot-paths. The fetched object is also exposed as raw `yaml` and `json`.
 
-Change the `required_providers` sections in your main code and in all used modules to reflect the usage of `alekc/kubectl` as shown above. Once this is done, use the `state replace-provider` to make the switch on all existing resources in your state.
-
+```hcl
+data "kubectl_manifest" "ns" {
+  api_version = "v1"
+  kind        = "Namespace"
+  name        = "kube-system"
+  fields = {
+    phase = "status.phase"
+  }
+}
 ```
-terraform state replace-provider gavinbunney/kubectl alekc/kubectl
+
+See [`docs/data-sources/kubectl_manifest.md`](./docs/data-sources/kubectl_manifest.md) for the full reference.
+
+### Reading sensitive data without persisting it
+
+For data that must never reach `terraform.tfstate` (Secret payloads, freshly-minted tokens, private keys), use the `ephemeral "kubectl_manifest"` resource — same shape, but the value is re-fetched on every plan / apply and never persisted. Requires Terraform 1.10+.
+
+```hcl
+ephemeral "kubectl_manifest" "db_creds" {
+  api_version = "v1"
+  kind        = "Secret"
+  name        = "postgres-credentials"
+  namespace   = "data"
+  fields = {
+    password = "data.password"
+  }
+}
 ```
 
-You should then `terraform init`, and the next terraform actions will use this provider.
+See [`docs/ephemeral-resources/kubectl_manifest.md`](./docs/ephemeral-resources/kubectl_manifest.md) for the full reference and consumer patterns.
 
 ---
 
 ## Development Guide
 
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.12+ is *required*).
-You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
+You will need [Go](http://www.golang.org) (the version pinned in [`go.mod`](./go.mod) — currently 1.26 or newer) and a correctly set up [GOPATH](http://golang.org/doc/code.html#GOPATH), with `$GOPATH/bin` on your `$PATH`.
 
-To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
+To compile the provider, run `make build`. This puts the provider binary at `$GOPATH/bin/terraform-provider-kubectl`.
 
-### Building The Provider
+### Building the provider
 
-You can build the master branch of the provider by running 
 ```sh
-git clone github.com/alekc/terraform-provider-kubectl
+git clone https://github.com/alekc/terraform-provider-kubectl
 cd terraform-provider-kubectl
 make build
 ```
-This will build an executable `terraform-provider-kubectl` in your `${GOPATH}/bin/` directory. 
-Now we need to tell Terraform to override remote versions with our local build. To do so create/edit `~/.terraformrc/` file and add following content to it:
+
+To point Terraform at your local build, create or edit `~/.terraformrc` and add the dev-override block below. Replace the path with your own `$GOPATH/bin/` (run `go env GOPATH` if you're unsure):
+
 ```hcl
- provider_installation {
+provider_installation {
   dev_overrides {
-    "alekc/kubectl" = "/Users/alekc/go/bin/"
+    "alekc/kubectl" = "<your-gopath>/bin/"
   }
   direct {}
 }
 ```
 
-change "/Users/alekc/go/bin/" with the path where your go has placed built executable. After that all you have to do is run 
-`terraform init` and you will be using the new version. 
+Run `terraform init` (it's a no-op under dev_overrides) and your local build is now in use. On every plan/apply you'll see Terraform note the override:
 
-If all went well, you should see a following message during the apply:
 ```text
 ╷
 │ Warning: Provider development overrides are in effect
 │ 
 │ The following provider development overrides are set in the CLI configuration:
-│  - alekc/kubectl in /Users/alekc/go/bin
-
+│  - alekc/kubectl in <your-gopath>/bin
 ```
 
 ### Testing
 
-In order to test the provider, you can simply run `make test`.
+There are two test surfaces:
+
+- **`make test`** — unit tests for the provider Go packages. No cluster required. Runs with `-race` and coverage.
+- **`make testacc`** — acceptance tests against a live Kubernetes cluster. Reads `KUBE_CONFIG_PATH` (or `KUBECONFIG`) to find the cluster. The CI workflow uses [`kind`](https://kind.sigs.k8s.io/) via `helm/kind-action`; locally any reachable cluster works (kind, k3d, Docker Desktop, EKS, …). Tests are isolated by namespace / random suffix and may be run in parallel — `ACC_TESTARGS="-parallel 4"` is the default.
 
 ```sh
-$ make test
+make test       # unit
+make testacc    # acceptance — needs a cluster + KUBE_CONFIG_PATH
 ```
 
-The provider uses k3s to run integration tests. These tests look for any `*.tf` files in the `_examples` folder and run an `plan`, `apply`, `refresh` and `plan` loop over each file. 
-
-Inside each file the string `name-here` is replaced with a unique name during test execution. This is a simple string replace before the TF is applied to ensure that tests don't fail due to naming clashes. 
-
-Each scenario can be placed in a folder, to help others navigate and use the examples, and added to the [README.MD](./_examples/README.MD). 
-
-> Note: The test infrastructure doesn't support multi-file TF configurations so ensure your test scenario is in a single file. 
-
-In order to run the full suite of Acceptance tests, run `make testacc`.
-
-*Note:* Acceptance tests create real resources, and often cost money to run.
+To narrow the run, pass `-run` through `ACC_TESTARGS`:
 
 ```sh
-$ make testacc
+ACC_TESTARGS="-parallel 4 -run TestAccKubectlDataSourceManifest" make testacc
 ```
+
+The CI workflow (`.github/workflows/tests.yaml`) runs the newest Kubernetes × Terraform pair as a single **smoke** job; only if it passes does it fan out to the rest of the matrix. This catches "obvious break" failures fast without burning 20 kind clusters on a syntax error.
+
+*Note:* acceptance tests create real Kubernetes resources. Against a managed cluster (EKS, GKE, AKS) they may incur cost.
+
+## Changing providers for existing resources
+
+When you used another fork of this provider in the past, you can switch the provider on all existing resources within your state. A common use-case is moving from `gavinbunney/kubectl` to this fork.
+
+Change the `required_providers` block in your root module and all child modules to use `alekc/kubectl` as shown in the [Installation](#terraform-013) section above. Then use `state replace-provider` to update existing state:
+
+```sh
+terraform state replace-provider gavinbunney/kubectl alekc/kubectl
+```
+
+Run `terraform init` afterwards; subsequent terraform actions will use this provider.
 
 ### Inspiration
 
-Thanks to the original provider by [gavinbunney](https://github.com/gavinbunney/terraform-provider-kubectl) on the original base of this provider. Current version has been forked from 1.14
-
+Thanks to the original provider by [gavinbunney](https://github.com/gavinbunney/terraform-provider-kubectl) — this fork was originally based on version 1.14 and has followed a separate development path since.

--- a/docs/data-sources/kubectl_server_version.md
+++ b/docs/data-sources/kubectl_server_version.md
@@ -11,11 +11,11 @@ data "kubectl_server_version" "current" { }
 
 ## Attribute Reference
 
-* `version` - Version of the server, e.g. `v1.12.10`.
+* `version` - Version of the server, e.g. `v1.34.0`.
 * `major` - Major version, semver if available, e.g. `1`.
-* `minor` - Minor version, semver if available, e.g. `12`.
-* `patch` - Patch version, semver if available, e.g. `10`.
-* `git_version` - Version of the server, e.g. `v1.12.10-eks-aae39f`.
+* `minor` - Minor version, semver if available, e.g. `34`.
+* `patch` - Patch version, semver if available, e.g. `0`.
+* `git_version` - Version of the server, e.g. `v1.34.0-eks-aae39f`.
 * `git_commit` - Git sha commit, e.g. `aae39f4697508697bf16c0de4a5687d464f4da81`.
-* `build_date` - Date server binaries were build, e.g. `2019-12-23T08:19:12Z`.
+* `build_date` - Date the server binaries were built, e.g. `2025-08-27T08:19:12Z`.
 * `platform` - Server platform name, e.g. `linux/amd64`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,20 @@ This yaml object is then tracked and handles creation, updates and deleted seaml
 
 A set of helpful data resources to process directories of yaml files and inline templating is available.
 
-This `terraform-provider-kubectl` provider has been originally forked from `gavinbunney/kubectl` and followed a separate development path from the version 0.14
+This `terraform-provider-kubectl` provider has been originally forked from `gavinbunney/kubectl` and followed a separate development path from the version 0.14.
+
+## What's in this provider
+
+| Type               | Name                                                                       | Purpose                                                                                              |
+| ------------------ | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Resource           | [`kubectl_manifest`](./resources/kubectl_manifest.md)                      | Apply a raw YAML manifest to the cluster (full create / update / delete + drift detection).          |
+| Resource           | [`kubectl_server_version`](./resources/kubectl_server_version.md)          | Read API-server version info, with `triggers` for use in `depends_on` chains.                        |
+| Data source        | [`kubectl_manifest`](./data-sources/kubectl_manifest.md)                   | Read any object from the cluster by GVK + name (+ namespace) and extract fields by dot-path.         |
+| Data source        | [`kubectl_server_version`](./data-sources/kubectl_server_version.md)       | Read API-server version info.                                                                        |
+| Data source        | [`kubectl_file_documents`](./data-sources/kubectl_file_documents.md)       | Split a multi-document YAML string into individual documents.                                        |
+| Data source        | [`kubectl_filename_list`](./data-sources/kubectl_filename_list.md)         | Glob a directory for YAML files.                                                                     |
+| Data source        | [`kubectl_path_documents`](./data-sources/kubectl_path_documents.md)       | Glob a directory and split every matched file into individual documents.                             |
+| Ephemeral resource | [`kubectl_manifest`](./ephemeral-resources/kubectl_manifest.md)            | Same shape as the data source, but the fetched value is **never written to state**. Terraform 1.10+. |
 
 ## Installation
 

--- a/docs/resources/kubectl_manifest.md
+++ b/docs/resources/kubectl_manifest.md
@@ -73,7 +73,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx:1.14.2
+    image: registry.k8s.io/e2e-test-images/nginx:1.28.0-1
     readinessProbe:
       httpGet:
         path: "/"
@@ -92,11 +92,11 @@ YAML
 * `server_side_apply` - Optional. Allow using server-side-apply method. Default `false`.
 * `field_manager` - Optional. Override the default field manager name. This is only relevent when using server-side apply. Default `kubectl`.
 * `force_conflicts` - Optional. Allow using force_conflicts. Default `false`.
-* `apply_only` - Optional. It does not delete resource in any case Default `false`.
+* `apply_only` - Optional. When `true`, the resource is never deleted on `terraform destroy`. Default `false`.
 * `ignore_fields` - Optional. List of map fields to ignore when applying the manifest. See below for more details.
 * `override_namespace` - Optional. Override the namespace to apply the kubernetes resource to, ignoring any declared namespace in the `yaml_body`.
 * `validate_schema` - Optional. Setting to `false` will mimic `kubectl apply --validate=false` mode. Default `true`.
-* `wait` - Optional. Set this flag to wait or not for finalized to complete for deleted objects. Default `false`.
+* `wait` - Optional. When `true`, wait for finalizers to complete on deleted objects before returning. Default `false`.
 * `wait_for_rollout` - Optional. Set this flag to wait or not for `Deployment`, `DaemonSet`, `StatefulSet` & `APIService`  resources to complete rollout. Default `true`.
 * `wait_for` - Optional. If set, will wait until either all conditions are satisfied, or until timeout is reached (see [below for nested schema](#wait_for)). Under the hood [gojsonq](https://github.com/thedevsaddam/gojsonq) is used for querying, see the related syntax and examples.
 * `delete_cascade` - Optional; `Background` or `Foreground` are valid options. If set this overrides the default provider behaviour which is to use `Background` unless `wait` is `true` when `Foreground` will be used. To duplicate the default behaviour of `kubectl` this should be explicitly set to `Background`.

--- a/docs/resources/kubectl_server_version.md
+++ b/docs/resources/kubectl_server_version.md
@@ -16,11 +16,11 @@ resource "kubectl_server_version" "current" { }
 
 ## Attribute Reference
 
-* `version` - Version of the server, e.g. `v1.12.10`.
+* `version` - Version of the server, e.g. `v1.34.0`.
 * `major` - Major version, semver if available, e.g. `1`.
-* `minor` - Minor version, semver if available, e.g. `12`.
-* `patch` - Patch version, semver if available, e.g. `10`.
-* `git_version` - Version of the server, e.g. `v1.12.10-eks-aae39f`.
+* `minor` - Minor version, semver if available, e.g. `34`.
+* `patch` - Patch version, semver if available, e.g. `0`.
+* `git_version` - Version of the server, e.g. `v1.34.0-eks-aae39f`.
 * `git_commit` - Git sha commit, e.g. `aae39f4697508697bf16c0de4a5687d464f4da81`.
-* `build_date` - Date server binaries were build, e.g. `2019-12-23T08:19:12Z`.
+* `build_date` - Date the server binaries were built, e.g. `2025-08-27T08:19:12Z`.
 * `platform` - Server platform name, e.g. `linux/amd64`.


### PR DESCRIPTION
Replace the stale "7 K8s × 4 TF + 0.15" prose with a grid that matches what the workflow actually runs (4 K8s cycles × 4 TF minors + 1.5.7) and explain the smoke-then-matrix design. Bring the rest of the README in line with current reality: Go 1.26+ (not 1.12+), kind + KUBE_CONFIG_PATH (not the long-removed k3s + _examples helper), GOPATH placeholder instead of a hard-coded personal path.

Surface the data source and ephemeral resource that landed in #257 from both README and docs/index.md via a "What's in this provider" table. Fix copy bugs in docs/resources/kubectl_manifest.md (wait / apply_only descriptions) and swap the wait_for example image to the e2e-test-images nginx so the documented example matches what the test suite actually runs against. Bump kubectl_server_version examples off the 2019 v1.12.10 snapshot. Add a CHANGELOG.md stub pointing at GitHub Releases.