### PR TITLE
ci(workflows): add OpenTofu to the testing matrix

### DIFF
--- a/.github/workflows/tests-docs-skip.yaml
+++ b/.github/workflows/tests-docs-skip.yaml
@@ -50,13 +50,29 @@ jobs:
     steps:
       - run: echo "Docs-only change; skipping real-terraform smoke."
 
-  acc_test_smoke:
-    name: "acc_test smoke"
+  real_opentofu_smoke:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Docs-only change; skipping acceptance smoke."
+      - run: echo "Docs-only change; skipping real-opentofu smoke."
 
-  acc_test:
+  acc_test_terraform_smoke:
+    name: "acc_test smoke (terraform)"
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Docs-only change; skipping acceptance matrix."
+      - run: echo "Docs-only change; skipping terraform acceptance smoke."
+
+  acc_test_opentofu_smoke:
+    name: "acc_test smoke (opentofu)"
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change; skipping opentofu acceptance smoke."
+
+  acc_test_terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change; skipping terraform acceptance matrix."
+
+  acc_test_opentofu:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change; skipping opentofu acceptance matrix."

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -399,6 +399,18 @@ jobs:
           KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
           TF_ACC_TERRAFORM_PATH: ${{ steps.tfpath.outputs.path }}
           TF_ACC_TERRAFORM_VERSION: ${{ needs.get_version_matrix.outputs.latest_opentofu_version }}
+          # terraform-plugin-testing auto-injects a required_providers
+          # block whose `source` is built from these env vars. The
+          # defaults (registry.terraform.io / "-" or "hashicorp") produce
+          # a legacy "-" namespace address that OpenTofu's parser rejects
+          # with "The legacy provider namespace '-' can be used only with
+          # hostname registry.opentofu.org". Setting both fields to the
+          # real values makes the generated source address a fully
+          # qualified registry.opentofu.org/alekc/kubectl that OpenTofu
+          # accepts and the SDK v2 in-process provider plumbing serves.
+          # Terraform tolerates the default and does not need these vars.
+          TF_ACC_PROVIDER_NAMESPACE: alekc
+          TF_ACC_PROVIDER_HOST: registry.opentofu.org
           ACC_TESTARGS: "-parallel 4"
         run: |
           make testacc
@@ -499,6 +511,9 @@ jobs:
           KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
           TF_ACC_TERRAFORM_PATH: ${{ steps.tfpath.outputs.path }}
           TF_ACC_TERRAFORM_VERSION: ${{ matrix.opentofu_version }}
+          # See acc_test_opentofu_smoke for why these are set.
+          TF_ACC_PROVIDER_NAMESPACE: alekc
+          TF_ACC_PROVIDER_HOST: registry.opentofu.org
           ACC_TESTARGS: "-parallel 4"
         run: |
           make testacc

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -399,17 +399,29 @@ jobs:
           KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
           TF_ACC_TERRAFORM_PATH: ${{ steps.tfpath.outputs.path }}
           TF_ACC_TERRAFORM_VERSION: ${{ needs.get_version_matrix.outputs.latest_opentofu_version }}
