### PR TITLE
ci(workflows): skip CI on documentation-only PRs

### DIFF
--- a/.github/workflows/tests-docs-skip.yaml
+++ b/.github/workflows/tests-docs-skip.yaml
@@ -1,0 +1,56 @@
+# CI ghost workflow for documentation-only pull requests.
+#
+# Companion to .github/workflows/tests.yaml. That workflow uses
+# `paths-ignore` so its real jobs (get_version_matrix, unit_test,
+# real_terraform_smoke, acc_test_smoke, acc_test) do not run on
+# documentation-only changes. If branch protection on master is ever
+# configured to require those job names as status checks, a skipped
+# workflow leaves the required checks permanently pending and the PR
+# cannot merge.
+#
+# This workflow fires on exactly the inverse path set and emits success
+# statuses with the same job names, so the contract is satisfied. Each
+# job is a no-op that prints why it was skipped.
+#
+# Keep in sync with tests.yaml:
+#   * `paths:` here must equal `paths-ignore:` over there.
+#   * Job names here must equal job names over there.
+#   * `acc_test` is a single job rather than the full matrix; branch
+#     protection by job name matches it as one context. If matrix cells
+#     are ever pinned as required checks individually, mirror them here.
+name: "tests"
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '**.md'
+      - 'docs/**'
+
+jobs:
+  get_version_matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change; skipping real version-matrix lookup."
+
+  unit_test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change; skipping unit tests."
+
+  real_terraform_smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change; skipping real-terraform smoke."
+
+  acc_test_smoke:
+    name: "acc_test smoke"
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change; skipping acceptance smoke."
+
+  acc_test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change; skipping acceptance matrix."

--- a/.github/workflows/tests-docs-skip.yaml
+++ b/.github/workflows/tests-docs-skip.yaml
@@ -28,6 +28,12 @@ on:
       - '**.md'
       - 'docs/**'
 
+# The ghost jobs do nothing except echo a single line. They do not check
+# out the repo, contact any API, or read any secret, so the workflow
+# needs no GITHUB_TOKEN scope at all. An empty permissions block denies
+# every category and is the strictest setting available.
+permissions: {}
+
 jobs:
   get_version_matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,6 +3,15 @@ on:
   pull_request:
     branches:
       - master
+    # Skip the real kind / Terraform matrix on documentation-only PRs.
+    # A companion ghost workflow at .github/workflows/tests-docs-skip.yaml
+    # fires on the inverse path set and reports success on the same job
+    # names, so branch protection (if ever configured to require these
+    # checks) is still satisfied without burning runners on a Markdown
+    # edit. Keep this list and the ghost's `paths:` list in lockstep.
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 concurrency:
   group: pr-${{ github.ref }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,6 +17,15 @@ concurrency:
   group: pr-${{ github.ref }}
   cancel-in-progress: true
 
+# Lock GITHUB_TOKEN to the minimum scope every job in this workflow needs.
+# All five jobs just check out the repo and run tests; none post comments,
+# push commits, write packages, or otherwise mutate GitHub state. Setting
+# `contents: read` here implicitly denies every other permission category
+# (per GitHub's "set one, deny the rest" semantics), so a compromised
+# step or action cannot escalate beyond reading the source tree.
+permissions:
+  contents: read
+
 env:
   KUBECONFIG: ${{ github.workspace }}/.kube/config
 


### PR DESCRIPTION
## Summary

Stop running the real kind + Terraform matrix on documentation-only PRs. Add `paths-ignore` to `.github/workflows/tests.yaml` covering `**.md` and `docs/**`, and pair it with a new ghost workflow at `.github/workflows/tests-docs-skip.yaml` that fires on exactly the inverse path set and reports success on the same job names.

## Why ghost and not just `paths-ignore`?

Branch protection on `master` currently requires no status checks, so a bare `paths-ignore` would already work today. The ghost is precautionary: the moment any of `get_version_matrix`, `unit_test`, `real_terraform_smoke`, `acc_test smoke`, or `acc_test` is added to required-status-checks, a workflow that is skipped (rather than running its jobs) leaves those checks permanently pending and blocks the PR. The ghost emits the matching success statuses on docs-only changes, so the protection contract stays satisfied either way.

The alternative would be per-commit `[skip ci]` discipline. That is easy to forget, has to be added every time, and breaks the moment branch protection is tightened. The workflow-level filter is set-once, opt-out-by-default-on-docs.

## What docs-only means here

```yaml
paths-ignore:  # tests.yaml
  - '**.md'
  - 'docs/**'
```

Anything else (Go sources, `Makefile`, `go.mod`, `.github/workflows/**`, `.github/dependabot.yaml`, ...) keeps running the full matrix. The lists in `tests.yaml` and `tests-docs-skip.yaml` must move in lockstep; both files cross-reference each other in header comments to make that contract obvious.

## acc_test matrix caveat

The ghost `acc_test` job is a single no-op, not the full Terraform x Kubernetes fan-out. Branch protection by job name matches it as one context. If individual matrix cells are ever pinned as required checks, mirror them in the ghost.

## Test plan

- [x] YAML parses (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [x] This PR is itself a `.github/workflows/**` change, so the docs-skip does NOT apply to it; the full matrix runs and validates the new tests.yaml
- [ ] After merge, the next PR that touches only `**.md` or `docs/**` should fire `tests-docs-skip.yaml` instead of `tests.yaml` and complete in seconds
- [ ] After merge, a PR that touches Go sources should still fire the full matrix as today

## Follow-ups (out of scope)

- If the matrix `acc_test` cells become required checks, add a matrix-mirror in the ghost (or convert `acc_test` to a gate-job pattern that aggregates the matrix into one success status).
- Consider extending `paths-ignore` to `CHANGELOG.md`, `LICENSE`, `.github/ISSUE_TEMPLATE/**`, `.github/PULL_REQUEST_TEMPLATE.md` if you want broader text-only coverage.
