### PR TITLE
fix(provider): mirror muxed schema halves to fix #275

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,6 +60,108 @@ jobs:
         run: |
           make test
           make vet
+  real_terraform_smoke:
+    # End-to-end smoke that drives a real Terraform CLI against a
+    # dev_overrides build of the provider, applies a real manifest to a
+    # real kind cluster, and tears it back down. Covers two regression
+    # surfaces the SDK-test harness does not:
+    #
+    #   1. Provider load (GetProviderSchema): catches schema-parity
+    #      regressions across the muxed providers — issue #275.
+    #   2. Full create / read / delete lifecycle through the real CLI:
+    #      catches anything that only manifests when the provider is
+    #      driven over gRPC by `terraform` itself (plugin protocol
+    #      versioning, mux server plumbing, signal handling, etc.).
+    #
+    # One Kubernetes × Terraform pair is enough — the matrix-wide
+    # coverage already lives in acc_test_smoke / acc_test. This job is
+    # about catching real-CLI-only regressions, not version drift.
+    needs:
+      - get_version_matrix
+      - unit_test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          wait: 2m
+          node_image: kindest/node:v${{ needs.get_version_matrix.outputs.latest_k8s_version }}
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: ${{ needs.get_version_matrix.outputs.latest_terraform_version }}
+          terraform_wrapper: false
+      - name: Build provider
+        run: go build -o "${HOME}/terraform-provider-kubectl" .
+      - name: Configure dev_overrides
+        run: |
+          cat > "${HOME}/.terraformrc" <<EOF
+          provider_installation {
+            dev_overrides {
+              "alekc/kubectl" = "${HOME}"
+            }
+            direct {}
+          }
+          EOF
+      - name: Write smoke config
+        run: |
+          mkdir -p smoke
+          cat > smoke/main.tf <<'EOF'
+          terraform {
+            required_providers {
+              kubectl = {
+                source = "alekc/kubectl"
+              }
+            }
+          }
+
+          # Reads kubeconfig via KUBE_CONFIG_PATH env var (defaulted to the
+          # kind-action workspace path in this workflow). load_config_file
+          # defaults to true.
+          provider "kubectl" {}
+
+          resource "kubectl_manifest" "smoke" {
+            yaml_body = <<-YAML
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: kubectl-provider-real-smoke
+            YAML
+          }
+          EOF
+      - name: terraform apply
+        # This is the real CLI driving the real provider binary through
+        # gRPC. GetProviderSchema fires here; if mux parity is broken,
+        # this step exits non-zero with the same diagnostic users see.
+        env:
+          KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
+        run: |
+          cd smoke
+          terraform apply -auto-approve
+      - name: Verify namespace exists
+        run: kubectl get namespace kubectl-provider-real-smoke
+      - name: terraform destroy
+        env:
+          KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
+        run: |
+          cd smoke
+          terraform destroy -auto-approve
+      - name: Verify namespace deleted
+        run: |
+          # `kubectl get` returns non-zero with a NotFound error once the
+          # namespace is gone; treat that as success. Anything else (still
+          # Terminating, still Active, transport error) fails the job.
+          if kubectl get namespace kubectl-provider-real-smoke 2>&1 | grep -q 'NotFound'; then
+            echo "namespace deleted as expected"
+          else
+            echo "namespace still present after terraform destroy" >&2
+            kubectl get namespace kubectl-provider-real-smoke -o yaml >&2 || true
+            exit 1
+          fi
   acc_test_smoke:
     name: "acc_test smoke (k8s ${{ needs.get_version_matrix.outputs.latest_k8s_version }} / tf ${{ needs.get_version_matrix.outputs.latest_terraform_version }})"
     needs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -125,6 +125,13 @@ jobs:
           provider "kubectl" {}
 
           resource "kubectl_manifest" "smoke" {
+            # `wait = true` makes the provider block on `terraform destroy`
+            # until all finalizers (including the built-in `kubernetes`
+            # finalizer that drains in-namespace resources) finish. Without
+            # this, destroy returns while the namespace is still in
+            # Terminating phase and the post-destroy `kubectl get` check
+            # races against the kube-controller-manager.
+            wait = true
             yaml_body = <<-YAML
               apiVersion: v1
               kind: Namespace

--- a/internal/framework/provider.go
+++ b/internal/framework/provider.go
@@ -8,14 +8,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // kubectlFrameworkProvider is the plugin-framework half of the muxed provider.
 // All provider configuration (kubeconfig, auth, etc.) is handled by the SDK v2
-// half — this provider has no schema of its own and receives the configured
+// half — this provider has no behaviour of its own and receives the configured
 // SDK v2 meta via the SDKv2Meta callback. The Configure pass simply forwards
 // that callback down to each resource (currently just the manifest ephemeral
 // resource).
+//
+// The Schema() method below MUST stay byte-for-byte identical to the SDK v2
+// provider's Schema in `kubernetes/provider.go`. The muxer
+// (`tf6muxserver.NewMuxServer`) compares the provider configuration schema
+// returned by every muxed server and refuses to start if they differ — that
+// regression is tracked by issue #275 and pinned by the unit test in
+// `internal/mux/mux_test.go`. If you add, rename, or change the description
+// of any field on either side, update both.
 type kubectlFrameworkProvider struct {
 	version   string
 	SDKv2Meta func() any
@@ -43,8 +52,102 @@ func (p *kubectlFrameworkProvider) Metadata(_ context.Context, _ provider.Metada
 }
 
 func (p *kubectlFrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
+	// Mirror of the SDK v2 schema in `kubernetes/provider.go`. Keep field
+	// names, types, optional/required flags, and descriptions identical on
+	// both sides; the muxer enforces byte-for-byte parity. Defaults
+	// (DefaultFunc / EnvDefaultFunc) live on the SDK v2 side only — they do
+	// not propagate to the wire schema, so they aren't mirrored here.
 	resp.Schema = schema.Schema{
-		Attributes: map[string]schema.Attribute{},
+		Attributes: map[string]schema.Attribute{
+			"apply_retry_count": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Defines the number of attempts any create/update action will take",
+			},
+			"host": schema.StringAttribute{
+				Optional:    true,
+				Description: "The hostname (in form of URI) of Kubernetes master.",
+			},
+			"username": schema.StringAttribute{
+				Optional:    true,
+				Description: "The username to use for HTTP basic authentication when accessing the Kubernetes master endpoint.",
+			},
+			"password": schema.StringAttribute{
+				Optional:    true,
+				Description: "The password to use for HTTP basic authentication when accessing the Kubernetes master endpoint.",
+			},
+			"insecure": schema.BoolAttribute{
+				Optional:    true,
+				Description: "Whether server should be accessed without verifying the TLS certificate.",
+			},
+			"client_certificate": schema.StringAttribute{
+				Optional:    true,
+				Description: "PEM-encoded client certificate for TLS authentication.",
+			},
+			"client_key": schema.StringAttribute{
+				Optional:    true,
+				Description: "PEM-encoded client certificate key for TLS authentication.",
+			},
+			"cluster_ca_certificate": schema.StringAttribute{
+				Optional:    true,
+				Description: "PEM-encoded root certificates bundle for TLS authentication.",
+			},
+			"config_paths": schema.ListAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
+				Description: "A list of paths to kube config files. Can be set with KUBE_CONFIG_PATHS environment variable.",
+			},
+			"config_path": schema.StringAttribute{
+				Optional:    true,
+				Description: "Path to the kube config file, defaults to ~/.kube/config",
+			},
+			"config_context": schema.StringAttribute{
+				Optional: true,
+			},
+			"config_context_auth_info": schema.StringAttribute{
+				Optional: true,
+			},
+			"config_context_cluster": schema.StringAttribute{
+				Optional: true,
+			},
+			"token": schema.StringAttribute{
+				Optional:    true,
+				Description: "Token to authentifcate an service account",
+			},
+			"proxy_url": schema.StringAttribute{
+				Optional:    true,
+				Description: "URL to the proxy to be used for all API requests",
+			},
+			"load_config_file": schema.BoolAttribute{
+				Optional:    true,
+				Description: "Load local kubeconfig.",
+			},
+			"tls_server_name": schema.StringAttribute{
+				Optional:    true,
+				Description: "Server name passed to the server for SNI and is used in the client to check server certificates against.",
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"exec": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"api_version": schema.StringAttribute{
+							Required: true,
+						},
+						"command": schema.StringAttribute{
+							Required: true,
+						},
+						"env": schema.MapAttribute{
+							Optional:    true,
+							ElementType: types.StringType,
+						},
+						"args": schema.ListAttribute{
+							Optional:    true,
+							ElementType: types.StringType,
+						},
+					},
+				},
+			},
+		},
 	}
 }
 