-          # terraform-plugin-testing auto-injects a required_providers
-          # block whose `source` is built from these env vars. The
-          # defaults (registry.terraform.io / "-" or "hashicorp") produce
-          # a legacy "-" namespace address that OpenTofu's parser rejects
-          # with "The legacy provider namespace '-' can be used only with
-          # hostname registry.opentofu.org". Setting both fields to the
-          # real values makes the generated source address a fully
-          # qualified registry.opentofu.org/alekc/kubectl that OpenTofu
-          # accepts and the SDK v2 in-process provider plumbing serves.
-          # Terraform tolerates the default and does not need these vars.
-          TF_ACC_PROVIDER_NAMESPACE: alekc
+          # The SDK v2 harness (helper/resource/plugin.go) builds the
+          # TF_REATTACH_PROVIDERS map keyed by <host>/<namespace>/<name>.
+          # With defaults it registers BOTH a legacy `-` and a modern
+          # `hashicorp` namespace key so any Terraform CLI version finds
+          # a match.
+          #
+          # Two OpenTofu wrinkles need fixing:
+          #   1. OpenTofu's parser rejects the legacy `-` namespace
+          #      unless the host is registry.opentofu.org, so we have to
+          #      pin the host explicitly to silence the parse-time
+          #      panic the default would produce.
+          #   2. The test configs are bare `resource "kubectl_manifest"`
+          #      blocks with no `required_providers`, so OpenTofu's
+          #      implicit local-name lookup resolves to
+          #      registry.opentofu.org/hashicorp/kubectl. The reattach
+          #      map must contain that exact key. Setting NAMESPACE to
+          #      `hashicorp` makes the harness register exactly that
+          #      key (and skips the legacy `-` key that would otherwise
+          #      trip wrinkle 1).
+          #
+          # Terraform tolerates the defaults silently and does not need
+          # either var.
+          TF_ACC_PROVIDER_NAMESPACE: hashicorp
           TF_ACC_PROVIDER_HOST: registry.opentofu.org
           ACC_TESTARGS: "-parallel 4"
         run: |
@@ -512,7 +524,7 @@ jobs:
           TF_ACC_TERRAFORM_PATH: ${{ steps.tfpath.outputs.path }}
           TF_ACC_TERRAFORM_VERSION: ${{ matrix.opentofu_version }}
           # See acc_test_opentofu_smoke for why these are set.
-          TF_ACC_PROVIDER_NAMESPACE: alekc
+          TF_ACC_PROVIDER_NAMESPACE: hashicorp
           TF_ACC_PROVIDER_HOST: registry.opentofu.org
           ACC_TESTARGS: "-parallel 4"
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -427,10 +427,14 @@ jobs:
         run: |
           make testacc
   acc_test_terraform:
-    # Full Kubernetes × Terraform matrix, gated on acc_test_terraform_smoke
-    # (latest k8s × latest tf). This catches "syntax error / missing
-    # assertion / forgotten t.Parallel()" failures against one cell
-    # before fanning out the rest of the matrix.
+    # Full Kubernetes × Terraform matrix, gated on both Terraform smokes:
+    #   * acc_test_terraform_smoke catches "syntax error / missing
+    #     assertion / forgotten t.Parallel()" failures against one cell
+    #     before fanning out the rest of the matrix.
+    #   * real_terraform_smoke catches real-CLI / mux-parity / plugin-
+    #     protocol regressions that the SDK harness does not exercise.
+    #     If either is broken, fanning out the full matrix would burn
+    #     CI minutes on a known-bad provider for the same reason.
     #
     # Independent of the OpenTofu side: an OpenTofu CI hiccup does not
     # block this job, and a Terraform regression does not block
@@ -440,6 +444,7 @@ jobs:
       - get_version_matrix
       - unit_test
       - acc_test_terraform_smoke
+      - real_terraform_smoke
     runs-on: ubuntu-latest
     # Same hard cap as the smoke job. See that job for rationale.
     timeout-minutes: 30
@@ -481,15 +486,18 @@ jobs:
         run: |
           make testacc
   acc_test_opentofu:
-    # Full Kubernetes × OpenTofu matrix, gated on acc_test_opentofu_smoke.
-    # Mirrors acc_test_terraform but with the OpenTofu axis and the
-    # opentofu/setup-opentofu action. terraform-plugin-testing execs the
-    # binary at TF_ACC_TERRAFORM_PATH regardless of its name.
+    # Full Kubernetes × OpenTofu matrix, gated on both OpenTofu smokes
+    # (acc_test_opentofu_smoke + real_opentofu_smoke) for the same
+    # reasons spelled out on acc_test_terraform. Mirrors that job but
+    # with the OpenTofu axis and the opentofu/setup-opentofu action.
+    # terraform-plugin-testing execs the binary at TF_ACC_TERRAFORM_PATH
+    # regardless of its name.
     name: "acc_test opentofu ${{ matrix.opentofu_version }} / k8s ${{ matrix.k8s_version }}"
     needs:
       - get_version_matrix
       - unit_test
       - acc_test_opentofu_smoke
