### PR TITLE
docs(readme): promote ephemeral resource and bump version constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This provider offers the most effective method for handling Kubernetes resources
 
 At the heart of this provider lies the `kubectl_manifest` resource, enabling the processing and application of free-form YAML directly to Kubernetes. This YAML object is monitored across its full lifecycle — creation, updates, drift detection and deletion.
 
+For reads, the provider exposes both a `data "kubectl_manifest"` source for ordinary lookups and an `ephemeral "kubectl_manifest"` resource (Terraform 1.10+) that fetches Secret payloads, freshly-minted tokens, and any other sensitive data without ever writing the value to `terraform.tfstate`.
+
 The `terraform-provider-kubectl` has gained widespread adoption in numerous large Kubernetes installations, serving as the primary tool for orchestrating the complete lifecycle of Kubernetes resources.
 
 ## What's in this provider
@@ -19,7 +21,7 @@ The `terraform-provider-kubectl` has gained widespread adoption in numerous larg
 | Data source        | [`kubectl_file_documents`](./docs/data-sources/kubectl_file_documents.md)            | Split a multi-document YAML string into individual documents.                                        |
 | Data source        | [`kubectl_filename_list`](./docs/data-sources/kubectl_filename_list.md)              | Glob a directory for YAML files.                                                                     |
 | Data source        | [`kubectl_path_documents`](./docs/data-sources/kubectl_path_documents.md)            | Glob a directory and split every matched file into individual documents.                             |
-| Ephemeral resource | [`kubectl_manifest`](./docs/ephemeral-resources/kubectl_manifest.md)                 | Same shape as the data source, but the fetched value is **never written to state**. Terraform 1.10+. |
+| Ephemeral resource | [`kubectl_manifest`](./docs/ephemeral-resources/kubectl_manifest.md)                 | Read any cluster object without ever writing the value to `terraform.tfstate` or the plan file. Required for Secret payloads, freshly-minted tokens, private keys, and anything else you must keep out of state. Re-fetched on every plan / apply. Terraform 1.10+. |
 
 ## Supported Kubernetes and Terraform versions
 