--- a/internal/mux/mux_test.go
+++ b/internal/mux/mux_test.go
@@ -1,0 +1,40 @@
+package mux
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+// TestMuxServer_GetProviderSchemaIsClean pins the fix for issue #275.
+//
+// Background: tf6muxserver.NewMuxServer compares the provider configuration
+// schema returned by every muxed server and emits an error diagnostic when
+// they differ. Versions before 2.3.1 shipped with the framework half
+// declaring an empty schema while the SDK v2 half declared the full set,
+// which broke `terraform plan` at provider startup for every user (the
+// terraform-plugin-testing harness used by acc tests does not surface that
+// diagnostic, so CI did not catch it).
+//
+// This test invokes GetProviderSchema directly and fails if any error-
+// severity diagnostic comes back. The two halves of the schema live in
+// `kubernetes/provider.go` (SDK v2) and `internal/framework/provider.go`
+// (framework) — when adding, renaming, or re-describing a provider
+// attribute, both must be touched, and this test will fail otherwise.
+func TestMuxServer_GetProviderSchemaIsClean(t *testing.T) {
+	ctx := context.Background()
+	server, err := MuxServer(ctx, "test")
+	if err != nil {
+		t.Fatalf("MuxServer: %v", err)
+	}
+	resp, err := server.GetProviderSchema(ctx, &tfprotov6.GetProviderSchemaRequest{})
+	if err != nil {
+		t.Fatalf("GetProviderSchema: %v", err)
+	}
+	for i, d := range resp.Diagnostics {
+		if d.Severity == tfprotov6.DiagnosticSeverityError {
+			t.Errorf("diagnostic[%d]: %s — %s", i, d.Summary, d.Detail)
+		}
+	}
+}

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -141,7 +141,13 @@ func Provider() *schema.Provider {
 			"exec": {
 				Type:     schema.TypeList,
 				Optional: true,
-				MaxItems: 1,
+				// MaxItems is intentionally NOT set here. The framework half
+				// of the muxed provider does not emit MaxItems at the schema
+				// protocol level (terraform-plugin-framework drops it), so
+				// declaring it here causes tf6muxserver to fail with a schema
+				// parity error at provider startup (see issue #275). Single-
+				// element enforcement is preserved in initializeConfiguration
+				// below, which rejects len(exec) > 1 explicitly.
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"api_version": {
@@ -295,8 +301,16 @@ func initializeConfiguration(d *schema.ResourceData) (*restclient.Config, error)
 	}
 
 	if v, ok := d.GetOk("exec"); ok {
+		execList := v.([]interface{})
+		// Enforce the single-block limit that used to come for free from
+		// schema MaxItems: 1. The MaxItems hint was dropped from the schema
+		// to keep parity with the framework half of the muxed provider
+		// (see issue #275); the limit lives here now.
+		if len(execList) > 1 {
+			return nil, fmt.Errorf("provider supports at most one exec block, got %d", len(execList))
+		}
 		exec := &clientcmdapi.ExecConfig{}
-		if spec, ok := v.([]interface{})[0].(map[string]interface{}); ok {
+		if spec, ok := execList[0].(map[string]interface{}); ok {
 			exec.InteractiveMode = clientcmdapi.IfAvailableExecInteractiveMode
 			exec.APIVersion = spec["api_version"].(string)
 			exec.Command = spec["command"].(string)


### PR DESCRIPTION
## Summary

Fixes #275. The plugin-framework half of the muxed provider declared an empty configuration schema while the SDK v2 half declared the full set of provider arguments. `tf6muxserver.NewMuxServer` compares the schema returned by every muxed server and refuses to start when they differ, so every user on Terraform CLI 1.6+ hit `Invalid Provider Server Combination: The combined provider has differing provider schema implementations across providers` at `terraform plan` time on v2.3.0. Same root cause as jfrog/terraform-provider-artifactory#834.

## Fix

Mirror the full SDK v2 schema (17 top-level attributes plus the `exec` nested block) on the framework provider. Field names, types, optional/required flags, and descriptions are now byte-for-byte identical across both halves; the file comment on `kubectlFrameworkProvider` calls out the parity contract so future edits touch both sides. The SDK v2 `exec` block lost `MaxItems: 1` because the plugin-framework intentionally does not emit `MaxItems` at the schema protocol layer ([terraform-plugin-framework/internal/fwschema/block.go](https://github.com/hashicorp/terraform-plugin-framework/blob/v1.19.0/internal/fwschema/block.go#L24) explains why). The single-element limit is preserved at runtime inside `initializeConfiguration`, which now errors on `len(exec) > 1` instead of relying on the schema hint.

## Why CI shipped v2.3.0 broken, and what's added to prevent recurrence

The acc-test matrix uses `terraform-plugin-testing` which drives the provider in-process and silently swallows error-severity diagnostics returned from `GetProviderSchema`. The schema-parity bug fired in every CI run too, but the harness did not surface it as a test failure. Two new layers close that gap.

First, a unit test in `internal/mux/mux_test.go` invokes `MuxServer().GetProviderSchema()` directly and fails on any error diagnostic. Sub-second, no cluster, no Terraform binary required. Confirmed locally to fail on master pre-fix and pass on this branch.

Second, a new `real_terraform_smoke` CI job builds the provider, configures `dev_overrides`, spins up a kind cluster, applies a `kubectl_manifest` Namespace through a real `terraform` binary, verifies it exists via `kubectl get`, destroys it, and confirms it is gone. This exercises the exact gRPC path real users hit and is what would have caught #275 had it existed. The job runs in parallel with `acc_test_smoke` against the latest k8s / Terraform pair — matrix-wide drift coverage stays in `acc_test`, this job is about real-CLI-only regressions.

## Verification

`go build ./...`, `go vet ./...`, `go test ./... -short` all clean. `TestMuxServer_GetProviderSchemaIsClean` passes on this branch and fails on master (confirmed by stashing the framework `Schema()` change). Locally built the provider against a `dev_overrides` `~/.terraformrc`, ran `terraform validate` with a `kubectl_manifest` Namespace resource — succeeds with only the expected dev_overrides warning. `gofmt -l` clean on touched files.

## Release impact

Recommend cutting **v2.3.1** as soon as this lands. v2.3.0 is broken at provider load for every user on TF CLI 1.6+; backporting via patch tag is appropriate.

## Test plan

- [x] Unit test passes (`go test ./internal/mux/`).
- [x] Full short test suite passes.
- [x] Locally drove real `terraform validate` against the muxed binary via dev_overrides.
- [x] `real_terraform_smoke` job goes green in this PR's CI.
- [x] Full `acc_test_smoke` + `acc_test` matrix stays green in this PR's CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive end-to-end smoke test for Terraform provider using real provider binary
  * Added schema consistency validation test to ensure SDK and framework provider schemas remain in sync

* **Bug Fixes**
  * Enhanced validation for Kubernetes provider exec block configuration with explicit error handling for multiple exec blocks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alekc/terraform-provider-kubectl/pull/276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->