+      - real_opentofu_smoke
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          k8s_cycles="$(curl -sSfL https://endoflife.date/api/kubernetes.json | jq -rc '[sort_by(.releaseDate) | reverse | .[0:4] | .[].cycle]')"
+          k8s_cycles="$(curl -sSfL https://endoflife.date/api/kubernetes.json | jq -rc '[sort_by(.releaseDate) | reverse | .[0:5] | .[].cycle]')"
           # The final `select($versions[.] != null)` drops cycles that
           # endoflife.date reports as current but for which kindest/node has
           # not yet published a matching tag (the typical case immediately
@@ -48,21 +48,30 @@ jobs:
           # picks up a JSON null which renders as `kindest/node:v` and the
           # job fails with "manifest unknown".
           kind_versions="$(crane ls docker.io/kindest/node | jq -sRrc --argjson cycles "${k8s_cycles}" 'split("\n") | [.[] | match("^v((\\d+\\.\\d+)\\.\\d+)$").captures | {cycle: .[1].string, version: .[0].string}] | group_by(.cycle) | [.[] | .[-1] | {(.cycle): {"version": .version}}] | reduce .[] as $item ({}; . *= $item) | . as $versions | [$cycles | .[] | select($versions[.] != null) | $versions[.].version]')"
-          terraform_versions="$(curl -sSfL https://endoflife.date/api/terraform.json | jq -rc '[sort_by(.releaseDate) | reverse | .[0:4] | .[].latest] + ["1.5.7"]')"
+          terraform_versions="$(curl -sSfL https://endoflife.date/api/terraform.json | jq -rc '[sort_by(.releaseDate) | reverse | .[0:5] | .[].latest] + ["1.5.7"]')"
+          # OpenTofu version list. No legacy pin equivalent to Terraform's
+          # 1.5.7 because OpenTofu's first GA is 1.6.0 and there is no
+          # MPL/BSL transition to commemorate.
+          opentofu_versions="$(curl -sSfL https://endoflife.date/api/opentofu.json | jq -rc '[sort_by(.releaseDate) | reverse | .[0:5] | .[].latest]')"
 
           {
             echo "terraform_versions=${terraform_versions}"
+            echo "opentofu_versions=${opentofu_versions}"
             echo "k8s_versions=${kind_versions}"
-            # Index 0 of each is the most recent version. The smoke job uses
-            # these singletons; the full matrix job excludes this pair so
-            # it isn't re-run.
+            # Index 0 of each version list is the most recent. The
+            # per-engine smoke jobs consume these singletons; the
+            # per-engine matrix jobs use the full lists and exclude the
+            # smoke pair via the matrix's own `exclude:` block.
             echo "latest_terraform_version=$(echo "${terraform_versions}" | jq -rc '.[0]')"
+            echo "latest_opentofu_version=$(echo "${opentofu_versions}" | jq -rc '.[0]')"
             echo "latest_k8s_version=$(echo "${kind_versions}" | jq -rc '.[0]')"
           } >> "${GITHUB_OUTPUT}"
     outputs:
       terraform_versions: ${{ steps.get_version_matrix.outputs.terraform_versions }}
+      opentofu_versions: ${{ steps.get_version_matrix.outputs.opentofu_versions }}
       k8s_versions: ${{ steps.get_version_matrix.outputs.k8s_versions }}
       latest_terraform_version: ${{ steps.get_version_matrix.outputs.latest_terraform_version }}
+      latest_opentofu_version: ${{ steps.get_version_matrix.outputs.latest_opentofu_version }}
       latest_k8s_version: ${{ steps.get_version_matrix.outputs.latest_k8s_version }}
   unit_test:
     runs-on: ubuntu-latest
