### PR TITLE
fix(provider): surface clientcmd error instead of empty-config fallback

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -125,6 +125,41 @@ provider "kubectl" {
 }
 ```
 
+## Troubleshooting
+
+### `Failed to get RESTMapper client / cannot create discovery client: no client config`
+
+This error means the provider configuration produced an empty REST config —
+`host`, `token`, `cluster_ca_certificate`, `exec`, or a kubeconfig path either
+wasn't supplied or wasn't resolvable when Terraform configured the provider.
+The provider now reports the underlying `clientcmd` reason (missing host,
+malformed cert, unresolved variable, …) directly in the diagnostic, so check
+the full error text first.
+
+The most common trigger is **deferred evaluation of provider arguments**:
+Terraform configures providers up front, before any resources have been
+applied. If `host`/`token`/etc. come from outputs of resources that haven't
+been applied yet (or from a sibling module that errored during plan), those
+values are unknown at provider-configure time and the provider falls back to
+an empty config. The same pitfall affects `hashicorp/kubernetes` —
+see Terraform's
+[providers documentation](https://developer.hashicorp.com/terraform/language/providers/configuration#provider-versions)
+for the broader pattern.
+
+Workarounds, in order of preference:
+
+1. **Two-stage apply** — apply the cluster (or whatever owns the credentials)
+   in one root module, then apply the manifests in a separate root module
+   that reads the cluster outputs via `terraform_remote_state` or a data
+   source.
+2. **Pin the credentials to a stable source** — e.g. `data
+   "aws_eks_cluster"` / `data "google_container_cluster"` instead of the
+   resource attribute, since data sources are re-read on every plan and
+   don't carry the "unknown until apply" status that resource outputs do.
+3. **Smoke-test with literal values** — replace `var.host` /
+   `var.cluster_ca_certificate` etc. with hardcoded strings briefly to
+   confirm the rest of the config is correct; if that succeeds the failure
+   is the deferred-evaluation pattern above.
 
 ## Example
 

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -399,8 +399,14 @@ func initializeConfiguration(d *schema.ResourceData) (*restclient.Config, error)
 	cc := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loader, overrides)
 	cfg, err := cc.ClientConfig()
 	if err != nil {
-		log.Printf("[WARN] Invalid provider configuration was supplied. Provider operations likely to fail: %v", err)
-		return nil, nil
+		// Surface the underlying clientcmd error to the caller. Swallowing it
+		// here (returning nil, nil) lets the rest of providerConfigure run
+		// against an empty restclient.Config, and the failure resurfaces much
+		// later as a misleading "cannot create discovery client: no client
+		// config" from ToRESTMapper. Returning the real reason — typically a
+		// missing host, an unresolved variable, or a malformed cert — points
+		// users straight at the bad field. See issue #203.
+		return nil, fmt.Errorf("invalid provider configuration: %w", err)
 	}
 
 	return cfg, nil


### PR DESCRIPTION
## Summary

- `initializeConfiguration` no longer swallows `clientcmd.ClientConfig()` errors. The wrapped error now propagates through `providerConfigure` and surfaces as a Terraform diagnostic, instead of being masked by the empty-`restclient.Config{}` fallback and resurfacing later as the cryptic *"Failed to get RESTMapper client / cannot create discovery client: no client config"*.
- Added a Troubleshooting section to `docs/index.md` explaining the deferred-evaluation pitfall (provider arguments sourced from not-yet-applied resource outputs), with three workarounds in order of preference.

## Context

Reported in #203: a user configures `provider "kubectl"` with `host` / `cluster_ca_certificate` / etc. coming from another module's outputs and hits the *"no client config"* error during plan. Tracing through `kubernetes/provider.go` showed the real `clientcmd` error was being logged as `[WARN]` and discarded; the rest of `providerConfigure` then ran against an empty REST config. The user never sees the actual reason their config was rejected.

This is a diagnostic-only change. It does NOT fix the underlying Terraform pitfall (provider config that depends on unknown-until-apply outputs is a known sharp edge that also affects `hashicorp/kubernetes`). It just makes the error message point at the bad field instead of a symptom three layers away.

## Behaviour change

Before:
```
Error: Failed to get RESTMapper client
cannot create discovery client: no client config
```

After (example):
```
Error: invalid provider configuration: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
```
…or whatever the underlying `clientcmd` reason actually is for the user's setup.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -short` (all unit tests pass — flatten, framework, kubernetes, yaml)
- [x] CI matrix (acc_test across TF 1.5.7 / 1.12.2 / 1.13.5 / 1.14.9 / 1.15.3 × K8s 1.33.7 / 1.34.3 / 1.35.1)
- [ ] Manual smoke: configure provider with a deliberately bad `host` and confirm the diagnostic now names the real reason