### PR TITLE
fix: honor update/delete timeouts and close Get-then-Watch race on wait_for_rollout

### DIFF
--- a/docs/resources/kubectl_manifest.md
+++ b/docs/resources/kubectl_manifest.md
@@ -230,6 +230,34 @@ More examples can be found in the provider tests.
 By default, this resource will wait for `Deployment`, `DaemonSet`, `StatefulSet` & `APIService` to complete their rollout before proceeding.
 You can disable this behavior by setting the `wait_for_rollout` field to `false`.
 
+## Timeouts
+
+The resource supports `create`, `update`, and `delete` timeouts via a standard Terraform
+`timeouts` block. Each defaults to **10 minutes** and bounds the corresponding
+`wait_for_rollout` / `wait_for` wait when that operation is in flight. Workloads that take
+longer than ten minutes to roll out (Windows images, large StatefulSets, anything pulling a
+multi-gigabyte image) should raise the relevant key.
+
+```hcl
+resource "kubectl_manifest" "my_deployment" {
+  timeouts {
+    create = "30m"
+    update = "30m"
+    delete = "5m"
+  }
+
+  yaml_body = <<YAML
+apiVersion: apps/v1
+kind: Deployment
+# ...
+YAML
+}
+```
+
+`update` covers in-place changes to the manifest (the most common case for long rollouts —
+scaling, image bumps, env tweaks). `create` covers the initial apply. `delete` bounds resource
+deletion.
+
 ## Import
 
 This provider supports importing existing resources. The ID format expected uses a double `//` as a deliminator (as apiVersion can have a forward-slash):