@@ -187,8 +196,124 @@ jobs:
             kubectl get namespace kubectl-provider-real-smoke -o yaml >&2 || true
             exit 1
           fi
-  acc_test_smoke:
-    name: "acc_test smoke (k8s ${{ needs.get_version_matrix.outputs.latest_k8s_version }} / tf ${{ needs.get_version_matrix.outputs.latest_terraform_version }})"
+  real_opentofu_smoke:
+    # Sibling of real_terraform_smoke for the OpenTofu CLI. Same shape: kind
+    # cluster, dev_overrides build, real CLI apply/destroy on a namespace
+    # manifest. Two reasons for a separate job rather than an engine matrix
+    # on real_terraform_smoke:
+    #
+    #   1. Job names stay stable for branch protection. The existing
+    #      `real_terraform_smoke` name keeps matching its required check;
+    #      `real_opentofu_smoke` is the new contract.
+    #   2. setup-terraform and setup-opentofu have different inputs
+    #      (terraform_version / terraform_wrapper vs tofu_version /
+    #      tofu_wrapper), and an engine-matrix + `if:` pattern would add
+    #      noise without DRY savings; the rest of the job is ~15 lines.
+    #
+    # OpenTofu reads `~/.tofurc` first and falls back to `~/.terraformrc`.
+    # We write the explicit `~/.tofurc` here so the provider_installation
+    # block is the one OpenTofu prefers, not the compat-fallback path.
+    needs:
+      - get_version_matrix
+      - unit_test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          wait: 2m
+          node_image: kindest/node:v${{ needs.get_version_matrix.outputs.latest_k8s_version }}
+      - uses: opentofu/setup-opentofu@847eaa4afeb791b06daa46e8eafa8b1b68d7cfb4 # v2.0.1
+        with:
+          tofu_version: ${{ needs.get_version_matrix.outputs.latest_opentofu_version }}
+          tofu_wrapper: false
+      - name: Build provider
+        run: go build -o "${HOME}/terraform-provider-kubectl" .
+      - name: Configure dev_overrides
+        run: |
+          cat > "${HOME}/.tofurc" <<EOF
+          provider_installation {
+            dev_overrides {
+              "alekc/kubectl" = "${HOME}"
+            }
+            direct {}
+          }
+          EOF
+      - name: Write smoke config
+        run: |
+          mkdir -p smoke
+          cat > smoke/main.tf <<'EOF'
+          terraform {
+            required_providers {
+              kubectl = {
+                source = "alekc/kubectl"
+              }
+            }
+          }
+
+          # Reads kubeconfig via KUBE_CONFIG_PATH env var (defaulted to the
+          # kind-action workspace path in this workflow). load_config_file
+          # defaults to true.
+          provider "kubectl" {}
+
+          resource "kubectl_manifest" "smoke" {
+            # `wait = true` makes the provider block on `tofu destroy`
+            # until all finalizers (including the built-in `kubernetes`
+            # finalizer that drains in-namespace resources) finish. Without
+            # this, destroy returns while the namespace is still in
+            # Terminating phase and the post-destroy `kubectl get` check
+            # races against the kube-controller-manager.
+            wait = true
+            yaml_body = <<-YAML
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: kubectl-provider-real-smoke
+            YAML
+          }
+          EOF
+      - name: tofu apply
+        # OpenTofu driving the real provider binary through gRPC. Same
+        # GetProviderSchema / mux-parity coverage as the Terraform smoke,
+        # but exercised against the OpenTofu CLI's plugin-protocol
+        # implementation.
+        env:
+          KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
+        run: |
+          cd smoke
+          tofu apply -auto-approve
+      - name: Verify namespace exists
+        run: kubectl get namespace kubectl-provider-real-smoke
+      - name: tofu destroy
+        env:
+          KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
+        run: |
+          cd smoke
+          tofu destroy -auto-approve
+      - name: Verify namespace deleted
+        run: |
+          # `kubectl get` returns non-zero with a NotFound error once the
+          # namespace is gone; treat that as success. Anything else (still
+          # Terminating, still Active, transport error) fails the job.
+          if kubectl get namespace kubectl-provider-real-smoke 2>&1 | grep -q 'NotFound'; then
+            echo "namespace deleted as expected"
+          else
+            echo "namespace still present after tofu destroy" >&2
+            kubectl get namespace kubectl-provider-real-smoke -o yaml >&2 || true
+            exit 1
+          fi
+  acc_test_terraform_smoke:
+    # Cheap-failure shield for the Terraform half of acc_test. Runs the
+    # latest Kubernetes × latest Terraform cell first; the full Terraform
+    # matrix only fans out after this is green. Decoupled from the
+    # OpenTofu smoke so a tofu CI hiccup cannot block the Terraform
+    # matrix (and vice versa).
+    name: "acc_test smoke (terraform / k8s ${{ needs.get_version_matrix.outputs.latest_k8s_version }})"
     needs:
       - get_version_matrix
       - unit_test