@@ -42,16 +44,20 @@ The provider can be installed and managed automatically by Terraform. Sample `ve
 
 ```hcl
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
 
   required_providers {
     kubectl = {
       source  = "alekc/kubectl"
-      version = "~> 2.0"
+      version = "~> 2.3"
     }
   }
 }
 ```
+
+The provider itself works back to Terraform 0.13. The example above pins `>= 1.0` because most users will be on a supported Terraform release; if you need to run older Terraform, you can drop the constraint to `>= 0.13`.
+
+If your configuration uses the `ephemeral "kubectl_manifest"` block (covered below), the floor moves up to **Terraform 1.10**, because ephemeral resources are a 1.10+ language feature regardless of the provider version. Bump `required_version` to `">= 1.10"` in that case.
 
 ### Install manually
 
@@ -98,9 +104,39 @@ YAML
 
 See the [User Guide](https://registry.terraform.io/providers/alekc/kubectl/latest) for details on installation and all the provided data and resource types.
 
+### Reading sensitive data without persisting it
+
+For data that must never reach `terraform.tfstate` (Secret payloads, freshly-minted tokens, private keys), use the `ephemeral "kubectl_manifest"` resource. It has the same lookup shape as the data source, but the value is re-fetched on every plan / apply and never persisted. Requires Terraform 1.10+.
+
+Ephemeral values cannot flow through `output` blocks. They are consumed during apply through a resource's write-only attribute (Terraform 1.11+), a provisioner, or a `check` block:
+
+```hcl
+ephemeral "kubectl_manifest" "db_creds" {
+  api_version = "v1"
+  kind        = "Secret"
+  name        = "postgres-credentials"
+  namespace   = "data"
+
+  fields = {
+    password = "data.password"
+  }
+}
+
+# Example consumer: stage the password into a sibling tool's config
+# during apply, never to state. `content_wo` is a write-only attribute
+# (Terraform 1.11+); the value is forgotten after the file is written.
+resource "local_file" "db_password" {
+  filename            = "${path.module}/.db-password"
+  content_wo          = ephemeral.kubectl_manifest.db_creds.results["password"]
+  content_wo_revision = 1
+}
+```
+
+See [`docs/ephemeral-resources/kubectl_manifest.md`](./docs/ephemeral-resources/kubectl_manifest.md) for the full reference, additional consumer patterns (including `check` blocks for cluster invariants), and behaviour notes.
+
 ### Reading existing objects
 
-A `data "kubectl_manifest"` block reads any cluster object by `api_version` + `kind` + `name` (+ `namespace`) and extracts user-named fields via gojsonq dot-paths. The fetched object is also exposed as raw `yaml` and `json`.
+A `data "kubectl_manifest"` block reads any cluster object by `api_version` + `kind` + `name` (+ `namespace`) and extracts user-named fields via gojsonq dot-paths. The fetched object is also exposed as raw `yaml` and `json`. Use this when the value is non-sensitive and you want it cached in state; reach for the ephemeral resource above when it is not.
 
 ```hcl
 data "kubectl_manifest" "ns" {
@@ -114,24 +150,6 @@ data "kubectl_manifest" "ns" {
 ```
 
 See [`docs/data-sources/kubectl_manifest.md`](./docs/data-sources/kubectl_manifest.md) for the full reference.
-
-### Reading sensitive data without persisting it
-
-For data that must never reach `terraform.tfstate` (Secret payloads, freshly-minted tokens, private keys), use the `ephemeral "kubectl_manifest"` resource — same shape, but the value is re-fetched on every plan / apply and never persisted. Requires Terraform 1.10+.
-
-```hcl
-ephemeral "kubectl_manifest" "db_creds" {
-  api_version = "v1"
-  kind        = "Secret"
-  name        = "postgres-credentials"
-  namespace   = "data"
-  fields = {
-    password = "data.password"
-  }
-}
-```
-
-See [`docs/ephemeral-resources/kubectl_manifest.md`](./docs/ephemeral-resources/kubectl_manifest.md) for the full reference and consumer patterns.
 
 ---
 


### PR DESCRIPTION
## Summary

Promote the ephemeral `kubectl_manifest` resource on the README's first screen and fix two installation-snippet items that bite anyone who copies the snippet and then uses the ephemeral example a few lines below.

## What changed

1. **Intro gains a third paragraph** that names both the data source and the ephemeral resource. The previous intro framed the provider as a write-only tool with drift detection. PR #257 added the ephemeral resource and PR #284 just shipped `lazy_load`, so the read-without-state path is now a load-bearing feature, not a footnote. Registry visitors see it before scrolling.

2. **"What's in this provider" table, ephemeral row.** Strengthened from "never written to state" to spell out the `terraform.tfstate` / plan-file guarantee, the typical use cases (Secret payloads, freshly-minted tokens, private keys), and the re-fetch-every-run behaviour.

3. **Installation snippet bumped**: `required_version` from `">= 0.13"` to `">= 1.0"`, provider pin from `"~> 2.0"` to `"~> 2.3"`. Added a note clarifying that the provider itself still works on 0.13+, and that ephemeral blocks push the floor to Terraform 1.10. Stops users from copying the snippet and then hitting a parse error the moment they add the ephemeral block.

4. **Quick Start reordered**: "Reading sensitive data without persisting it" now comes before "Reading existing objects". Ephemeral is the load-bearing read path for secret material; the data source is the cheaper option when state persistence is fine. Order the examples in that priority.

5. **Connected ephemeral example** replaces the bare snippet. Mirrors the canonical pattern from `docs/ephemeral-resources/kubectl_manifest.md`: ephemeral Secret read feeding `local_file` via the write-only `content_wo` attribute (Terraform 1.11+). Demonstrates the only legal way to consume an ephemeral value at apply time.

## Test plan

- [x] Markdown renders (manual preview)
- [x] Code blocks: ephemeral block matches the schema in `docs/ephemeral-resources/kubectl_manifest.md`; `local_file` example uses the correct `content_wo` + `content_wo_revision` shape per the Terraform 1.11 write-only attribute spec
- [x] Cross-links resolve (`./docs/data-sources/kubectl_manifest.md`, `./docs/ephemeral-resources/kubectl_manifest.md`, `./CONTRIBUTING.md`)
- [x] No code/test changes; only `README.md` is touched

## Follow-ups (deferred)

- A short "Why this provider vs hashicorp/kubernetes" / Highlights block (was discussed; opted out to avoid a phrasing flame war with upstream).
- The Couchbase CRD in Quick Start is still the original example; not refreshed in this PR but worth a separate think later.
