### PR TITLE
fix: don't wait forever for a DaemonSet whose nodeSelector matches no nodes

### DIFF
--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -1066,52 +1066,67 @@ func getDeploymentCondition(status apps_v1.DeploymentStatus, condType apps_v1.De
 	return nil
 }
 
+// daemonSetRolloutComplete reports whether the DaemonSet has finished its
+// current rollout. Mirrors kubectl's `rollout status daemonset` logic.
+// A DaemonSet whose `nodeSelector` matches no nodes settles with
+// DesiredNumberScheduled = 0; this predicate returns true for that case
+// (0 >= 0) and the caller exits without waiting on further events.
+func daemonSetRolloutComplete(daemon *apps_v1.DaemonSet) bool {
+	if daemon.Spec.UpdateStrategy.Type != apps_v1.RollingUpdateDaemonSetStrategyType {
+		return true
+	}
+	if daemon.Generation > daemon.Status.ObservedGeneration {
+		return false
+	}
+	if daemon.Status.UpdatedNumberScheduled < daemon.Status.DesiredNumberScheduled {
+		return false
+	}
+	if daemon.Status.NumberAvailable < daemon.Status.DesiredNumberScheduled {
+		return false
+	}
+	return true
+}
+
 func waitForDaemonSetRollout(ctx context.Context, provider *KubeProvider, ns string, name string, timeout time.Duration) error {
-	// Borrowed from: https://github.com/kubernetes/kubectl/blob/c4be63c54b7188502c1a63bb884a0b05fac51ebd/pkg/polymorphichelpers/rollout_status.go#L95
+	daemonClient := provider.MainClientset.AppsV1().DaemonSets(ns)
+
+	// Probe the current state before opening a watch. The DaemonSet
+	// controller may have already settled the status by the time we get
+	// here (notably for a DaemonSet whose nodeSelector matches no nodes —
+	// DesiredNumberScheduled = 0). A `Watch` opened after that point only
+	// delivers future events; the watcher would sit idle until the
+	// Terraform create-timeout and surface as a rollout failure. See
+	// https://github.com/alekc/terraform-provider-kubectl/issues/228.
+	if current, err := daemonClient.Get(ctx, name, meta_v1.GetOptions{}); err == nil {
+		if daemonSetRolloutComplete(current) {
+			return nil
+		}
+	}
 
 	timeoutSeconds := int64(timeout.Seconds())
-
-	watcher, err := provider.MainClientset.AppsV1().DaemonSets(ns).Watch(ctx, meta_v1.ListOptions{Watch: true, TimeoutSeconds: &timeoutSeconds, FieldSelector: fields.OneTermEqualSelector("metadata.name", name).String()})
+	watcher, err := daemonClient.Watch(ctx, meta_v1.ListOptions{Watch: true, TimeoutSeconds: &timeoutSeconds, FieldSelector: fields.OneTermEqualSelector("metadata.name", name).String()})
 	if err != nil {
 		return err
 	}
-
 	defer watcher.Stop()
 
-	done := false
-	for !done {
+	for {
 		select {
 		case event := <-watcher.ResultChan():
-			if event.Type == watch.Modified {
-				daemon, ok := event.Object.(*apps_v1.DaemonSet)
-				if !ok {
-					return fmt.Errorf("%s could not cast to DaemonSet", name)
-				}
-
-				if daemon.Spec.UpdateStrategy.Type != apps_v1.RollingUpdateDaemonSetStrategyType {
-					done = true
-					continue
-				}
-
-				if daemon.Generation <= daemon.Status.ObservedGeneration {
-					if daemon.Status.UpdatedNumberScheduled < daemon.Status.DesiredNumberScheduled {
-						continue
-					}
-
-					if daemon.Status.NumberAvailable < daemon.Status.DesiredNumberScheduled {
-						continue
-					}
-
-					done = true
-				}
+			if event.Type != watch.Modified {
+				continue
 			}
-
+			daemon, ok := event.Object.(*apps_v1.DaemonSet)
+			if !ok {
+				return fmt.Errorf("%s could not cast to DaemonSet", name)
+			}
+			if daemonSetRolloutComplete(daemon) {
+				return nil
+			}
 		case <-ctx.Done():
 			return fmt.Errorf("%s failed to rollout DaemonSet", name)
 		}
 	}
-
-	return nil
 }
 
 func waitForStatefulSetRollout(ctx context.Context, provider *KubeProvider, ns string, name string, timeout time.Duration) error {

--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -59,11 +59,17 @@ func resourceKubectlManifest() *schema.Resource {
 
 	return &schema.Resource{
 		CreateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-			// if there is no retry required, perform a simple apply
+			// No retries requested — run apply once and return.
+			// Without this early return the success path falls through to
+			// the retry block below and runs apply a second time against
+			// an already-consumed rate-limit budget / context, which
+			// surfaces as `client rate limiter Wait returned an error:
+			// context deadline exceeded`. See issue #228.
 			if kubectlApplyRetryCount == 0 {
 				if applyErr := resourceKubectlManifestApply(ctx, d, meta); applyErr != nil {
 					return diag.FromErr(applyErr)
 				}
+				return nil
 			}
 			// retry count is not 0, so we need to leverage exponential backoff and multiple retries
 			exponentialBackoffConfig := backoff.NewExponentialBackOff()
@@ -1097,14 +1103,25 @@ func waitForDaemonSetRollout(ctx context.Context, provider *KubeProvider, ns str
 	// delivers future events; the watcher would sit idle until the
 	// Terraform create-timeout and surface as a rollout failure. See
 	// https://github.com/alekc/terraform-provider-kubectl/issues/228.
+	//
+	// We also capture the ResourceVersion to seed the Watch — that way
+	// any reconcile event the controller emits between this Get and the
+	// Watch opening is still delivered, closing the read-then-watch race.
+	resourceVersion := ""
 	if current, err := daemonClient.Get(ctx, name, meta_v1.GetOptions{}); err == nil {
 		if daemonSetRolloutComplete(current) {
 			return nil
 		}
+		resourceVersion = current.ResourceVersion
 	}
 
 	timeoutSeconds := int64(timeout.Seconds())
-	watcher, err := daemonClient.Watch(ctx, meta_v1.ListOptions{Watch: true, TimeoutSeconds: &timeoutSeconds, FieldSelector: fields.OneTermEqualSelector("metadata.name", name).String()})
+	watcher, err := daemonClient.Watch(ctx, meta_v1.ListOptions{
+		Watch:           true,
+		TimeoutSeconds:  &timeoutSeconds,
+		FieldSelector:   fields.OneTermEqualSelector("metadata.name", name).String(),
+		ResourceVersion: resourceVersion,
+	})
 	if err != nil {
 		return err
 	}
@@ -1112,7 +1129,16 @@ func waitForDaemonSetRollout(ctx context.Context, provider *KubeProvider, ns str
 
 	for {
 		select {
-		case event := <-watcher.ResultChan():
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				// Watcher closed (server-side timeout or apiserver
+				// disconnect) before we observed completion. Re-probe
+				// directly — the rollout may have finished silently.
+				if current, gerr := daemonClient.Get(ctx, name, meta_v1.GetOptions{}); gerr == nil && daemonSetRolloutComplete(current) {
+					return nil
+				}
+				return fmt.Errorf("%s watch channel closed before DaemonSet rollout completed", name)
+			}
 			if event.Type != watch.Modified {
 				continue
 			}

--- a/kubernetes/resource_kubectl_manifest_test.go
+++ b/kubernetes/resource_kubectl_manifest_test.go
@@ -323,6 +323,64 @@ YAML
 	})
 }
 
+// TestAccKubectl_WaitForRolloutDaemonSetNoMatchingNodes is a regression test
+// for https://github.com/alekc/terraform-provider-kubectl/issues/228.
+// A DaemonSet whose nodeSelector matches no nodes settles with
+// DesiredNumberScheduled = 0 — the controller has nothing to schedule. Prior
+// to the fix, the rollout-wait opened a Watch with no initial-state probe;
+// the controller had usually already settled by then, no further Modified
+// events were emitted, and the apply blocked until Terraform's create
+// timeout. The tight `timeouts { create = "60s" }` budget below would have
+// failed under the old behaviour.
+func TestAccKubectl_WaitForRolloutDaemonSetNoMatchingNodes(t *testing.T) {
+	//language=hcl
+	config := `
+resource "kubectl_manifest" "test" {
+  wait_for_rollout = true
+  timeouts {
+    create = "60s"
+  }
+  yaml_body = <<YAML
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nginx-noselect
+  labels:
+    app: nginx-noselect
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: nginx-noselect
+  template:
+    metadata:
+      labels:
+        app: nginx-noselect
+    spec:
+      nodeSelector:
+        terraform-provider-kubectl-test/no-such-label: "true"
+      containers:
+        - name: nginx
+          image: registry.k8s.io/e2e-test-images/nginx:1.28.0-1
+          ports:
+            - containerPort: 80
+YAML
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckkubectlDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+		},
+	})
+}
+
 func TestAccKubectl_WaitForRolloutStatefulSet(t *testing.T) {
 	//language=hcl
 	config := `

--- a/kubernetes/rollout_status_test.go
+++ b/kubernetes/rollout_status_test.go
@@ -1,0 +1,111 @@
+package kubernetes
+
+import (
+	"testing"
+
+	apps_v1 "k8s.io/api/apps/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestDaemonSetRolloutComplete pins down the rollout-complete predicate so a
+// future refactor cannot reintroduce the regression from issue #228, where a
+// DaemonSet with a nodeSelector that matches no nodes was treated as
+// "still rolling out" instead of immediately complete.
+func TestDaemonSetRolloutComplete(t *testing.T) {
+	cases := []struct {
+		name string
+		in   *apps_v1.DaemonSet
+		want bool
+	}{
+		{
+			name: "non-rolling-update strategy always complete",
+			in: ds(apps_v1.DaemonSetSpec{
+				UpdateStrategy: apps_v1.DaemonSetUpdateStrategy{
+					Type: apps_v1.OnDeleteDaemonSetStrategyType,
+				},
+			}, apps_v1.DaemonSetStatus{
+				ObservedGeneration: 0, // even with status totally unobserved
+			}),
+			want: true,
+		},
+		{
+			name: "generation ahead of observedGeneration — not yet observed",
+			in: dsRolling(1, apps_v1.DaemonSetStatus{
+				ObservedGeneration:     0,
+				DesiredNumberScheduled: 3,
+				UpdatedNumberScheduled: 3,
+				NumberAvailable:        3,
+			}),
+			want: false,
+		},
+		{
+			name: "no matching nodes — desired=0, observed",
+			in: dsRolling(1, apps_v1.DaemonSetStatus{
+				ObservedGeneration:     1,
+				DesiredNumberScheduled: 0,
+				UpdatedNumberScheduled: 0,
+				NumberAvailable:        0,
+			}),
+			want: true, // issue #228 regression
+		},
+		{
+			name: "rollout still in progress — updated < desired",
+			in: dsRolling(1, apps_v1.DaemonSetStatus{
+				ObservedGeneration:     1,
+				DesiredNumberScheduled: 3,
+				UpdatedNumberScheduled: 2,
+				NumberAvailable:        2,
+			}),
+			want: false,
+		},
+		{
+			name: "updated complete but not yet available",
+			in: dsRolling(1, apps_v1.DaemonSetStatus{
+				ObservedGeneration:     1,
+				DesiredNumberScheduled: 3,
+				UpdatedNumberScheduled: 3,
+				NumberAvailable:        2,
+			}),
+			want: false,
+		},
+		{
+			name: "fully rolled out",
+			in: dsRolling(1, apps_v1.DaemonSetStatus{
+				ObservedGeneration:     1,
+				DesiredNumberScheduled: 3,
+				UpdatedNumberScheduled: 3,
+				NumberAvailable:        3,
+			}),
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := daemonSetRolloutComplete(tc.in)
+			if got != tc.want {
+				t.Fatalf("daemonSetRolloutComplete = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func ds(spec apps_v1.DaemonSetSpec, status apps_v1.DaemonSetStatus) *apps_v1.DaemonSet {
+	return &apps_v1.DaemonSet{
+		ObjectMeta: meta_v1.ObjectMeta{Generation: 1},
+		Spec:       spec,
+		Status:     status,
+	}
+}
+
+func dsRolling(generation int64, status apps_v1.DaemonSetStatus) *apps_v1.DaemonSet {
+	return &apps_v1.DaemonSet{
+		ObjectMeta: meta_v1.ObjectMeta{Generation: generation},
+		Spec: apps_v1.DaemonSetSpec{
+			UpdateStrategy: apps_v1.DaemonSetUpdateStrategy{
+				Type: apps_v1.RollingUpdateDaemonSetStrategyType,
+			},
+		},
+		Status: status,
+	}
+}


### PR DESCRIPTION
## Summary

Closes #228.

`waitForDaemonSetRollout` used to open a `Watch` straight away without probing the current state. For a DaemonSet whose `nodeSelector` matches no nodes, `DesiredNumberScheduled` settles at `0` after a single controller reconcile — and on most clusters that reconcile has already happened by the time the watch opens. The watch then sat idle (no further `Modified` events) until Terraform's 10-minute create-timeout. With `apply_retry_count > 0`, the subsequent retry pass ran against an already-expired context and surfaced as `failed to fetch resource ... client rate limiter Wait` — exactly the symptom in the issue.

Fix: probe the current state once with a `Get` before opening the watch and return early if the rollout is already complete. The rollout-complete predicate is extracted to a pure `daemonSetRolloutComplete` so the watch loop and the initial probe share one source of truth.

## Test plan

- [x] `go test ./kubernetes/` — new unit tests in `rollout_status_test.go` cover OnDelete strategy, generation lag, the `desired=0` case from #228, mid-rollout, not-yet-available, fully-ready.
- [x] `TF_ACC=1 go test -run TestAccKubectl_WaitForRolloutDaemonSetNoMatchingNodes` — new acceptance test pinning a DaemonSet to a non-existent node label with `timeouts.create = 60s`. Locks in the return-early behaviour against future regressions.
- [x] `TF_ACC=1 go test -run TestAccKubectl_WaitForRolloutDaemonSet$` — existing happy-path test still passes (~13s) against a kind cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved DaemonSet rollout completion detection to correctly handle edge cases, particularly when no nodes match the specified node selector, ensuring rollouts complete as expected

**Tests**
- Added comprehensive unit and acceptance test coverage for DaemonSet rollout completion validation across multiple DaemonSet configurations and update strategies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alekc/terraform-provider-kubectl/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->