@@ -240,18 +365,59 @@ jobs:
           ACC_TESTARGS: "-parallel 4"
         run: |
           make testacc
-  acc_test:
-    # acc_test runs the full Kubernetes × Terraform matrix, but only after
-    # acc_test_smoke (latest of each) has passed. This catches the common
-    # "syntax error / missing assertion / forgotten t.Parallel()" failures
-    # against one combination before fanning out N×M kind cluster spin-ups
-    # across the matrix.
+  acc_test_opentofu_smoke:
+    # OpenTofu sibling of acc_test_terraform_smoke. Same shape, swapped
+    # setup action. terraform-plugin-testing execs whatever binary sits
+    # at TF_ACC_TERRAFORM_PATH, so `tofu` works the same as `terraform`
+    # for the harness; only the setup-* action differs.
+    name: "acc_test smoke (opentofu / k8s ${{ needs.get_version_matrix.outputs.latest_k8s_version }})"
     needs:
       - get_version_matrix
       - unit_test
-      - acc_test_smoke
     runs-on: ubuntu-latest
-    # Same hard cap as acc_test_smoke. See that job for rationale.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        id: kind
+        with:
+          wait: 2m
+          node_image: kindest/node:v${{ needs.get_version_matrix.outputs.latest_k8s_version }}
+      - uses: opentofu/setup-opentofu@847eaa4afeb791b06daa46e8eafa8b1b68d7cfb4 # v2.0.1
+        with:
+          tofu_version: ${{ needs.get_version_matrix.outputs.latest_opentofu_version }}
+          tofu_wrapper: false
+      - name: Locate OpenTofu binary
+        id: tfpath
+        run: echo "path=$(which tofu)" >> "${GITHUB_OUTPUT}"
+      - name: Acceptance Tests
+        env:
+          KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
+          TF_ACC_TERRAFORM_PATH: ${{ steps.tfpath.outputs.path }}
+          TF_ACC_TERRAFORM_VERSION: ${{ needs.get_version_matrix.outputs.latest_opentofu_version }}
+          ACC_TESTARGS: "-parallel 4"
+        run: |
+          make testacc
+  acc_test_terraform:
+    # Full Kubernetes × Terraform matrix, gated on acc_test_terraform_smoke
+    # (latest k8s × latest tf). This catches "syntax error / missing
+    # assertion / forgotten t.Parallel()" failures against one cell
+    # before fanning out the rest of the matrix.
+    #
+    # Independent of the OpenTofu side: an OpenTofu CI hiccup does not
+    # block this job, and a Terraform regression does not block
+    # acc_test_opentofu. The two engines run in parallel.
+    name: "acc_test terraform ${{ matrix.terraform_version }} / k8s ${{ matrix.k8s_version }}"
+    needs:
+      - get_version_matrix
+      - unit_test
+      - acc_test_terraform_smoke
+    runs-on: ubuntu-latest
+    # Same hard cap as the smoke job. See that job for rationale.
     timeout-minutes: 30
     strategy:
       fail-fast: true