--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -66,7 +66,7 @@ func resourceKubectlManifest() *schema.Resource {
 			// surfaces as `client rate limiter Wait returned an error:
 			// context deadline exceeded`. See issue #228.
 			if kubectlApplyRetryCount == 0 {
-				if applyErr := resourceKubectlManifestApply(ctx, d, meta); applyErr != nil {
+				if applyErr := resourceKubectlManifestApply(ctx, d, meta, schema.TimeoutCreate); applyErr != nil {
 					return diag.FromErr(applyErr)
 				}
 				return nil
@@ -78,7 +78,7 @@ func resourceKubectlManifest() *schema.Resource {
 
 			retryConfig := backoff.WithMaxRetries(exponentialBackoffConfig, kubectlApplyRetryCount)
 			retryErr := backoff.Retry(func() error {
-				err := resourceKubectlManifestApply(ctx, d, meta)
+				err := resourceKubectlManifestApply(ctx, d, meta, schema.TimeoutCreate)
 				if err != nil {
 					log.Printf("[ERROR] creating manifest failed: %+v", err)
 				}
@@ -111,7 +111,7 @@ func resourceKubectlManifest() *schema.Resource {
 			if kubectlApplyRetryCount > 0 {
 				retryConfig := backoff.WithMaxRetries(exponentialBackoffConfig, kubectlApplyRetryCount)
 				retryErr := backoff.Retry(func() error {
-					err := resourceKubectlManifestApply(ctx, d, meta)
+					err := resourceKubectlManifestApply(ctx, d, meta, schema.TimeoutUpdate)
 					if err != nil {
 						log.Printf("[ERROR] updating manifest failed: %+v", err)
 					}
@@ -124,7 +124,7 @@ func resourceKubectlManifest() *schema.Resource {
 
 				return nil
 			} else {
-				if applyErr := resourceKubectlManifestApply(ctx, d, meta); applyErr != nil {
+				if applyErr := resourceKubectlManifestApply(ctx, d, meta, schema.TimeoutUpdate); applyErr != nil {
 					return diag.FromErr(applyErr)
 				}
 
@@ -133,6 +133,8 @@ func resourceKubectlManifest() *schema.Resource {
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
@@ -558,7 +560,12 @@ func newApplyOptions(yamlBody string) *apply.ApplyOptions {
 	}
 	return applyOptions
 }
-func resourceKubectlManifestApply(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+// resourceKubectlManifestApply applies the manifest and (when configured)
+// waits for the resource's rollout to complete. The caller passes the
+// timeout key matching the active operation (schema.TimeoutCreate or
+// schema.TimeoutUpdate); it determines which user-configured `timeouts`
+// block governs the wait_for_rollout / wait_for loops.
+func resourceKubectlManifestApply(ctx context.Context, d *schema.ResourceData, meta interface{}, timeoutKey string) error {
 	yamlBody := d.Get("yaml_body").(string)
 
 	// convert hcl into an unstructured object
@@ -649,7 +656,7 @@ func resourceKubectlManifestApply(ctx context.Context, d *schema.ResourceData, m
 	_ = d.Set("live_manifest_incluster", liveManifestFingerprint)
 
 	if d.Get("wait_for_rollout").(bool) {
-		timeout := d.Timeout(schema.TimeoutCreate)
+		timeout := d.Timeout(timeoutKey)
 
 		switch {
 		case manifest.GetKind() == "Deployment":
@@ -680,7 +687,7 @@ func resourceKubectlManifestApply(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if v, ok := d.GetOk("wait_for"); ok {
-		timeout := d.Timeout(schema.TimeoutCreate)
+		timeout := d.Timeout(timeoutKey)
 
 		waitFor := types.WaitFor{}
 		if err := mapstructure.Decode((v.([]interface{}))[0], &waitFor); err != nil {
@@ -1009,56 +1016,86 @@ func waitForDelete(ctx context.Context, restClient *RestClientResult, name strin
 	return nil
 }
 
+// deploymentRolloutComplete reports whether the Deployment has finished
+// its current rollout. Mirrors kubectl's `rollout status deployment`
+// progression semantics. Same as the existing watch logic — extracted to
+// a pure predicate so we can probe both before and after opening the
+// Watch, closing the Get-then-Watch race that left wait_for_rollout
+// hanging until the operation timeout. See issue #226.
+func deploymentRolloutComplete(deployment *apps_v1.Deployment) bool {
+	if deployment.Generation > deployment.Status.ObservedGeneration {
+		return false
+	}
+	// Preserve the existing provider behaviour: a Progressing=False with
+	// reason=ProgressDeadlineExceeded is treated as "still waiting", not
+	// as a permanent failure. Callers rely on this to keep waiting while
+	// the controller retries.
+	if condition := getDeploymentCondition(deployment.Status, apps_v1.DeploymentProgressing); condition != nil && condition.Reason == TimedOutReason {
+		return false
+	}
+	if deployment.Spec.Replicas != nil && deployment.Status.UpdatedReplicas < *deployment.Spec.Replicas {
+		return false
+	}
+	if deployment.Status.Replicas > deployment.Status.UpdatedReplicas {
+		return false
+	}
+	if deployment.Status.AvailableReplicas < deployment.Status.UpdatedReplicas {
+		return false
+	}
+	return true
+}
+
 func waitForDeploymentRollout(ctx context.Context, provider *KubeProvider, ns string, name string, timeout time.Duration) error {
-	// Borrowed from: https://github.com/kubernetes/kubectl/blob/c4be63c54b7188502c1a63bb884a0b05fac51ebd/pkg/polymorphichelpers/rollout_status.go#L59
+	deploymentClient := provider.MainClientset.AppsV1().Deployments(ns)
+
+	// Probe current state and capture ResourceVersion before opening the
+	// Watch. A Watch opened with no ResourceVersion only delivers future
+	// events; if the controller settled the rollout between this Get and
+	// the Watch open, the watcher would sit idle until the operation
+	// timeout. See issue #226.
+	resourceVersion := ""
+	if current, err := deploymentClient.Get(ctx, name, meta_v1.GetOptions{}); err == nil {
+		if deploymentRolloutComplete(current) {
+			return nil
+		}
+		resourceVersion = current.ResourceVersion
+	}
 
 	timeoutSeconds := int64(timeout.Seconds())
-
-	watcher, err := provider.MainClientset.AppsV1().Deployments(ns).Watch(ctx, meta_v1.ListOptions{Watch: true, TimeoutSeconds: &timeoutSeconds, FieldSelector: fields.OneTermEqualSelector("metadata.name", name).String()})
+	watcher, err := deploymentClient.Watch(ctx, meta_v1.ListOptions{
+		Watch:           true,
+		TimeoutSeconds:  &timeoutSeconds,
+		FieldSelector:   fields.OneTermEqualSelector("metadata.name", name).String(),
+		ResourceVersion: resourceVersion,
+	})
 	if err != nil {
 		return err
 	}
-
 	defer watcher.Stop()
 
-	done := false
-	for !done {
+	for {
 		select {
-		case event := <-watcher.ResultChan():
-			if event.Type == watch.Modified {
-				deployment, ok := event.Object.(*apps_v1.Deployment)
-				if !ok {
-					return fmt.Errorf("%s could not cast to Deployment", name)
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				if current, gerr := deploymentClient.Get(ctx, name, meta_v1.GetOptions{}); gerr == nil && deploymentRolloutComplete(current) {
+					return nil
 				}
-
-				if deployment.Generation <= deployment.Status.ObservedGeneration {
-					condition := getDeploymentCondition(deployment.Status, apps_v1.DeploymentProgressing)
-					if condition != nil && condition.Reason == TimedOutReason {
-						continue
-					}
-
-					if deployment.Spec.Replicas != nil && deployment.Status.UpdatedReplicas < *deployment.Spec.Replicas {
-						continue
-					}
-
-					if deployment.Status.Replicas > deployment.Status.UpdatedReplicas {
-						continue
-					}
-
-					if deployment.Status.AvailableReplicas < deployment.Status.UpdatedReplicas {
-						continue
-					}
-
-					done = true
-				}
+				return fmt.Errorf("%s watch channel closed before Deployment rollout completed", name)
 			}
-
+			if event.Type != watch.Modified {
+				continue
+			}
+			deployment, ok := event.Object.(*apps_v1.Deployment)
+			if !ok {
+				return fmt.Errorf("%s could not cast to Deployment", name)
+			}
+			if deploymentRolloutComplete(deployment) {
+				return nil
+			}
 		case <-ctx.Done():
 			return fmt.Errorf("%s failed to rollout Deployment", name)
 		}
 	}
-
-	return nil
 }
 
 func getDeploymentCondition(status apps_v1.DeploymentStatus, condType apps_v1.DeploymentConditionType) *apps_v1.DeploymentCondition {
@@ -1155,65 +1192,80 @@ func waitForDaemonSetRollout(ctx context.Context, provider *KubeProvider, ns str
 	}
 }
 
+// statefulSetRolloutComplete reports whether the StatefulSet has
+// finished its current rollout. Mirrors kubectl's `rollout status
+// statefulset` semantics, extracted from the original watch loop so we
+// can probe state before opening the Watch. See issue #226.
+func statefulSetRolloutComplete(sts *apps_v1.StatefulSet) bool {
+	if sts.Spec.UpdateStrategy.Type != apps_v1.RollingUpdateStatefulSetStrategyType {
+		return true
+	}
+	if sts.Status.ObservedGeneration == 0 || sts.Generation > sts.Status.ObservedGeneration {
+		return false
+	}
+	if sts.Spec.Replicas != nil && sts.Status.ReadyReplicas < *sts.Spec.Replicas {
+		return false
+	}
+	if sts.Spec.UpdateStrategy.RollingUpdate != nil {
+		if sts.Spec.Replicas != nil && sts.Spec.UpdateStrategy.RollingUpdate.Partition != nil {
+			if sts.Status.UpdatedReplicas < (*sts.Spec.Replicas - *sts.Spec.UpdateStrategy.RollingUpdate.Partition) {
+				return false
+			}
+		}
+		return true
+	}
+	if sts.Status.UpdateRevision != sts.Status.CurrentRevision {
+		return false
+	}
+	return true
+}
+
 func waitForStatefulSetRollout(ctx context.Context, provider *KubeProvider, ns string, name string, timeout time.Duration) error {
-	// Borrowed from: https://github.com/kubernetes/kubectl/blob/c4be63c54b7188502c1a63bb884a0b05fac51ebd/pkg/polymorphichelpers/rollout_status.go#L120
+	stsClient := provider.MainClientset.AppsV1().StatefulSets(ns)
+
+	resourceVersion := ""
+	if current, err := stsClient.Get(ctx, name, meta_v1.GetOptions{}); err == nil {
+		if statefulSetRolloutComplete(current) {
+			return nil
+		}
+		resourceVersion = current.ResourceVersion
+	}
 
 	timeoutSeconds := int64(timeout.Seconds())
-
-	watcher, err := provider.MainClientset.AppsV1().StatefulSets(ns).Watch(ctx, meta_v1.ListOptions{Watch: true, TimeoutSeconds: &timeoutSeconds, FieldSelector: fields.OneTermEqualSelector("metadata.name", name).String()})
+	watcher, err := stsClient.Watch(ctx, meta_v1.ListOptions{
+		Watch:           true,
+		TimeoutSeconds:  &timeoutSeconds,
+		FieldSelector:   fields.OneTermEqualSelector("metadata.name", name).String(),
+		ResourceVersion: resourceVersion,
+	})
 	if err != nil {
 		return err
 	}
-
 	defer watcher.Stop()
 
-	done := false
-	for !done {
+	for {
 		select {
-		case event := <-watcher.ResultChan():
-			if event.Type == watch.Modified {
-				sts, ok := event.Object.(*apps_v1.StatefulSet)
-				if !ok {
-					return fmt.Errorf("%s could not cast to StatefulSet", name)
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				if current, gerr := stsClient.Get(ctx, name, meta_v1.GetOptions{}); gerr == nil && statefulSetRolloutComplete(current) {
+					return nil
 				}
-
-				if sts.Spec.UpdateStrategy.Type != apps_v1.RollingUpdateStatefulSetStrategyType {
-					done = true
-					continue
-				}
-
-				if sts.Status.ObservedGeneration == 0 || sts.Generation > sts.Status.ObservedGeneration {
-					continue
-				}
-
-				if sts.Spec.Replicas != nil && sts.Status.ReadyReplicas < *sts.Spec.Replicas {
-					continue
-				}
-
-				if sts.Spec.UpdateStrategy.Type == apps_v1.RollingUpdateStatefulSetStrategyType && sts.Spec.UpdateStrategy.RollingUpdate != nil {
-					if sts.Spec.Replicas != nil && sts.Spec.UpdateStrategy.RollingUpdate.Partition != nil {
-						if sts.Status.UpdatedReplicas < (*sts.Spec.Replicas - *sts.Spec.UpdateStrategy.RollingUpdate.Partition) {
-							continue
-						}
-					}
-
-					done = true
-					continue
-				}
-
-				if sts.Status.UpdateRevision != sts.Status.CurrentRevision {
-					continue
-				}
-
-				done = true
+				return fmt.Errorf("%s watch channel closed before StatefulSet rollout completed", name)
 			}
-
+			if event.Type != watch.Modified {
+				continue
+			}
+			sts, ok := event.Object.(*apps_v1.StatefulSet)
+			if !ok {
+				return fmt.Errorf("%s could not cast to StatefulSet", name)
+			}
+			if statefulSetRolloutComplete(sts) {
+				return nil
+			}
 		case <-ctx.Done():
 			return fmt.Errorf("%s failed to rollout StatefulSet", name)
 		}
 	}
-
-	return nil
 }
 
 func waitForApiService(ctx context.Context, provider *KubeProvider, name string, timeout time.Duration) error {

--- a/kubernetes/resource_kubectl_manifest_test.go
+++ b/kubernetes/resource_kubectl_manifest_test.go
@@ -170,6 +170,67 @@ YAML
 	})
 }
 
+// TestAccKubectl_WaitForRolloutDeploymentUpdate is a regression test for
+// https://github.com/alekc/terraform-provider-kubectl/issues/226. Two
+// behaviours converged in that issue:
+//   - the resource schema only declared a `create` timeout, so users
+//     setting `timeouts { update = ... }` were silently ignored, and
+//   - `waitForDeploymentRollout` opened a Watch without an initial-state
+//     probe; an update whose rollout settled between the spec write and
+//     the Watch open then blocked until the operation timeout.
+//
+// This test exercises both: it creates a Deployment, then runs an
+// in-place update with an `update` timeout configured. The new code
+// path returns immediately once the rollout settles; the old path
+// hung 20 minutes and failed.
+func TestAccKubectl_WaitForRolloutDeploymentUpdate(t *testing.T) {
+	t.Parallel()
+
+	deploymentConfig := func(replicas int) string {
+		return fmt.Sprintf(`
+resource "kubectl_manifest" "test" {
+  wait_for_rollout = true
+  timeouts {
+    create = "60s"
+    update = "60s"
+    delete = "60s"
+  }
+  yaml_body = <<YAML
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: issue-226-deployment
+  labels:
+    app: issue-226
+spec:
+  replicas: %d
+  selector:
+    matchLabels:
+      app: issue-226
+  template:
+    metadata:
+      labels:
+        app: issue-226
+    spec:
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.10
+YAML
+}
+`, replicas)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckkubectlDestroy,
+		Steps: []resource.TestStep{
+			{Config: deploymentConfig(1)},
+			{Config: deploymentConfig(2)},
+		},
+	})
+}
+
 func TestAccKubectl_WaitForRolloutStatefulSet(t *testing.T) {
 	t.Parallel()
 

--- a/kubernetes/resource_kubectl_manifest_test.go
+++ b/kubernetes/resource_kubectl_manifest_test.go
@@ -186,7 +186,12 @@ YAML
 func TestAccKubectl_WaitForRolloutDeploymentUpdate(t *testing.T) {
 	t.Parallel()
 
-	deploymentConfig := func(replicas int) string {
+	// Generate one unique name per test run so this test does not
+	// collide with concurrent runs (matrix jobs sharing a cluster,
+	// or other `t.Parallel()` tests that touch the default namespace).
+	name := acctest.RandomWithPrefix("issue-226-deployment")
+
+	deploymentConfig := func(name string, replicas int) string {
 		return fmt.Sprintf(`
 resource "kubectl_manifest" "test" {
   wait_for_rollout = true
@@ -199,25 +204,25 @@ resource "kubectl_manifest" "test" {
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: issue-226-deployment
+  name: %s
   labels:
-    app: issue-226
+    app: %s
 spec:
   replicas: %d
   selector:
     matchLabels:
-      app: issue-226
+      app: %s
   template:
     metadata:
       labels:
-        app: issue-226
+        app: %s
     spec:
       containers:
         - name: pause
           image: registry.k8s.io/pause:3.10
 YAML
 }
-`, replicas)
+`, name, name, replicas, name, name)
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -225,8 +230,8 @@ YAML
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckkubectlDestroy,
 		Steps: []resource.TestStep{
-			{Config: deploymentConfig(1)},
-			{Config: deploymentConfig(2)},
+			{Config: deploymentConfig(name, 1)},
+			{Config: deploymentConfig(name, 2)},
 		},
 	})
 }

--- a/kubernetes/rollout_status_test.go
+++ b/kubernetes/rollout_status_test.go
@@ -109,3 +109,242 @@ func dsRolling(generation int64, status apps_v1.DaemonSetStatus) *apps_v1.Daemon
 		Status: status,
 	}
 }
+
+// TestDeploymentRolloutComplete pins down the Deployment rollout-complete
+// predicate extracted while fixing issue #226 (Get-then-Watch race in
+// wait_for_rollout that left updates hanging until the operation timeout).
+func TestDeploymentRolloutComplete(t *testing.T) {
+	replicas := func(n int32) *int32 { return &n }
+
+	cases := []struct {
+		name string
+		in   *apps_v1.Deployment
+		want bool
+	}{
+		{
+			name: "generation ahead of observedGeneration — not yet observed",
+			in: dep(2, apps_v1.DeploymentStatus{
+				ObservedGeneration: 1,
+				Replicas:           3,
+				UpdatedReplicas:    3,
+				AvailableReplicas:  3,
+			}, replicas(3)),
+			want: false,
+		},
+		{
+			name: "progress deadline exceeded — still waiting (not failing) per existing provider semantics",
+			in: dep(1, apps_v1.DeploymentStatus{
+				ObservedGeneration: 1,
+				Replicas:           3,
+				UpdatedReplicas:    3,
+				AvailableReplicas:  3,
+				Conditions: []apps_v1.DeploymentCondition{{
+					Type:   apps_v1.DeploymentProgressing,
+					Reason: TimedOutReason,
+				}},
+			}, replicas(3)),
+			want: false,
+		},
+		{
+			name: "updated < desired",
+			in: dep(1, apps_v1.DeploymentStatus{
+				ObservedGeneration: 1,
+				Replicas:           3,
+				UpdatedReplicas:    2,
+				AvailableReplicas:  2,
+			}, replicas(3)),
+			want: false,
+		},
+		{
+			name: "old replicas still being scaled down",
+			in: dep(1, apps_v1.DeploymentStatus{
+				ObservedGeneration: 1,
+				Replicas:           4,
+				UpdatedReplicas:    3,
+				AvailableReplicas:  3,
+			}, replicas(3)),
+			want: false,
+		},
+		{
+			name: "available < updated",
+			in: dep(1, apps_v1.DeploymentStatus{
+				ObservedGeneration: 1,
+				Replicas:           3,
+				UpdatedReplicas:    3,
+				AvailableReplicas:  2,
+			}, replicas(3)),
+			want: false,
+		},
+		{
+			name: "fully rolled out",
+			in: dep(1, apps_v1.DeploymentStatus{
+				ObservedGeneration: 1,
+				Replicas:           3,
+				UpdatedReplicas:    3,
+				AvailableReplicas:  3,
+			}, replicas(3)),
+			want: true,
+		},
+		{
+			name: "fully rolled out with nil spec.replicas (omits the spec-replicas check)",
+			in: dep(1, apps_v1.DeploymentStatus{
+				ObservedGeneration: 1,
+				Replicas:           1,
+				UpdatedReplicas:    1,
+				AvailableReplicas:  1,
+			}, nil),
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := deploymentRolloutComplete(tc.in)
+			if got != tc.want {
+				t.Fatalf("deploymentRolloutComplete = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStatefulSetRolloutComplete pins down the StatefulSet
+// rollout-complete predicate extracted alongside the Deployment one.
+func TestStatefulSetRolloutComplete(t *testing.T) {
+	replicas := func(n int32) *int32 { return &n }
+	partition := func(n int32) *int32 { return &n }
+
+	cases := []struct {
+		name string
+		in   *apps_v1.StatefulSet
+		want bool
+	}{
+		{
+			name: "OnDelete strategy always complete",
+			in: &apps_v1.StatefulSet{
+				ObjectMeta: meta_v1.ObjectMeta{Generation: 1},
+				Spec: apps_v1.StatefulSetSpec{
+					UpdateStrategy: apps_v1.StatefulSetUpdateStrategy{Type: apps_v1.OnDeleteStatefulSetStrategyType},
+				},
+				Status: apps_v1.StatefulSetStatus{ObservedGeneration: 0},
+			},
+			want: true,
+		},
+		{
+			name: "observedGeneration == 0 — controller not yet observed",
+			in: stsRolling(1, apps_v1.StatefulSetStatus{
+				ObservedGeneration: 0,
+				ReadyReplicas:      3,
+			}, replicas(3), nil),
+			want: false,
+		},
+		{
+			name: "generation ahead of observedGeneration",
+			in: stsRolling(2, apps_v1.StatefulSetStatus{
+				ObservedGeneration: 1,
+				ReadyReplicas:      3,
+			}, replicas(3), nil),
+			want: false,
+		},
+		{
+			name: "ready < desired",
+			in: stsRolling(1, apps_v1.StatefulSetStatus{
+				ObservedGeneration: 1,
+				ReadyReplicas:      2,
+			}, replicas(3), nil),
+			want: false,
+		},
+		{
+			name: "partition: updated covers (replicas - partition) → complete",
+			in: stsRolling(1, apps_v1.StatefulSetStatus{
+				ObservedGeneration: 1,
+				ReadyReplicas:      3,
+				UpdatedReplicas:    2, // updated 2 pods, replicas=3, partition=1 → 2 >= 3-1 ✓
+			}, replicas(3), partition(1)),
+			want: true,
+		},
+		{
+			name: "partition: updated below (replicas - partition) → still rolling",
+			in: stsRolling(1, apps_v1.StatefulSetStatus{
+				ObservedGeneration: 1,
+				ReadyReplicas:      3,
+				UpdatedReplicas:    1, // 1 < 3-1
+			}, replicas(3), partition(1)),
+			want: false,
+		},
+		{
+			name: "rolling update with rollingUpdate config but no partition",
+			in: stsRolling(1, apps_v1.StatefulSetStatus{
+				ObservedGeneration: 1,
+				ReadyReplicas:      3,
+				UpdatedReplicas:    3,
+			}, replicas(3), nil),
+			want: true,
+		},
+		{
+			name: "updateRevision != currentRevision when no rollingUpdate config",
+			in: &apps_v1.StatefulSet{
+				ObjectMeta: meta_v1.ObjectMeta{Generation: 1},
+				Spec: apps_v1.StatefulSetSpec{
+					Replicas:       replicas(3),
+					UpdateStrategy: apps_v1.StatefulSetUpdateStrategy{Type: apps_v1.RollingUpdateStatefulSetStrategyType},
+				},
+				Status: apps_v1.StatefulSetStatus{
+					ObservedGeneration: 1,
+					ReadyReplicas:      3,
+					UpdateRevision:     "rev-2",
+					CurrentRevision:    "rev-1",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "updateRevision == currentRevision when no rollingUpdate config",
+			in: &apps_v1.StatefulSet{
+				ObjectMeta: meta_v1.ObjectMeta{Generation: 1},
+				Spec: apps_v1.StatefulSetSpec{
+					Replicas:       replicas(3),
+					UpdateStrategy: apps_v1.StatefulSetUpdateStrategy{Type: apps_v1.RollingUpdateStatefulSetStrategyType},
+				},
+				Status: apps_v1.StatefulSetStatus{
+					ObservedGeneration: 1,
+					ReadyReplicas:      3,
+					UpdateRevision:     "rev-1",
+					CurrentRevision:    "rev-1",
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := statefulSetRolloutComplete(tc.in)
+			if got != tc.want {
+				t.Fatalf("statefulSetRolloutComplete = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func dep(generation int64, status apps_v1.DeploymentStatus, specReplicas *int32) *apps_v1.Deployment {
+	return &apps_v1.Deployment{
+		ObjectMeta: meta_v1.ObjectMeta{Generation: generation},
+		Spec:       apps_v1.DeploymentSpec{Replicas: specReplicas},
+		Status:     status,
+	}
+}
+
+func stsRolling(generation int64, status apps_v1.StatefulSetStatus, specReplicas, partition *int32) *apps_v1.StatefulSet {
+	spec := apps_v1.StatefulSetSpec{
+		Replicas: specReplicas,
+		UpdateStrategy: apps_v1.StatefulSetUpdateStrategy{
+			Type:          apps_v1.RollingUpdateStatefulSetStrategyType,
+			RollingUpdate: &apps_v1.RollingUpdateStatefulSetStrategy{Partition: partition},
+		},
+	}
+	return &apps_v1.StatefulSet{
+		ObjectMeta: meta_v1.ObjectMeta{Generation: generation},
+		Spec:       spec,
+		Status:     status,
+	}
+}


### PR DESCRIPTION
## Summary

Resolves https://github.com/alekc/terraform-provider-kubectl/issues/226. Three converging bugs caused user-set update timeouts to be ignored and in-place Deployment/StatefulSet updates to hang for 20 minutes even after the rollout completed.

- **Schema only declared `create`**, so `timeouts { update = "30m" }` was silently dropped and the framework's 20-minute default took over for in-place updates. Adds `update` and `delete` to the schema (both default 10m, matching `create`).
- **`resourceKubectlManifestApply` hardcoded `d.Timeout(schema.TimeoutCreate)`**, so even after the schema change the wait_for_rollout / wait_for loops would still use the create timeout during Update. Now Create passes `schema.TimeoutCreate` and Update passes `schema.TimeoutUpdate`.
- **Get-then-Watch race in `waitForDeploymentRollout` and `waitForStatefulSetRollout`** — mirrors the DaemonSet fix from #228/#262. Opens Watch with `ResourceVersion=""` lost any reconcile event that landed between the spec write and the Watch open; the watcher then sat idle until the operation timeout even though the rollout had finished. Both helpers now probe Get first, return early if complete, seed Watch with the captured ResourceVersion, and re-probe on watch-channel close.

Rollout-complete logic is extracted into pure `deploymentRolloutComplete` and `statefulSetRolloutComplete` predicates with table-driven unit tests, matching the DaemonSet predicate split. Existing semantics preserved — including the Deployment `ProgressDeadlineExceeded` → "still waiting" behaviour (diverges from kubectl, kept for backwards-compatibility).

Docs: added a Timeouts section to `docs/resources/kubectl_manifest.md`.

## Test plan

- [x] `go test ./...` — green (unit + framework + flatten + yaml suites)
- [x] `go test -run TestDaemonSetRolloutComplete|TestDeploymentRolloutComplete|TestStatefulSetRolloutComplete -v` — green (24 cases)
- [x] `TF_ACC=1 go test -run TestAccKubectl_WaitForRollout -v` against local kind — five tests green: DaemonSet (13.4s), Deployment (13.4s), StatefulSet (37.5s), DaemonSetNoMatchingNodes (1.3s), DeploymentUpdate (4.3s — new)
- [ ] CI matrix on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timeout configuration support for `kubectl_manifest` resource with operation-specific timeouts for create, update, and delete operations (each defaults to 10 minutes).

* **Bug Fixes**
  * Improved rollout wait logic to prevent race conditions when monitoring Deployment and StatefulSet rollout completion.

* **Documentation**
  * Added documentation describing timeout configuration options and usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alekc/terraform-provider-kubectl/pull/263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->