### PR TITLE
fix(provider): move apply_retry_count from package global onto KubeProvider

### DIFF
--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -199,11 +199,10 @@ type KubeProvider struct {
 	MainClientset       *kubernetes.Clientset
 	RestConfig          restclient.Config
 	AggregatorClientset *aggregator.Clientset
-	// ApplyRetryCount is how many times an apply will be retried with
-	// exponential backoff before surfacing the error. Sourced from the
-	// `apply_retry_count` provider arg (or KUBECTL_PROVIDER_APPLY_RETRY_COUNT).
-	// Held per-provider so aliased blocks with different values don't clobber
-	// each other.
+	// ApplyRetryCount is how many times an apply is retried with exponential
+	// backoff before surfacing the error. Sourced from the `apply_retry_count`
+	// provider arg (or KUBECTL_PROVIDER_APPLY_RETRY_COUNT). Held per-provider
+	// so aliased blocks with different values don't clobber each other.
 	ApplyRetryCount uint64
 }
 

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -199,6 +199,12 @@ type KubeProvider struct {
 	MainClientset       *kubernetes.Clientset
 	RestConfig          restclient.Config
 	AggregatorClientset *aggregator.Clientset
+	// ApplyRetryCount is how many times an apply will be retried with
+	// exponential backoff before surfacing the error. Sourced from the
+	// `apply_retry_count` provider arg (or KUBECTL_PROVIDER_APPLY_RETRY_COUNT).
+	// Held per-provider so aliased blocks with different values don't clobber
+	// each other.
+	ApplyRetryCount uint64
 }
 
 var _ k8sresource.RESTClientGetter = &KubeProvider{}
@@ -232,8 +238,6 @@ func (p *KubeProvider) ToRESTMapper() (meta.RESTMapper, error) {
 	return nil, fmt.Errorf("no restmapper")
 }
 
-var kubectlApplyRetryCount uint64
-
 func providerConfigure(d *schema.ResourceData, terraformVersion string) (interface{}, diag.Diagnostics) {
 
 	cfg, err := initializeConfiguration(d)
@@ -245,10 +249,10 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 		cfg = &restclient.Config{}
 	}
 
-	kubectlApplyRetryCount = uint64(d.Get("apply_retry_count").(int))
+	applyRetryCount := uint64(d.Get("apply_retry_count").(int))
 	if os.Getenv("KUBECTL_PROVIDER_APPLY_RETRY_COUNT") != "" {
 		applyEnvValue, _ := strconv.Atoi(os.Getenv("KUBECTL_PROVIDER_APPLY_RETRY_COUNT"))
-		kubectlApplyRetryCount = uint64(applyEnvValue)
+		applyRetryCount = uint64(applyEnvValue)
 	}
 
 	cfg.QPS = 100.0
@@ -273,6 +277,7 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 		MainClientset:       k,
 		RestConfig:          *cfg,
 		AggregatorClientset: a,
+		ApplyRetryCount:     applyRetryCount,
 	}, nil
 }
 

--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -27,6 +27,59 @@ func TestProvider(t *testing.T) {
 	}
 }
 
+// TestProviderConfigure_ApplyRetryCountIsPerProvider pins the fix for issue
+// #265: apply_retry_count used to live in a package-level global, so the last
+// providerConfigure to run silently set the value for every other aliased
+// provider's resources. Each providerConfigure call must populate its own
+// *KubeProvider with the value the caller passed.
+func TestProviderConfigure_ApplyRetryCountIsPerProvider(t *testing.T) {
+	t.Setenv("KUBECTL_PROVIDER_APPLY_RETRY_COUNT", "")
+
+	raw := func(retry int) map[string]interface{} {
+		return map[string]interface{}{
+			"apply_retry_count": retry,
+			"load_config_file":  false,
+			"host":              "http://example.invalid",
+		}
+	}
+	schemaMap := Provider().Schema
+
+	metaA, diags := providerConfigure(schema.TestResourceDataRaw(t, schemaMap, raw(1)), "test")
+	if diags.HasError() {
+		t.Fatalf("provider A: %v", diags)
+	}
+	metaB, diags := providerConfigure(schema.TestResourceDataRaw(t, schemaMap, raw(42)), "test")
+	if diags.HasError() {
+		t.Fatalf("provider B: %v", diags)
+	}
+
+	if got := metaA.(*KubeProvider).ApplyRetryCount; got != 1 {
+		t.Errorf("provider A: ApplyRetryCount = %d, want 1", got)
+	}
+	if got := metaB.(*KubeProvider).ApplyRetryCount; got != 42 {
+		t.Errorf("provider B: ApplyRetryCount = %d, want 42 (was clobbered by provider B)", got)
+	}
+}
+
+// TestProviderConfigure_ApplyRetryCountEnvOverride verifies the env var still
+// wins over the schema value, and that the override is captured per-call.
+func TestProviderConfigure_ApplyRetryCountEnvOverride(t *testing.T) {
+	t.Setenv("KUBECTL_PROVIDER_APPLY_RETRY_COUNT", "7")
+
+	raw := map[string]interface{}{
+		"apply_retry_count": 1,
+		"load_config_file":  false,
+		"host":              "http://example.invalid",
+	}
+	meta, diags := providerConfigure(schema.TestResourceDataRaw(t, Provider().Schema, raw), "test")
+	if diags.HasError() {
+		t.Fatalf("providerConfigure: %v", diags)
+	}
+	if got := meta.(*KubeProvider).ApplyRetryCount; got != 7 {
+		t.Errorf("env override: ApplyRetryCount = %d, want 7", got)
+	}
+}
+
 func testAccCheckkubectlDestroy(s *terraform.State) error {
 	return testAccCheckkubectlStatus(s, false)
 }

