### PR TITLE
feat(provider): add lazy_load to defer kubeconfig errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,205 @@
+# Contributing to terraform-provider-kubectl
+
+Thanks for your interest in contributing! This document covers building the
+provider from source, testing a custom build against your own Terraform
+configurations, running the test suites, and submitting changes.
+
+## Prerequisites
+
+- [Go](https://go.dev/dl/) at the version pinned in [`go.mod`](./go.mod)
+  (currently 1.26 or newer)
+- `$(go env GOPATH)/bin` on your `$PATH`
+- Terraform 0.14+ (`dev_overrides` was added in 0.14) if you want to point
+  Terraform at a local build
+- A Kubernetes cluster for acceptance tests ([`kind`](https://kind.sigs.k8s.io/),
+  [`k3d`](https://k3d.io/), Docker Desktop, or any reachable cluster)
+
+## Building the provider
+
+```sh
+git clone https://github.com/alekc/terraform-provider-kubectl
+cd terraform-provider-kubectl
+make build
+```
+
+`make build` runs `go install`, which places the binary at
+`$(go env GOPATH)/bin/terraform-provider-kubectl`. The binary name must
+stay `terraform-provider-kubectl` for Terraform to pick it up via
+`dev_overrides`.
+
+## Trying an unreleased version
+
+If a fix you need is already on `master` but no release has been cut yet,
+you can build the provider locally and point Terraform at the binary with a
+[`dev_overrides`](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers)
+block. This is the same mechanism the project's own CI smoke job uses,
+and is the recommended way to test a regression fix before it ships to the
+Terraform Registry.
+
+### Build the version you want
+
+```sh
+git clone https://github.com/alekc/terraform-provider-kubectl
+cd terraform-provider-kubectl
+git checkout master           # or any branch / tag / commit
+make build                    # binary at $(go env GOPATH)/bin/terraform-provider-kubectl
+```
+
+### Tell Terraform about the local binary
+
+Create or edit `~/.terraformrc` (or `%APPDATA%\terraform.rc` on Windows)
+and add a `dev_overrides` block pointing at the directory that holds the
+binary, not the binary itself:
+
+```hcl
+provider_installation {
+  dev_overrides {
+    "alekc/kubectl" = "/path/to/your/gopath/bin"
+  }
+  direct {}
+}
+```
+
+Run `go env GOPATH` to fill in the path if you are unsure. The `direct {}`
+line keeps the default registry lookup for every other provider in your
+config so they still resolve normally.
+
+### Use it
+
+In your Terraform configuration, keep the `required_providers` block
+unchanged (the source still points at `alekc/kubectl`):
+
+```hcl
+terraform {
+  required_providers {
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = ">= 2.0.0"
+    }
+  }
+}
+```
+
+`terraform init` becomes a no-op under `dev_overrides`. From the next
+`terraform plan` or `terraform apply` onward Terraform prints the override
+warning every run:
+
+```text
+│ Warning: Provider development overrides are in effect
+│
+│ The following provider development overrides are set in the CLI
+│ configuration:
+│  - alekc/kubectl in /path/to/your/gopath/bin
+```
+
+That warning is the signal that your custom build is in use. It is
+expected and cannot be suppressed.
+
+### Caveats
+
+- `dev_overrides` skips the registry checksum check and ignores the
+  `version` constraint in `required_providers`. Anything in the override
+  directory wins, even if it is older or newer than the constraint says.
+- Other team members on the same Terraform configuration will keep using
+  the released version unless they also configure a `dev_overrides`
+  block. Do not commit `~/.terraformrc`.
+- Remove the `dev_overrides` block (or comment it out) once a real
+  release containing the fix is out, otherwise Terraform will keep using
+  your stale local binary.
+
+## Running tests
+
+There are two test surfaces:
+
+- **`make test`** runs unit tests for the provider Go packages. No
+  cluster required. Runs with `-race` and coverage.
+- **`make testacc`** runs acceptance tests against a live Kubernetes
+  cluster. Reads `KUBE_CONFIG_PATH` (or `KUBECONFIG`) to find the
+  cluster. The CI workflow uses [`kind`](https://kind.sigs.k8s.io/) via
+  `helm/kind-action`; locally any reachable cluster works (kind, k3d,
+  Docker Desktop, EKS, etc.). Tests are isolated by namespace / random
+  suffix and may be run in parallel. `ACC_TESTARGS="-parallel 4"` is the
+  default.
+
+```sh
+make test       # unit
+make testacc    # acceptance, needs a cluster + KUBE_CONFIG_PATH
+```
+
+To narrow the run, pass `-run` through `ACC_TESTARGS`:
+
+```sh
+ACC_TESTARGS="-parallel 4 -run TestAccKubectlDataSourceManifest" make testacc
+```
+
+The CI workflow (`.github/workflows/tests.yaml`) runs the newest
+Kubernetes x Terraform pair as a single **smoke** job; only if it passes
+does it fan out to the rest of the matrix. This catches obvious-break
+failures fast without burning 20 kind clusters on a syntax error.
+
+> Acceptance tests create real Kubernetes resources. Against a managed
+> cluster (EKS, GKE, AKS) they may incur cost. Point them at a throw-away
+> cluster.
+
+## Project layout
+
+- `kubernetes/` is the SDK v2 half of the provider (legacy
+  `terraform-plugin-sdk/v2`). Holds resources, data sources, and the
+  authoritative provider configuration schema.
+- `internal/framework/` is the plugin-framework half
+  (`terraform-plugin-framework`). Currently hosts the ephemeral
+  `kubectl_manifest` resource and a mirror of the provider configuration
+  schema.
+- `internal/mux/` brings both halves together via `tf6muxserver`.
+- `kubernetes/provider.go` and `internal/framework/provider.go` declare
+  the **same** provider configuration schema. `tf6muxserver` compares
+  them at startup and refuses to start if they differ.
+  `internal/mux/mux_test.go` pins this and will fail in CI when only one
+  side is updated.
+- `docs/` holds the Terraform Registry-rendered documentation. Resource
+  / data-source pages live under `docs/resources/`, `docs/data-sources/`,
+  and `docs/ephemeral-resources/`.
+
+## Submitting changes
+
+1. Open an issue first if the change is non-trivial, so we can agree on
+   the shape before code is written.
+2. Branch off `master`. A descriptive branch name helps
+   (`feat/issue-NNN-short-slug` works well).
+3. Follow [Conventional Commits](https://www.conventionalcommits.org/)
+   for commit subjects, e.g. `feat(provider): add lazy_load to defer
+   kubeconfig errors`. Use the body to explain the why, not the what.
+4. Sign off every commit with `git commit -s` so the
+   `Signed-off-by` trailer is added. We follow
+   [DCO](https://developercertificate.org/) for contributions.
+5. Keep PRs focused. A diagnostic improvement and an unrelated refactor
+   should be two PRs, not one.
+6. Update the muxed schema on **both** sides if you touch provider
+   configuration. The `internal/mux.TestMuxServer_GetProviderSchemaIsClean`
+   test will catch a half-update.
+7. Update relevant docs in the same PR. New provider attribute means a
+   line in `docs/index.md` "Argument Reference"; new behaviour means a
+   note in Troubleshooting; new resource means a page under
+   `docs/resources/`.
+8. Run `make test` locally before opening the PR. CI will run the full
+   matrix; the smoke job's job is to fail fast.
+9. CodeRabbit also reviews PRs automatically. Resolve its comments or
+   reply why they do not apply before requesting human review.
+
+If your change is a fix for an open issue, reference it in the PR
+description (`Fixes: alekc/terraform-provider-kubectl#NNN`) so GitHub
+links and auto-closes on merge.
+
+## Reporting bugs
+
+[Open an issue](https://github.com/alekc/terraform-provider-kubectl/issues/new)
+with:
+
+- Provider version (`terraform providers`)
+- Terraform version (`terraform version`)
+- Kubernetes cluster type and version (`kubectl version`)
+- A minimal config that reproduces the problem
+- The full error output, not just the last line
+
+If the error mentions provider configuration, include the relevant
+`provider "kubectl"` block (with secrets redacted).

--- a/README.md
+++ b/README.md
@@ -135,62 +135,12 @@ See [`docs/ephemeral-resources/kubectl_manifest.md`](./docs/ephemeral-resources/
 
 ---
 
-## Development Guide
+## Contributing
 
-You will need [Go](http://www.golang.org) (the version pinned in [`go.mod`](./go.mod) — currently 1.26 or newer) and a correctly set up [GOPATH](http://golang.org/doc/code.html#GOPATH), with `$GOPATH/bin` on your `$PATH`.
-
-To compile the provider, run `make build`. This puts the provider binary at `$GOPATH/bin/terraform-provider-kubectl`.
-
-### Building the provider
-
-```sh
-git clone https://github.com/alekc/terraform-provider-kubectl
-cd terraform-provider-kubectl
-make build
-```
-
-To point Terraform at your local build, create or edit `~/.terraformrc` and add the dev-override block below. Replace the path with your own `$GOPATH/bin/` (run `go env GOPATH` if you're unsure):
-
-```hcl
-provider_installation {
-  dev_overrides {
-    "alekc/kubectl" = "<your-gopath>/bin/"
-  }
-  direct {}
-}
-```
-
-Run `terraform init` (it's a no-op under dev_overrides) and your local build is now in use. On every plan/apply you'll see Terraform note the override:
-
-```text
-╷
-│ Warning: Provider development overrides are in effect
-│ 
-│ The following provider development overrides are set in the CLI configuration:
-│  - alekc/kubectl in <your-gopath>/bin
-```
-
-### Testing
-
-There are two test surfaces:
-
-- **`make test`** — unit tests for the provider Go packages. No cluster required. Runs with `-race` and coverage.
-- **`make testacc`** — acceptance tests against a live Kubernetes cluster. Reads `KUBE_CONFIG_PATH` (or `KUBECONFIG`) to find the cluster. The CI workflow uses [`kind`](https://kind.sigs.k8s.io/) via `helm/kind-action`; locally any reachable cluster works (kind, k3d, Docker Desktop, EKS, …). Tests are isolated by namespace / random suffix and may be run in parallel — `ACC_TESTARGS="-parallel 4"` is the default.
-
-```sh
-make test       # unit
-make testacc    # acceptance — needs a cluster + KUBE_CONFIG_PATH
-```
-
-To narrow the run, pass `-run` through `ACC_TESTARGS`:
-
-```sh
-ACC_TESTARGS="-parallel 4 -run TestAccKubectlDataSourceManifest" make testacc
-```
-
-The CI workflow (`.github/workflows/tests.yaml`) runs the newest Kubernetes × Terraform pair as a single **smoke** job; only if it passes does it fan out to the rest of the matrix. This catches "obvious break" failures fast without burning 20 kind clusters on a syntax error.
-
-*Note:* acceptance tests create real Kubernetes resources. Against a managed cluster (EKS, GKE, AKS) they may incur cost.
+Building from source, pointing Terraform at a local build with
+`dev_overrides`, running the test suites, and the PR workflow are all
+documented in [CONTRIBUTING.md](./CONTRIBUTING.md). Start there if you
+want to try an unreleased fix from `master` or submit a change.
 
 ## Changing providers for existing resources
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,6 +179,112 @@ Workarounds, in order of preference:
    }
    ```
 
+## Trying an unreleased version
+
+If a fix you need is already on `master` but no release has been cut yet,
+you can build the provider locally and point Terraform at the binary with a
+[`dev_overrides`](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers)
+block. This is the same mechanism the project's own CI smoke job uses, and
+is the recommended way to test a regression fix before it ships to the
+Terraform Registry.
+
+### Prerequisites
+
+- [Go](https://go.dev/dl/) at the version pinned in
+  [`go.mod`](https://github.com/alekc/terraform-provider-kubectl/blob/master/go.mod)
+  (currently 1.26 or newer)
+- `$(go env GOPATH)/bin` on your `$PATH`
+- Terraform 0.14+ (`dev_overrides` was added in 0.14)
+
+### Build
+
+```sh
+git clone https://github.com/alekc/terraform-provider-kubectl
+cd terraform-provider-kubectl
+git checkout master           # or any branch / tag / commit you want to test
+make build                    # places the binary at $(go env GOPATH)/bin/terraform-provider-kubectl
+```
+
+Alternatively, `go install` from the repo root produces the same binary.
+The binary name must stay `terraform-provider-kubectl` for Terraform to
+pick it up.
+
+### Tell Terraform about the local binary
+
+Create or edit `~/.terraformrc` (or `%APPDATA%\terraform.rc` on Windows)
+and add a `dev_overrides` block pointing at the directory that holds the
+binary, not the binary itself:
+
+```hcl
+provider_installation {
+  dev_overrides {
+    "alekc/kubectl" = "/path/to/your/gopath/bin"
+  }
+  direct {}
+}
+```
+
+Run `go env GOPATH` to fill in the path if you are not sure. The `direct {}`
+line keeps the default registry lookup for every other provider in your
+config so they still resolve normally.
+
+### Use it
+
+In your Terraform configuration, keep the `required_providers` block
+unchanged (the source still points at `alekc/kubectl`):
+
+```hcl
+terraform {
+  required_providers {
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = ">= 2.0.0"
+    }
+  }
+}
+```
+
+`terraform init` becomes a no-op under `dev_overrides`. From the next
+`terraform plan` or `terraform apply` onward you will see Terraform print
+the override warning every run:
+
+```text
+│ Warning: Provider development overrides are in effect
+│
+│ The following provider development overrides are set in the CLI
+│ configuration:
+│  - alekc/kubectl in /path/to/your/gopath/bin
+```
+
+That warning is the signal that your custom build is in use. It is
+expected and cannot be suppressed.
+
+### Caveats
+
+- `dev_overrides` skips the registry checksum check and ignores the
+  `version` constraint in `required_providers`. Anything in the override
+  directory wins, even if it is older or newer than the constraint says.
+- Other team members on the same Terraform configuration will keep using
+  the released version unless they also configure a `dev_overrides`
+  block. Do not commit `~/.terraformrc`.
+- Remove the `dev_overrides` block (or comment it out) once a real
+  release containing the fix is out, otherwise Terraform will keep using
+  your stale local binary.
+
+### Run the tests
+
+If you want to verify your build against the provider's own suite before
+trusting it:
+
+```sh
+make test       # unit tests, no cluster required
+make testacc    # acceptance tests against a live cluster (KUBECONFIG / KUBE_CONFIG_PATH)
+```
+
+Acceptance tests create real Kubernetes objects. Point them at a throw-away
+cluster (`kind`, `k3d`, Docker Desktop, …) rather than anything you care
+about.
+
 ## Example
 
 Loading a raw yaml manifest into kubernetes is simple, just set the `yaml_body` argument:

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,7 @@ The following arguments are supported:
 
 * `apply_retry_count` - (Optional) Defines the number of attempts any create/update action will take. Default `1`.
 * `load_config_file` - (Optional) Flag to enable/disable loading of the local kubeconf file. Default `true`. Can be sourced from `KUBE_LOAD_CONFIG_FILE`.
+* `lazy_load` - (Optional) When `true`, kubeconfig resolution errors at provider-configure time are swallowed and the actual client is built lazily on first use. Lets `terraform plan` succeed when provider arguments (`host`, `token`, certs) are sourced from outputs of resources that have not been applied yet. Off by default; can be sourced from `KUBE_LAZY_LOAD`. See [Troubleshooting](#troubleshooting) for trade-offs.
 * `host` - (Optional) The hostname (in form of URI) of the Kubernetes API. Can be sourced from `KUBE_HOST`.
 * `username` - (Optional) The username to use for HTTP basic authentication when accessing the Kubernetes API. Can be sourced from `KUBE_USER`.
 * `password` - (Optional) The password to use for HTTP basic authentication when accessing the Kubernetes API. Can be sourced from `KUBE_PASSWORD`.
@@ -160,6 +161,23 @@ Workarounds, in order of preference:
    `var.cluster_ca_certificate` etc. with hardcoded strings briefly to
    confirm the rest of the config is correct; if that succeeds the failure
    is the deferred-evaluation pattern above.
+4. **Set `lazy_load = true`** to opt back into the pre-`v2.3.0` behaviour:
+   `clientcmd` errors at provider-configure time are swallowed and the
+   actual client is built lazily on first use. This trades the precise
+   diagnostic above for a less specific late error if the configuration
+   is genuinely broken, so prefer one of the other workarounds when they
+   fit. Use this when the same-root cluster-plus-manifests pattern is
+   the only shape that fits the workflow.
+
+   ```hcl
+   provider "kubectl" {
+     host                   = module.eks.cluster_endpoint
+     cluster_ca_certificate = base64decode(module.eks.cluster_ca_certificate)
+     token                  = data.aws_eks_cluster_auth.this.token
+     load_config_file       = false
+     lazy_load              = true
+   }
+   ```
 
 ## Example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,111 +179,11 @@ Workarounds, in order of preference:
    }
    ```
 
-## Trying an unreleased version
+## Building from source
 
-If a fix you need is already on `master` but no release has been cut yet,
-you can build the provider locally and point Terraform at the binary with a
-[`dev_overrides`](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers)
-block. This is the same mechanism the project's own CI smoke job uses, and
-is the recommended way to test a regression fix before it ships to the
-Terraform Registry.
-
-### Prerequisites
-
-- [Go](https://go.dev/dl/) at the version pinned in
-  [`go.mod`](https://github.com/alekc/terraform-provider-kubectl/blob/master/go.mod)
-  (currently 1.26 or newer)
-- `$(go env GOPATH)/bin` on your `$PATH`
-- Terraform 0.14+ (`dev_overrides` was added in 0.14)
-
-### Build
-
-```sh
-git clone https://github.com/alekc/terraform-provider-kubectl
-cd terraform-provider-kubectl
-git checkout master           # or any branch / tag / commit you want to test
-make build                    # places the binary at $(go env GOPATH)/bin/terraform-provider-kubectl
-```
-
-Alternatively, `go install` from the repo root produces the same binary.
-The binary name must stay `terraform-provider-kubectl` for Terraform to
-pick it up.
-
-### Tell Terraform about the local binary
-
-Create or edit `~/.terraformrc` (or `%APPDATA%\terraform.rc` on Windows)
-and add a `dev_overrides` block pointing at the directory that holds the
-binary, not the binary itself:
-
-```hcl
-provider_installation {
-  dev_overrides {
-    "alekc/kubectl" = "/path/to/your/gopath/bin"
-  }
-  direct {}
-}
-```
-
-Run `go env GOPATH` to fill in the path if you are not sure. The `direct {}`
-line keeps the default registry lookup for every other provider in your
-config so they still resolve normally.
-
-### Use it
-
-In your Terraform configuration, keep the `required_providers` block
-unchanged (the source still points at `alekc/kubectl`):
-
-```hcl
-terraform {
-  required_providers {
-    kubectl = {
-      source  = "alekc/kubectl"
-      version = ">= 2.0.0"
-    }
-  }
-}
-```
-
-`terraform init` becomes a no-op under `dev_overrides`. From the next
-`terraform plan` or `terraform apply` onward you will see Terraform print
-the override warning every run:
-
-```text
-│ Warning: Provider development overrides are in effect
-│
-│ The following provider development overrides are set in the CLI
-│ configuration:
-│  - alekc/kubectl in /path/to/your/gopath/bin
-```
-
-That warning is the signal that your custom build is in use. It is
-expected and cannot be suppressed.
-
-### Caveats
-
-- `dev_overrides` skips the registry checksum check and ignores the
-  `version` constraint in `required_providers`. Anything in the override
-  directory wins, even if it is older or newer than the constraint says.
-- Other team members on the same Terraform configuration will keep using
-  the released version unless they also configure a `dev_overrides`
-  block. Do not commit `~/.terraformrc`.
-- Remove the `dev_overrides` block (or comment it out) once a real
-  release containing the fix is out, otherwise Terraform will keep using
-  your stale local binary.
-
-### Run the tests
-
-If you want to verify your build against the provider's own suite before
-trusting it:
-
-```sh
-make test       # unit tests, no cluster required
-make testacc    # acceptance tests against a live cluster (KUBECONFIG / KUBE_CONFIG_PATH)
-```
-
-Acceptance tests create real Kubernetes objects. Point them at a throw-away
-cluster (`kind`, `k3d`, Docker Desktop, …) rather than anything you care
-about.
+To try a fix on `master` before a release is cut, see
+[CONTRIBUTING.md](https://github.com/alekc/terraform-provider-kubectl/blob/master/CONTRIBUTING.md#trying-an-unreleased-version)
+on GitHub for the `dev_overrides` walkthrough.
 
 ## Example
 

--- a/internal/framework/provider.go
+++ b/internal/framework/provider.go
@@ -121,6 +121,10 @@ func (p *kubectlFrameworkProvider) Schema(_ context.Context, _ provider.SchemaRe
 				Optional:    true,
 				Description: "Load local kubeconfig.",
 			},
+			"lazy_load": schema.BoolAttribute{
+				Optional:    true,
+				Description: "When true, kubeconfig resolution errors at provider-configure time are swallowed and the actual client is built lazily on first use. Lets `terraform plan` succeed when provider arguments (host, token, certs) are sourced from outputs of resources that have not been applied yet. Off by default; see Troubleshooting in the provider docs for trade-offs.",
+			},
 			"tls_server_name": schema.StringAttribute{
 				Optional:    true,
 				Description: "Server name passed to the server for SNI and is used in the client to check server certificates against.",

--- a/kubernetes/lazy_load_test.go
+++ b/kubernetes/lazy_load_test.go
@@ -1,0 +1,108 @@
+package kubernetes
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TestLazyLoadSwallowsClientcmdError pins the fix for issue #283.
+//
+// With lazy_load disabled (the default), initializeConfiguration must
+// surface the clientcmd error so users see the real reason their provider
+// config is unusable. With lazy_load enabled, the same call must return
+// (nil, nil) so providerConfigure can substitute &restclient.Config{} and
+// let `terraform plan` succeed while provider arguments are still
+// unresolved.
+//
+// The fixture isolates clientcmd from the developer's real environment by
+// pointing HOME at a fresh empty directory and clearing every KUBE_* env
+// var; without that, a kubeconfig on the dev machine could mask the
+// "no configuration provided" path that lazy_load is meant to swallow.
+func TestLazyLoadSwallowsClientcmdError(t *testing.T) {
+	emptyHome := t.TempDir()
+	t.Setenv("HOME", emptyHome)
+	t.Setenv("USERPROFILE", emptyHome)
+	t.Setenv("KUBECONFIG", filepath.Join(emptyHome, "missing"))
+	t.Setenv("KUBE_CONFIG", "")
+	t.Setenv("KUBE_CONFIG_PATH", "")
+	t.Setenv("KUBE_CONFIG_PATHS", "")
+	t.Setenv("KUBE_HOST", "")
+	t.Setenv("KUBE_USER", "")
+	t.Setenv("KUBE_PASSWORD", "")
+	t.Setenv("KUBE_TOKEN", "")
+	t.Setenv("KUBE_CLIENT_CERT_DATA", "")
+	t.Setenv("KUBE_CLIENT_KEY_DATA", "")
+	t.Setenv("KUBE_CLUSTER_CA_CERT_DATA", "")
+	t.Setenv("KUBERNETES_MASTER", "")
+
+	provider := Provider()
+
+	t.Run("default surfaces error", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, provider.Schema, map[string]interface{}{
+			"load_config_file": false,
+			"lazy_load":        false,
+		})
+		cfg, err := initializeConfiguration(d)
+		if err == nil {
+			t.Fatalf("expected clientcmd error, got cfg=%v err=nil", cfg)
+		}
+		if !strings.Contains(err.Error(), "invalid provider configuration") {
+			t.Errorf("expected wrapped 'invalid provider configuration' diagnostic, got: %s", err)
+		}
+	})
+
+	t.Run("lazy_load swallows error", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, provider.Schema, map[string]interface{}{
+			"load_config_file": false,
+			"lazy_load":        true,
+		})
+		cfg, err := initializeConfiguration(d)
+		if err != nil {
+			t.Fatalf("expected lazy_load to swallow the clientcmd error, got: %s", err)
+		}
+		if cfg != nil {
+			t.Errorf("expected nil cfg so providerConfigure falls back to empty restclient.Config, got: %+v", cfg)
+		}
+	})
+}
+
+// TestLazyLoadEnvDefault confirms the KUBE_LAZY_LOAD env var feeds the
+// schema default and is picked up by initializeConfiguration without an
+// explicit value in the provider block.
+func TestLazyLoadEnvDefault(t *testing.T) {
+	emptyHome := t.TempDir()
+	t.Setenv("HOME", emptyHome)
+	t.Setenv("USERPROFILE", emptyHome)
+	t.Setenv("KUBECONFIG", filepath.Join(emptyHome, "missing"))
+	t.Setenv("KUBE_LAZY_LOAD", "true")
+	t.Setenv("KUBE_CONFIG", "")
+	t.Setenv("KUBE_CONFIG_PATH", "")
+	t.Setenv("KUBE_CONFIG_PATHS", "")
+	t.Setenv("KUBE_HOST", "")
+	t.Setenv("KUBE_TOKEN", "")
+	t.Setenv("KUBE_CLIENT_CERT_DATA", "")
+	t.Setenv("KUBE_CLIENT_KEY_DATA", "")
+	t.Setenv("KUBE_CLUSTER_CA_CERT_DATA", "")
+	t.Setenv("KUBERNETES_MASTER", "")
+
+	provider := Provider()
+	d := schema.TestResourceDataRaw(t, provider.Schema, map[string]interface{}{
+		"load_config_file": false,
+	})
+
+	// Sanity-check the schema picked up the env default.
+	if got := d.Get("lazy_load").(bool); !got {
+		t.Fatalf("KUBE_LAZY_LOAD=true should default lazy_load to true, got %v", got)
+	}
+
+	cfg, err := initializeConfiguration(d)
+	if err != nil {
+		t.Fatalf("expected env-default lazy_load to swallow the clientcmd error, got: %s", err)
+	}
+	if cfg != nil {
+		t.Errorf("expected nil cfg, got: %+v", cfg)
+	}
+}

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -132,6 +132,12 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("KUBE_LOAD_CONFIG_FILE", true),
 				Description: "Load local kubeconfig.",
 			},
+			"lazy_load": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("KUBE_LAZY_LOAD", false),
+				Description: "When true, kubeconfig resolution errors at provider-configure time are swallowed and the actual client is built lazily on first use. Lets `terraform plan` succeed when provider arguments (host, token, certs) are sourced from outputs of resources that have not been applied yet. Off by default; see Troubleshooting in the provider docs for trade-offs.",
+			},
 			"tls_server_name": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -413,13 +419,23 @@ func initializeConfiguration(d *schema.ResourceData) (*restclient.Config, error)
 	cc := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loader, overrides)
 	cfg, err := cc.ClientConfig()
 	if err != nil {
-		// Surface the underlying clientcmd error to the caller. Swallowing it
-		// here (returning nil, nil) lets the rest of providerConfigure run
-		// against an empty restclient.Config, and the failure resurfaces much
-		// later as a misleading "cannot create discovery client: no client
-		// config" from ToRESTMapper. Returning the real reason — typically a
-		// missing host, an unresolved variable, or a malformed cert — points
-		// users straight at the bad field. See issue #203.
+		// Default: surface the underlying clientcmd error. Swallowing it
+		// (returning nil, nil) lets the rest of providerConfigure run against
+		// an empty restclient.Config and the failure resurfaces later as a
+		// misleading "cannot create discovery client: no client config" from
+		// ToRESTMapper. Returning the real reason (missing host, unresolved
+		// variable, malformed cert) points users at the bad field (#203).
+		//
+		// Opt-out: when lazy_load = true, the user is explicitly accepting
+		// that provider arguments resolve at apply time (e.g. host sourced
+		// from an EKS module output in the same root). Swallow the error so
+		// `terraform plan` succeeds; the empty REST config falls through to
+		// providerConfigure, which substitutes &restclient.Config{} and lets
+		// resource-time calls surface the real failure naturally (#283).
+		if v, ok := d.Get("lazy_load").(bool); ok && v {
+			log.Printf("[WARN] lazy_load: swallowing clientcmd error: %s", err)
+			return nil, nil
+		}
 		return nil, fmt.Errorf("invalid provider configuration: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- Add an opt-in `lazy_load` provider attribute (default `false`, env `KUBE_LAZY_LOAD`). When `true`, `initializeConfiguration` swallows the `clientcmd.ClientConfig()` error and returns `nil`, letting `providerConfigure` substitute `&restclient.Config{}` so `terraform plan` can complete while provider arguments are still unresolved.
- Mirror the attribute on the plugin-framework half of the muxed provider so `tf6muxserver` schema parity (pinned by `internal/mux.TestMuxServer_GetProviderSchemaIsClean`, #275) keeps holding.
- Document the trade-off and a sample provider block in the Troubleshooting section of `docs/index.md`, alongside the three existing workarounds added by #264.
- Add a "Trying an unreleased version" section to `docs/index.md` so users hitting #283 (or any future regression) can build from `master` with `dev_overrides` and verify the fix before a release is cut. The Registry page previously had no mention of this workflow.

## Context

#283 reported a regression in v2.3.0: configs where `host`/`cluster_ca_certificate`/`token` are sourced from another module's outputs (the same-root EKS-plus-manifests pattern) now fail during plan with `invalid provider configuration: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable`. They used to plan cleanly because PR #264 had not yet stopped swallowing the underlying `clientcmd` error.

PR #264 is the right call for the common case: mis-typed `host`, malformed cert bundle, wrong `config_path`, or a single unresolved variable. The diagnostic now points straight at the bad field instead of resurfacing as a misleading "no client config" three layers away (the original #203 symptom). Reverting that improvement unconditionally would re-open #203 for everyone.

The reporter (`rajatjindal`) explicitly asked for an opt-in flag and offered to send the PR. This change implements that flag on the owner side so the regression has a one-line workaround in the same minor.

## Behaviour change

Default (`lazy_load = false`) is unchanged. Same diagnostic from #264, same fail-fast contract:

```
Error: invalid provider configuration: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
```

Opt-in (`lazy_load = true` or `KUBE_LAZY_LOAD=true`):

```hcl
provider "kubectl" {
  host                   = module.eks.cluster_endpoint
  cluster_ca_certificate = base64decode(module.eks.cluster_ca_certificate)
  token                  = data.aws_eks_cluster_auth.this.token
  load_config_file       = false
  lazy_load              = true
}
```

`initializeConfiguration` returns `nil` instead of an error, the empty REST config falls through to `providerConfigure`, the kubernetes/aggregator clients build against `&restclient.Config{}`, and resource-time calls surface the real failure naturally. This is exactly the pre-2.3.0 shape, scoped to users who explicitly accept that risk.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -short` (unit pass)
- [x] New `kubernetes/lazy_load_test.go`: pins both directions of the new flag and confirms `KUBE_LAZY_LOAD` env-default plumbing
- [x] Existing `internal/mux.TestMuxServer_GetProviderSchemaIsClean` still passes (schema parity preserved after mirroring on the framework half)
- [ ] Manual smoke: a same-root EKS-plus-manifests config with `lazy_load = true` plans and applies, with `lazy_load = false` reproduces the #283 error

Fixes #283.
