### PR TITLE
chore(ci): bump hashicorp/setup-terraform to v4.0.1 for Node 24 support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -91,7 +91,7 @@ jobs:
         with:
           wait: 2m
           node_image: kindest/node:v${{ needs.get_version_matrix.outputs.latest_k8s_version }}
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ needs.get_version_matrix.outputs.latest_terraform_version }}
           terraform_wrapper: false
@@ -200,7 +200,7 @@ jobs:
       # `terraform_wrapper: false` is required so the binary on PATH is the
       # real Terraform, not the wrapping script setup-terraform installs by
       # default.
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ needs.get_version_matrix.outputs.latest_terraform_version }}
           terraform_wrapper: false
@@ -257,7 +257,7 @@ jobs:
           wait: 2m
           node_image: kindest/node:v${{ matrix.k8s_version }}
       # See acc_test_smoke for why TF_ACC_TERRAFORM_PATH is set.
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ matrix.terraform_version }}
           terraform_wrapper: false


### PR DESCRIPTION
## Summary

GitHub will force JavaScript actions to Node.js 24 starting 2026-06-02 and remove Node.js 20 from the runner image on 2026-09-16. The CI matrix was emitting a deprecation warning on every run because `hashicorp/setup-terraform` v3.1.2 still ships on Node 20. Bump all three pins in `.github/workflows/tests.yaml` (`acc_test_smoke`, the `acc_test` matrix, and the new `real_terraform_smoke` job) to v4.0.1.

## Risk

Low. The upstream v4.0.0 release notes call out a single breaking change, "Upgrade to Node.js 24", with no API or input-shape changes. v4.0.1 is a follow-up bug fix that silences a Node 24 DEP0169 warning by bumping a transitive dependency. The action's inputs we use (`terraform_version`, `terraform_wrapper: false`) are unchanged across v3 and v4. Functional behaviour stays identical, only the embedded Node runtime changes.

## Test plan

- [ ] CI completes successfully on this PR with the new pin (acc_test_smoke, full acc_test matrix, real_terraform_smoke).
- [ ] No "Node.js 20 actions are deprecated" warning appears on any job in this PR run.