--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -28,10 +28,9 @@ func TestProvider(t *testing.T) {
 }
 
 // TestProviderConfigure_ApplyRetryCountIsPerProvider pins the fix for issue
-// #265: apply_retry_count used to live in a package-level global, so the last
-// providerConfigure to run silently set the value for every other aliased
-// provider's resources. Each providerConfigure call must populate its own
-// *KubeProvider with the value the caller passed.
+// #265: apply_retry_count was held in a package-level global, so the last call
+// to providerConfigure silently overwrote the value seen by every other aliased
+// provider. Each call must now populate its own *KubeProvider with its value.
 func TestProviderConfigure_ApplyRetryCountIsPerProvider(t *testing.T) {
 	t.Setenv("KUBECTL_PROVIDER_APPLY_RETRY_COUNT", "")
 

--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -59,13 +59,14 @@ func resourceKubectlManifest() *schema.Resource {
 
 	return &schema.Resource{
 		CreateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+			retryCount := meta.(*KubeProvider).ApplyRetryCount
 			// No retries requested — run apply once and return.
 			// Without this early return the success path falls through to
 			// the retry block below and runs apply a second time against
 			// an already-consumed rate-limit budget / context, which
 			// surfaces as `client rate limiter Wait returned an error:
 			// context deadline exceeded`. See issue #228.
-			if kubectlApplyRetryCount == 0 {
+			if retryCount == 0 {
 				if applyErr := resourceKubectlManifestApply(ctx, d, meta, schema.TimeoutCreate); applyErr != nil {
 					return diag.FromErr(applyErr)
 				}
@@ -76,7 +77,7 @@ func resourceKubectlManifest() *schema.Resource {
 			exponentialBackoffConfig.InitialInterval = 3 * time.Second
 			exponentialBackoffConfig.MaxInterval = 30 * time.Second
 
-			retryConfig := backoff.WithMaxRetries(exponentialBackoffConfig, kubectlApplyRetryCount)
+			retryConfig := backoff.WithMaxRetries(exponentialBackoffConfig, retryCount)
 			retryErr := backoff.Retry(func() error {
 				err := resourceKubectlManifestApply(ctx, d, meta, schema.TimeoutCreate)
 				if err != nil {
@@ -104,12 +105,13 @@ func resourceKubectlManifest() *schema.Resource {
 			return nil
 		},
 		UpdateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+			retryCount := meta.(*KubeProvider).ApplyRetryCount
 			exponentialBackoffConfig := backoff.NewExponentialBackOff()
 			exponentialBackoffConfig.InitialInterval = 3 * time.Second
 			exponentialBackoffConfig.MaxInterval = 30 * time.Second
 
-			if kubectlApplyRetryCount > 0 {
-				retryConfig := backoff.WithMaxRetries(exponentialBackoffConfig, kubectlApplyRetryCount)
+			if retryCount > 0 {
+				retryConfig := backoff.WithMaxRetries(exponentialBackoffConfig, retryCount)
 				retryErr := backoff.Retry(func() error {
 					err := resourceKubectlManifestApply(ctx, d, meta, schema.TimeoutUpdate)
 					if err != nil {


### PR DESCRIPTION
## Summary

- Fixes #265.
- `apply_retry_count` was being stored in a package-level global `kubectlApplyRetryCount`, written by `providerConfigure` and read by the resource Create / Update path. With multiple aliased `provider "kubectl"` blocks, the last `providerConfigure` to run silently set the value for every parallel apply afterwards, regardless of which alias the resource belonged to.
- Move the value onto `*KubeProvider` (the per-provider meta Terraform hands each resource). The provider arg and `KUBECTL_PROVIDER_APPLY_RETRY_COUNT` env var continue to work identically; aliases now stay independent.

## Diff shape

- `kubernetes/provider.go` — drop the package var, add an `ApplyRetryCount uint64` field to `KubeProvider`, set it in `providerConfigure`.
- `kubernetes/resource_kubectl_manifest.go` — read `meta.(*KubeProvider).ApplyRetryCount` at the start of `CreateContext` and `UpdateContext`.

Net: +15 / -8 across two files.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -short` (flatten, internal/framework, kubernetes, yaml — all pass)
- [ ] Acceptance test in a multi-cluster Terraform config with two aliased provider blocks, each with a different `apply_retry_count`, verifying both retry counts are honoured independently (covered by the existing matrix CI on merge).