@@ -274,7 +440,7 @@ jobs:
         with:
           wait: 2m
           node_image: kindest/node:v${{ matrix.k8s_version }}
-      # See acc_test_smoke for why TF_ACC_TERRAFORM_PATH is set.
+      # See acc_test_terraform_smoke for why TF_ACC_TERRAFORM_PATH is set.
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ matrix.terraform_version }}
@@ -287,6 +453,52 @@ jobs:
           KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
           TF_ACC_TERRAFORM_PATH: ${{ steps.tfpath.outputs.path }}
           TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform_version }}
+          ACC_TESTARGS: "-parallel 4"
+        run: |
+          make testacc
+  acc_test_opentofu:
+    # Full Kubernetes × OpenTofu matrix, gated on acc_test_opentofu_smoke.
+    # Mirrors acc_test_terraform but with the OpenTofu axis and the
+    # opentofu/setup-opentofu action. terraform-plugin-testing execs the
+    # binary at TF_ACC_TERRAFORM_PATH regardless of its name.
+    name: "acc_test opentofu ${{ matrix.opentofu_version }} / k8s ${{ matrix.k8s_version }}"
+    needs:
+      - get_version_matrix
+      - unit_test
+      - acc_test_opentofu_smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: true
+      matrix:
+        opentofu_version: ${{ fromJson(needs.get_version_matrix.outputs.opentofu_versions) }}
+        k8s_version: ${{ fromJson(needs.get_version_matrix.outputs.k8s_versions) }}
+        exclude:
+          - opentofu_version: ${{ needs.get_version_matrix.outputs.latest_opentofu_version }}
+            k8s_version: ${{ needs.get_version_matrix.outputs.latest_k8s_version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        id: kind
+        with:
+          wait: 2m
+          node_image: kindest/node:v${{ matrix.k8s_version }}
+      - uses: opentofu/setup-opentofu@847eaa4afeb791b06daa46e8eafa8b1b68d7cfb4 # v2.0.1
+        with:
+          tofu_version: ${{ matrix.opentofu_version }}
+          tofu_wrapper: false
+      - name: Locate OpenTofu binary
+        id: tfpath
+        run: echo "path=$(which tofu)" >> "${GITHUB_OUTPUT}"
+      - name: Acceptance Tests
+        env:
+          KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
+          TF_ACC_TERRAFORM_PATH: ${{ steps.tfpath.outputs.path }}
+          TF_ACC_TERRAFORM_VERSION: ${{ matrix.opentofu_version }}
           ACC_TESTARGS: "-parallel 4"
         run: |
           make testacc

--- a/README.md
+++ b/README.md
@@ -23,18 +23,31 @@ The `terraform-provider-kubectl` has gained widespread adoption in numerous larg
 | Data source        | [`kubectl_path_documents`](./docs/data-sources/kubectl_path_documents.md)            | Glob a directory and split every matched file into individual documents.                             |
 | Ephemeral resource | [`kubectl_manifest`](./docs/ephemeral-resources/kubectl_manifest.md)                 | Read any cluster object without ever writing the value to `terraform.tfstate` or the plan file. Required for Secret payloads, freshly-minted tokens, private keys, and anything else you must keep out of state. Re-fetched on every plan / apply. Terraform 1.10+. |
 
-## Supported Kubernetes and Terraform versions
+## Supported Kubernetes, Terraform, and OpenTofu versions
 
-Every PR is exercised against the matrix below on `kind`. The matrix is regenerated from [endoflife.date](https://endoflife.date) on each CI run, so it tracks the four most recent active Kubernetes release cycles and the four most recent stable Terraform minors, plus a legacy `1.5.7` cell (the last MPL-licensed Terraform release).
+Every PR is exercised against the matrices below on `kind`. The matrices are regenerated from [endoflife.date](https://endoflife.date) on each CI run, so they track the five most recent active Kubernetes release cycles, the five most recent stable Terraform minors (plus a legacy `1.5.7` pin, the last MPL-licensed Terraform release), and the five most recent OpenTofu versions.
 
-|                 | Terraform 1.15 | Terraform 1.14 | Terraform 1.13 | Terraform 1.12 | Terraform 1.5.7 |
-| --------------- | :------------: | :------------: | :------------: | :------------: | :-------------: |
-| Kubernetes 1.36 | smoke + ✅      | ✅              | ✅              | ✅              | ✅               |
-| Kubernetes 1.35 | ✅              | ✅              | ✅              | ✅              | ✅               |
-| Kubernetes 1.34 | ✅              | ✅              | ✅              | ✅              | ✅               |
-| Kubernetes 1.33 | ✅              | ✅              | ✅              | ✅              | ✅               |
+### Terraform
 
-The versions in the table are the snapshot resolved at the time of writing; the live matrix moves with the upstream release cadence. The newest pair (latest Kubernetes × latest Terraform) is run first as a single **smoke** job; the remaining 19 combinations fan out only after smoke passes. Combinations outside this grid may still work — your mileage may vary.
+|                 | Terraform 1.15 | Terraform 1.14 | Terraform 1.13 | Terraform 1.12 | Terraform 1.11 | Terraform 1.5.7 |
+| --------------- | :------------: | :------------: | :------------: | :------------: | :------------: | :-------------: |
+| Kubernetes 1.36 | smoke + ✅      | ✅              | ✅              | ✅              | ✅              | ✅               |
+| Kubernetes 1.35 | ✅              | ✅              | ✅              | ✅              | ✅              | ✅               |
+| Kubernetes 1.34 | ✅              | ✅              | ✅              | ✅              | ✅              | ✅               |
+| Kubernetes 1.33 | ✅              | ✅              | ✅              | ✅              | ✅              | ✅               |
+| Kubernetes 1.32 | ✅              | ✅              | ✅              | ✅              | ✅              | ✅               |
+
+### OpenTofu
+
+|                 | OpenTofu 1.11 | OpenTofu 1.10 | OpenTofu 1.9 | OpenTofu 1.8 | OpenTofu 1.7 |
+| --------------- | :-----------: | :-----------: | :----------: | :----------: | :----------: |
+| Kubernetes 1.36 | smoke + ✅     | ✅             | ✅            | ✅            | ✅            |
+| Kubernetes 1.35 | ✅             | ✅             | ✅            | ✅            | ✅            |
+| Kubernetes 1.34 | ✅             | ✅             | ✅            | ✅            | ✅            |
+| Kubernetes 1.33 | ✅             | ✅             | ✅            | ✅            | ✅            |
+| Kubernetes 1.32 | ✅             | ✅             | ✅            | ✅            | ✅            |
+
+The versions in the tables are the snapshot resolved at the time of writing; the live matrices move with the upstream release cadences. Each engine has its own **smoke** job (latest Kubernetes × latest CLI for that engine); the rest of that engine's matrix fans out only after its smoke passes. The Terraform and OpenTofu halves run independently, so an issue on one side does not block the other. Combinations outside this grid may still work; your mileage may vary.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Adds OpenTofu coverage to the CI matrix alongside Terraform and bumps the per-axis depth from 4 to 5 while the matrix is being touched. The two engines run as independent halves of the workflow; an OpenTofu CI hiccup cannot block the Terraform matrix, and vice versa. Closes #278.

## Why

OpenTofu shares the plugin protocol with Terraform today, but the contract is not pinned. Version drift, divergent plan-time behaviour, and OpenTofu-only features (encryption block, provider-defined functions, state-machine differences) could regress without anyone noticing until a user reports it. Worth pinning compatibility in CI alongside the existing Terraform coverage.

## What changed

`get_version_matrix`: bumps `.[0:4]` to `.[0:5]` on the Kubernetes and Terraform fetches; adds a parallel OpenTofu fetch from endoflife.date (no legacy pin equivalent to Terraform's `1.5.7` since OpenTofu's first GA is 1.6.0); emits new `opentofu_versions` and `latest_opentofu_version` outputs.

`acc_test_smoke` (the previous single-job engine-matrix shape) is split into two flat jobs: `acc_test_terraform_smoke` and `acc_test_opentofu_smoke`. Each runs the latest k8s × latest CLI for its engine and gates only its own matrix.

`acc_test` is split into `acc_test_terraform` (matrix on `terraform_versions × k8s_versions`, smoke pair excluded) and `acc_test_opentofu` (matrix on `opentofu_versions × k8s_versions`, smoke pair excluded). Each gates only on its own smoke job, so the two engines run in parallel from `get_version_matrix` all the way through the matrix fan-out.

`real_opentofu_smoke` is added as a sibling of `real_terraform_smoke`. Same shape, swapped setup action. Writes `~/.tofurc` rather than `~/.terraformrc` so the `provider_installation` block sits on OpenTofu's preferred config path rather than its compat-fallback.

`tests-docs-skip.yaml`: matching no-op jobs for every renamed / added real job, per the file's "Job names here must equal job names over there" contract.

`README.md`: rewrites the support-matrix section into sibling Terraform and OpenTofu tables at the new 5-deep dimensions (the Terraform legacy `1.5.7` column stays). Replaces the hardcoded "19 combinations" line with a count-free narrative that also calls out the per-engine independence.

## Job graph

```mermaid
flowchart TD
    PR([PR opened against master])
    PR --> PF{path filter}
    PF -- "docs only" --> Ghost[tests-docs-skip.yaml<br/>no-op jobs with matching names]
    PF -- "everything else" --> Real[tests.yaml]

    Real --> GVM[get_version_matrix]
    Real --> UT[unit_test]

    GVM --> RTS[real_terraform_smoke]
    UT  --> RTS

    GVM --> ROS[real_opentofu_smoke]
    UT  --> ROS

    GVM --> ATTS[acc_test_terraform_smoke]
    UT  --> ATTS

    GVM --> ATOS[acc_test_opentofu_smoke]
    UT  --> ATOS

    ATTS --> ATT[acc_test_terraform<br/>terraform_version × k8s_version<br/>smoke pair excluded]
    ATOS --> ATO[acc_test_opentofu<br/>opentofu_version × k8s_version<br/>smoke pair excluded]
```

## Matrix counts

55 acceptance-matrix cells per PR (29 Terraform fan-out + 24 OpenTofu fan-out + 2 smoke), up from the current 20. Materially more CI minutes; trading them for OpenTofu coverage seems worth it given the size of the OpenTofu user base.

## Out of scope

Not dual-publishing to registry.opentofu.org. Not chasing OpenTofu-specific features. Not adding `actionlint` as a separate workflow. If the matrix uncovers a real compatibility gap, that's a separate bug per #278's own out-of-scope note.

## Branch protection note

The previously required check names `acc_test_smoke` and `acc_test` no longer exist. If branch protection ever pins them as required checks, replace with the four new names: `acc_test_terraform_smoke`, `acc_test_opentofu_smoke`, `acc_test_terraform`, `acc_test_opentofu`.

## Test plan

CI-only change; the PR's own workflow run is the verification.

- [ ] `get_version_matrix` logs show non-empty `opentofu_versions` and a sane `latest_opentofu_version`
- [ ] `acc_test_terraform_smoke` and `acc_test_opentofu_smoke` both green
- [ ] `acc_test_terraform` runs 29 fan-out cells green, latest pair not re-run
- [ ] `acc_test_opentofu` runs 24 fan-out cells green, latest pair not re-run
- [ ] `real_terraform_smoke` and `real_opentofu_smoke` both green
- [ ] Failing one engine's smoke leaves the other engine's matrix unblocked (verifiable by inspecting the job graph on the run)

Local pre-push: `yamllint` clean (warnings match the existing single-space-before-comment convention on pinned-SHA annotations); job names cross-reference exactly between `tests.yaml` and `tests-docs-skip.yaml`.

Fixes #278.
