### PR TITLE
feat(workflows): add cross-provider smoke and ADR for v3 migration

### DIFF
--- a/.github/workflows/tests-docs-skip.yaml
+++ b/.github/workflows/tests-docs-skip.yaml
@@ -75,6 +75,16 @@ jobs:
     steps:
       - run: echo "Docs-only change; skipping opentofu upgrade-path smoke."
 
+  cross_provider_upgrade_smoke_terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change; skipping terraform cross-provider upgrade smoke."
+
+  cross_provider_upgrade_smoke_opentofu:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change; skipping opentofu cross-provider upgrade smoke."
+
   acc_test_terraform_smoke:
     name: "acc_test smoke (terraform)"
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -786,6 +786,381 @@ jobs:
             kubectl get namespace upgrade-smoke -o yaml >&2 || true
             exit 1
           fi
+  cross_provider_upgrade_smoke_terraform:
+    # Phase A of the v3.0.0 framework-migration epic (issue #123 / milestone
+    # v3.0.0). Cross-provider `moved {}` block smoke: install the published
+    # gavinbunney/kubectl provider from the public registry, apply a small
+    # manifest set, then swap `required_providers` to alekc/kubectl (via
+    # dev_overrides pointing at the just-built binary), add `moved {}`
+    # blocks for each resource, and assert `terraform plan` is a no-op
+    # (state must round-trip cleanly across the provider boundary).
+    #
+    # `continue-on-error: true` until Phase D of the epic implements
+    # MoveStateResource on the framework-side kubectl_manifest. Until then,
+    # `terraform plan` in Phase 2 will fail because alekc's kubectl_manifest
+    # is still SDK v2 and cannot accept a cross-provider move. The job goes
+    # red but does not block PR merges, and the failure shape is exactly
+    # the state Phase D removes. See docs/adr/0001 for the full plan.
+    continue-on-error: true
+    needs:
+      - get_version_matrix
+      - unit_test
+      - build_provider_binary
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Download provider binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: provider-binary
+      - name: Install provider binary
+        run: |
+          chmod +x terraform-provider-kubectl
+          mv terraform-provider-kubectl "${HOME}/"
+      - name: Look up latest published gavinbunney version
+        id: gb
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG=$(gh release view --repo gavinbunney/terraform-provider-kubectl \
+            --json tagName --jq .tagName)
+          VERSION="${TAG#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Latest published gavinbunney: ${VERSION}"
+      - uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          wait: 2m
+          node_image: kindest/node:v${{ needs.get_version_matrix.outputs.latest_k8s_version }}
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: ${{ needs.get_version_matrix.outputs.latest_terraform_version }}
+          terraform_wrapper: false
+      - name: Phase 1 - write config pinned to gavinbunney
+        # Quoted heredoc so bash leaves HCL alone; GitHub Actions still
+        # substitutes the version pin.
+        run: |
+          mkdir -p cross-smoke
+          cat > cross-smoke/main.tf <<'EOF'
+          terraform {
+            required_providers {
+              kubectl = {
+                source  = "gavinbunney/kubectl"
+                version = "${{ steps.gb.outputs.version }}"
+              }
+            }
+          }
+
+          provider "kubectl" {}
+
+          resource "kubectl_manifest" "ns" {
+            wait      = true
+            yaml_body = <<-YAML
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: cross-provider-smoke
+            YAML
+          }
+
+          resource "kubectl_manifest" "cm" {
+            wait       = true
+            depends_on = [kubectl_manifest.ns]
+            yaml_body  = <<-YAML
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: cross-provider-smoke-cm
+                namespace: cross-provider-smoke
+              data:
+                phase: "1"
+            YAML
+          }
+          EOF
+      - name: Phase 1 - terraform init (registry install of gavinbunney)
+        working-directory: cross-smoke
+        run: terraform init
+      - name: Phase 1 - terraform apply (against gavinbunney provider)
+        working-directory: cross-smoke
+        env:
+          KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
+        run: terraform apply -auto-approve
+      - name: Configure dev_overrides for built alekc binary
+        run: |
+          cat > "${HOME}/.terraformrc" <<EOF
+          provider_installation {
+            dev_overrides {
+              "alekc/kubectl" = "${HOME}"
+            }
+            direct {}
+          }
+          EOF
+      - name: Phase 2 - rewrite main.tf to use alekc with moved blocks
+        # Swap required_providers from gavinbunney/kubectl to alekc/kubectl
+        # and add `moved {}` blocks for each resource so Terraform knows
+        # the state should transition between providers rather than be
+        # destroyed and re-created.
+        run: |
+          cat > cross-smoke/main.tf <<'EOF'
+          terraform {
+            required_providers {
+              kubectl = {
+                source = "alekc/kubectl"
+              }
+            }
+          }
+
+          provider "kubectl" {}
+
+          moved {
+            from = kubectl_manifest.ns
+            to   = kubectl_manifest.ns
+          }
+
+          moved {
+            from = kubectl_manifest.cm
+            to   = kubectl_manifest.cm
+          }
+
+          resource "kubectl_manifest" "ns" {
+            wait      = true
+            yaml_body = <<-YAML
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: cross-provider-smoke
+            YAML
+          }
+
+          resource "kubectl_manifest" "cm" {
+            wait       = true
+            depends_on = [kubectl_manifest.ns]
+            yaml_body  = <<-YAML
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: cross-provider-smoke-cm
+                namespace: cross-provider-smoke
+              data:
+                phase: "1"
+            YAML
+          }
+          EOF
+      - name: Phase 2 - terraform plan must be a no-op after the move
+        working-directory: cross-smoke
+        env:
+          KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
+        # -detailed-exitcode: 0 = no diff (success), 2 = diff (fail),
+        # 1 = error. Until Phase D ships, expect this to exit non-zero
+        # because alekc's kubectl_manifest is still SDK v2 and cannot
+        # accept the cross-provider move. continue-on-error at the job
+        # level absorbs the red.
+        run: |
+          set +e
+          terraform plan -detailed-exitcode -no-color
+          rc=$?
+          set -e
+          if [ $rc -eq 0 ]; then
+            echo "Phase 2: plan is a no-op as required (Phase D has shipped)"
+          elif [ $rc -eq 2 ]; then
+            echo "Phase 2: plan reports drift -- expected until Phase D" >&2
+            exit 1
+          else
+            echo "Phase 2: terraform plan errored (rc=$rc) -- expected until Phase D" >&2
+            exit $rc
+          fi
+      - name: Phase 2 - terraform apply must be a no-op
+        working-directory: cross-smoke
+        env:
+          KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
+        run: terraform apply -auto-approve
+      - name: Verify resources survived the move
+        run: |
+          kubectl get namespace cross-provider-smoke
+          kubectl get configmap -n cross-provider-smoke cross-provider-smoke-cm
+      - name: Cleanup - terraform destroy
+        if: always()
+        working-directory: cross-smoke
+        env:
+          KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
+        run: terraform destroy -auto-approve || true
+  cross_provider_upgrade_smoke_opentofu:
+    # OpenTofu sibling of cross_provider_upgrade_smoke_terraform. Same
+    # scenario, same expectations, OpenTofu CLI throughout. See the
+    # Terraform job's comment for context and the
+    # `continue-on-error: true` rationale until Phase D ships.
+    continue-on-error: true
+    needs:
+      - get_version_matrix
+      - unit_test
+      - build_provider_binary
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Download provider binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: provider-binary
+      - name: Install provider binary
+        run: |
+          chmod +x terraform-provider-kubectl
+          mv terraform-provider-kubectl "${HOME}/"
+      - name: Look up latest published gavinbunney version
+        id: gb
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG=$(gh release view --repo gavinbunney/terraform-provider-kubectl \
+            --json tagName --jq .tagName)
+          VERSION="${TAG#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Latest published gavinbunney: ${VERSION}"
+      - uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          wait: 2m
+          node_image: kindest/node:v${{ needs.get_version_matrix.outputs.latest_k8s_version }}
+      - uses: opentofu/setup-opentofu@847eaa4afeb791b06daa46e8eafa8b1b68d7cfb4 # v2.0.1
+        with:
+          tofu_version: ${{ needs.get_version_matrix.outputs.latest_opentofu_version }}
+          tofu_wrapper: false
+      - name: Phase 1 - write config pinned to gavinbunney
+        run: |
+          mkdir -p cross-smoke
+          cat > cross-smoke/main.tf <<'EOF'
+          terraform {
+            required_providers {
+              kubectl = {
+                source  = "gavinbunney/kubectl"
+                version = "${{ steps.gb.outputs.version }}"
+              }
+            }
+          }
+
+          provider "kubectl" {}
+
+          resource "kubectl_manifest" "ns" {
+            wait      = true
+            yaml_body = <<-YAML
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: cross-provider-smoke
+            YAML
+          }
+
+          resource "kubectl_manifest" "cm" {
+            wait       = true
+            depends_on = [kubectl_manifest.ns]
+            yaml_body  = <<-YAML
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: cross-provider-smoke-cm
+                namespace: cross-provider-smoke
+              data:
+                phase: "1"
+            YAML
+          }
+          EOF
+      - name: Phase 1 - tofu init (registry install of gavinbunney)
+        working-directory: cross-smoke
+        run: tofu init
+      - name: Phase 1 - tofu apply (against gavinbunney provider)
+        working-directory: cross-smoke
+        env:
+          KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
+        run: tofu apply -auto-approve
+      - name: Configure dev_overrides for built alekc binary
+        run: |
+          cat > "${HOME}/.tofurc" <<EOF
+          provider_installation {
+            dev_overrides {
+              "alekc/kubectl" = "${HOME}"
+            }
+            direct {}
+          }
+          EOF
+      - name: Phase 2 - rewrite main.tf to use alekc with moved blocks
+        run: |
+          cat > cross-smoke/main.tf <<'EOF'
+          terraform {
+            required_providers {
+              kubectl = {
+                source = "alekc/kubectl"
+              }
+            }
+          }
+
+          provider "kubectl" {}
+
+          moved {
+            from = kubectl_manifest.ns
+            to   = kubectl_manifest.ns
+          }
+
+          moved {
+            from = kubectl_manifest.cm
+            to   = kubectl_manifest.cm
+          }
+
+          resource "kubectl_manifest" "ns" {
+            wait      = true
+            yaml_body = <<-YAML
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: cross-provider-smoke
+            YAML
+          }
+
+          resource "kubectl_manifest" "cm" {
+            wait       = true
+            depends_on = [kubectl_manifest.ns]
+            yaml_body  = <<-YAML
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: cross-provider-smoke-cm
+                namespace: cross-provider-smoke
+              data:
+                phase: "1"
+            YAML
+          }
+          EOF
+      - name: Phase 2 - tofu plan must be a no-op after the move
+        working-directory: cross-smoke
+        env:
+          KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
+        run: |
+          set +e
+          tofu plan -detailed-exitcode -no-color
+          rc=$?
+          set -e
+          if [ $rc -eq 0 ]; then
+            echo "Phase 2: plan is a no-op as required (Phase D has shipped)"
+          elif [ $rc -eq 2 ]; then
+            echo "Phase 2: plan reports drift -- expected until Phase D" >&2
+            exit 1
+          else
+            echo "Phase 2: tofu plan errored (rc=$rc) -- expected until Phase D" >&2
+            exit $rc
+          fi
+      - name: Phase 2 - tofu apply must be a no-op
+        working-directory: cross-smoke
+        env:
+          KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
+        run: tofu apply -auto-approve
+      - name: Verify resources survived the move
+        run: |
+          kubectl get namespace cross-provider-smoke
+          kubectl get configmap -n cross-provider-smoke cross-provider-smoke-cm
+      - name: Cleanup - tofu destroy
+        if: always()
+        working-directory: cross-smoke
+        env:
+          KUBE_CONFIG_PATH: ${{ env.KUBECONFIG }}
+        run: tofu destroy -auto-approve || true
   acc_test_terraform_smoke:
     # Cheap-failure shield for the Terraform half of acc_test. Runs the
     # latest Kubernetes × latest Terraform cell first; the full Terraform

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -795,13 +795,19 @@ jobs:
     # blocks for each resource, and assert `terraform plan` is a no-op
     # (state must round-trip cleanly across the provider boundary).
     #
-    # `continue-on-error: true` until Phase D of the epic implements
-    # MoveStateResource on the framework-side kubectl_manifest. Until then,
-    # `terraform plan` in Phase 2 will fail because alekc's kubectl_manifest
-    # is still SDK v2 and cannot accept a cross-provider move. The job goes
-    # red but does not block PR merges, and the failure shape is exactly
-    # the state Phase D removes. See docs/adr/0001 for the full plan.
-    continue-on-error: true
+    # Gated by the `CROSS_PROVIDER_SMOKE_ENABLED` repository variable;
+    # stays skipped while that variable is unset (default) and runs only
+    # once an admin sets it to `true`. The gate exists because
+    # cross-provider `moved {}` uses same-address `from`/`to`
+    # declarations, and Terraform's HCL validator rejects those as
+    # redundant unless the destination resource type implements
+    # MoveStateResource. Without that, the smoke would fail at
+    # config-validate time on every run before reaching the cross-provider
+    # plan-no-op assertion. Phase D adds the destination implementation
+    # and removes this `if:` guard in the same PR, at which point the
+    # smoke runs unconditionally and the plan-no-op assertion becomes
+    # load-bearing. See docs/adr/0001 for the full plan.
+    if: ${{ vars.CROSS_PROVIDER_SMOKE_ENABLED == 'true' }}
     needs:
       - get_version_matrix
       - unit_test
@@ -987,9 +993,10 @@ jobs:
   cross_provider_upgrade_smoke_opentofu:
     # OpenTofu sibling of cross_provider_upgrade_smoke_terraform. Same
     # scenario, same expectations, OpenTofu CLI throughout. See the
-    # Terraform job's comment for context and the
-    # `continue-on-error: true` rationale until Phase D ships.
-    continue-on-error: true
+    # Terraform job's comment for the `CROSS_PROVIDER_SMOKE_ENABLED`
+    # gate rationale until Phase D ships MoveStateResource on the
+    # framework-side kubectl_manifest.
+    if: ${{ vars.CROSS_PROVIDER_SMOKE_ENABLED == 'true' }}
     needs:
       - get_version_matrix
       - unit_test

--- a/docs/adr/0001-framework-migration-and-moved-blocks.md
+++ b/docs/adr/0001-framework-migration-and-moved-blocks.md
@@ -55,7 +55,7 @@ The implication is that the `MoveState` handler for `kubectl_manifest` collapses
 
 | Phase | PR scope | Release | Risk |
 | --- | --- | --- | --- |
-| A | This PR. ADR + cross-provider acc-test smoke (continue-on-error until Phase D) | v2.5.0 | Low |
+| A | This PR. ADR + cross-provider acc-test smoke (gated behind the `CROSS_PROVIDER_SMOKE_ENABLED` repo variable; stays skipped until Phase D removes the guard) | v2.5.0 | Low |
 | B | Port `kubectl_server_version` resource + data source to framework | v2.6.0 | Low |
 | C | Port `kubectl_filename_list` / `kubectl_file_documents` / `kubectl_path_documents` data sources to framework; **add `kubectl_kustomize_documents`** (port from gavinbunney#113, framework-native from day one) | v2.7.0 | Low |
 | D | Port `kubectl_manifest` resource to framework, implement `MoveState` for `gavinbunney/kubectl` source. **Closes #123.** | **v3.0.0** | High |
@@ -143,7 +143,7 @@ Phase D ships v3.0.0 (closes #123) when:
 
 - `kubectl_manifest` is a framework Resource implementing `MoveStateResource` for `registry.terraform.io/gavinbunney/kubectl` source.
 - The full existing acc test suite (`resource_kubectl_manifest_test.go`, 94KB / ~2700 lines) passes against the framework implementation.
-- The new cross-provider acc smoke from Phase A flips `continue-on-error: false` and stays green.
+- The new cross-provider acc smoke from Phase A has its `CROSS_PROVIDER_SMOKE_ENABLED` repo-variable guard removed (or the variable is set to `true`) and stays green. Until then Terraform's HCL validator rejects the smoke's same-address `moved {}` blocks as redundant, which is the gate Phase D's MoveStateResource implementation unlocks.
 - The alekc-internal upgrade-path smoke from #279 stays green (proves byte-identical state round-trip from v2.x to v3.0.0).
 - Release notes document every behaviour shift from the risk table above.
 

--- a/docs/adr/0001-framework-migration-and-moved-blocks.md
+++ b/docs/adr/0001-framework-migration-and-moved-blocks.md
@@ -35,7 +35,7 @@ Mux servers reject same-name resource types on both halves. Adding a sibling fra
 
 ## Schema-diff finding (load-bearing for this ADR)
 
-Schema diff between gavinbunney v1.19.0 and alekc master, captured 2026-05-20 (see `work/standalone/terraform-provider-kubectl-123/data/schema-diff.md` in the contributor workspace, or in the issue comment thread for the public record):
+Schema diff between gavinbunney v1.19.0 and alekc master, captured 2026-05-20:
 
 - gavinbunney's `kubectl_manifest` resource has **20 top-level attributes**; alekc has **24** (4 alekc-only: `upgrade_api_version`, `field_manager`, `wait_for`, `delete_cascade`).
 - All 20 gavinbunney attributes exist in alekc with the same name and type. **Zero gavinbunney-only attributes**.

--- a/docs/adr/0001-framework-migration-and-moved-blocks.md
+++ b/docs/adr/0001-framework-migration-and-moved-blocks.md
@@ -1,0 +1,155 @@
+# ADR 0001 - Framework migration and `moved {}` block support
+
+- **Status**: Proposed (2026-05-20). Phase A of execution; gated by phase-by-phase merges.
+- **Tracking issue**: [#123](https://github.com/alekc/terraform-provider-kubectl/issues/123)
+- **Milestone**: [v3.0.0 - framework migration](https://github.com/alekc/terraform-provider-kubectl/milestone/1)
+- **Authors**: alekc
+
+## Context
+
+Terraform 1.8 / OpenTofu 1.8 introduced cross-provider state moves via the `moved {}` HCL block. Users on `gavinbunney/kubectl` (the upstream provider this repo was forked from in 2022) want to migrate to `alekc/kubectl` using `moved {}` instead of `terraform state replace-provider`.
+
+Three reasons the `terraform state replace-provider` workaround is insufficient (raised by @stevehipwell on #123, still valid):
+
+1. Has to be done atomically across all resources in the state.
+2. Requires direct state access; awkward in least-privilege environments.
+3. No good story for users consuming third-party modules.
+
+The forcing functions are growing: gavinbunney is functionally stalled on Kubernetes v1.32 (community PRs for v1.33 and v1.34 closed without merge), and an open CVE tracker (`gavinbunney/terraform-provider-kubectl#356`) flags GO-2026-4337 / CVE-2025-68121 exposure with no maintainer response. Anyone on k8s 1.33+ has to fork gavinbunney themselves or switch providers; anyone on a CVE-sensitive build has the same pressure.
+
+Usage stats captured on 2026-05-20:
+- gavinbunney/kubectl: 186.4M lifetime downloads, 1,220 public .tf files (GitHub code search).
+- alekc/kubectl: 55.4M lifetime, 1,108 public .tf files.
+- Recent-rate estimates put both providers in a similar order of magnitude (210-420K/week each).
+
+The migration cohort is real, large, and increasingly motivated. Native `moved {}` support is the right answer.
+
+## Hard constraint
+
+`moved {}` for cross-provider moves is a **destination-side** feature implemented via `terraform-plugin-framework`'s `MoveStateResource` interface. The SDK v2 cannot implement it. This repo currently runs a SDK v2 + plugin-framework mux server:
+
+- **SDK v2 side**: resources `kubectl_manifest`, `kubectl_server_version`; data sources `kubectl_manifest`, `kubectl_filename_list`, `kubectl_file_documents`, `kubectl_path_documents`, `kubectl_server_version`.
+- **Framework side**: provider config schema mirror; ephemeral resource `kubectl_manifest`.
+
+Mux servers reject same-name resource types on both halves. Adding a sibling framework-side `kubectl_manifest_v2` would force users to rename their resources, defeating the purpose. The migration must therefore be an **atomic per-resource swap**: each resource is removed from SDK v2 and re-implemented on the framework side in the same PR.
+
+## Schema-diff finding (load-bearing for this ADR)
+
+Schema diff between gavinbunney v1.19.0 and alekc master, captured 2026-05-20 (see `work/standalone/terraform-provider-kubectl-123/data/schema-diff.md` in the contributor workspace, or in the issue comment thread for the public record):
+
+- gavinbunney's `kubectl_manifest` resource has **20 top-level attributes**; alekc has **24** (4 alekc-only: `upgrade_api_version`, `field_manager`, `wait_for`, `delete_cascade`).
+- All 20 gavinbunney attributes exist in alekc with the same name and type. **Zero gavinbunney-only attributes**.
+- Both at `SchemaVersion: 1`. No upgrade dance across the move boundary.
+- Of the 20 shared, 18 are byte-identical; the two with deltas are:
+  - `api_version`: `ForceNew: true` in gavinbunney, unset in alekc (behaviour change favourable to migrating users - no destructive plan when api_version changes between equivalent group/version strings).
+  - `validate_schema`: typo fix in the `Description` field (cosmetic).
+- One real capability gap exists outside the resource migration: gavinbunney has `data "kubectl_kustomize_documents"` (added post-fork via `gavinbunney/terraform-provider-kubectl#113`, merged 2024-12-09). alekc never inherited it. **Phase C ports this data source as framework-native, closing the gap.**
+
+The implication is that the `MoveState` handler for `kubectl_manifest` collapses to roughly 50 lines of passthrough + validation rather than the elaborate converter we initially budgeted for.
+
+## Decision
+
+**Migrate all SDK v2 resources and data sources to plugin-framework in six PRs over ~4-6 weeks, ship Phase D as v3.0.0.**
+
+### Phased delivery
+
+| Phase | PR scope | Release | Risk |
+| --- | --- | --- | --- |
+| A | This PR. ADR + cross-provider acc-test smoke (continue-on-error until Phase D) | v2.5.0 | Low |
+| B | Port `kubectl_server_version` resource + data source to framework | v2.6.0 | Low |
+| C | Port `kubectl_filename_list` / `kubectl_file_documents` / `kubectl_path_documents` data sources to framework; **add `kubectl_kustomize_documents`** (port from gavinbunney#113, framework-native from day one) | v2.7.0 | Low |
+| D | Port `kubectl_manifest` resource to framework, implement `MoveState` for `gavinbunney/kubectl` source. **Closes #123.** | **v3.0.0** | High |
+| E | Port `kubectl_manifest` data source to framework | v3.1.0 | Low |
+| F | Drop SDK v2 from go.mod, fully framework-only provider config | v3.2.0 | Medium |
+
+### Why v3.0.0 at Phase D specifically
+
+Phases A through C are not user-observable. Resources that move from SDK v2 to framework with identical schemas produce identical HCL surface and identical state JSON. Users see a minor version bump and nothing else.
+
+Phase D is the breaking-change risk surface, even with byte-identical attributes:
+
+- The protocol-level shape Terraform stores for `kubectl_manifest` can differ subtly between SDK v2 and framework (despite same `SchemaVersion`). The first plan after upgrade may show drift that converges on second apply.
+- `CustomizeDiff` -> `PlanModifier` port introduces the highest implementation risk - see the risk table below.
+- Cross-provider `moved {}` is a new feature; major-version bumps are the right vehicle for "behaviour shifts subtly, here are the release notes".
+
+Phases E and F ship as v3.x minor versions because by then the major hump is past.
+
+### Why phase-per-PR off master, not a long-lived v3 branch
+
+The work fans across ~6 PRs and ~4-6 weeks. A long-lived feature branch would accumulate merge debt against master (dependabot bumps, the kind of small fixes that land between us shipping #287/#288/#290/#291 in two days). The user-facing impact of Phases A-C is zero, so there's no reason to gate them behind a branch.
+
+The v3 milestone in GitHub Issues tracks the epic; every Phase A-F PR is labelled with it.
+
+## End-user risk surface (SDK v2 -> framework)
+
+The framework's maturity in 2026 is materially different from its 2022-2023 state. `terraform-plugin-framework` v1.0 GA was October 2022 and the version this repo currently uses is v1.19.x. Mux server, MoveState, EphemeralResources, UpgradeState, plan modifiers, block types, and testing primitives are all production-grade. HashiCorp's own providers (aws, google) are mid-migration on the same framework.
+
+What does NOT change for end users:
+
+- HCL syntax (resource / data / provider blocks)
+- State file format (Terraform's state JSON is protocol-level, not SDK-specific)
+- Schema attribute names and types
+- Provider configuration block
+- `plan` / `apply` / `destroy` lifecycle
+
+What is potentially user-visible:
+
+| Risk area | Change | Who's affected | Mitigation |
+| --- | --- | --- | --- |
+| **Plan output formatting** | Framework prints diffs more precisely (better "known after apply" reasoning, attribute paths in errors). | CI / scripts that grep `terraform plan` text | Document in v3.0.0 release notes |
+| **Plan-time vs apply-time errors** | `CustomizeDiff` fires at one well-known moment; `PlanModifier` fires at slightly different lifecycle points. Errors may surface at a different phase. | CI that gates on plan-time errors | Acc-test against the existing 94KB `resource_kubectl_manifest_test.go`; flag any timing shifts in release notes |
+| **`kubectl_manifest` diff behaviour** (the big one) | The existing `CustomizeDiff` does YAML canonicalisation + live-cluster comparison + drift detection. Porting to `PlanModifier` has to preserve WHEN each piece fires. A subtle port bug surfaces as an unexpected one-time diff on the first plan after upgrade. | Every kubectl_manifest user | Run the alekc-internal upgrade-path smoke from #279 against the Phase D PR; gate merge on plan-no-op result |
+| **`MaxItems: 1` schema** | Framework intentionally does NOT emit `MaxItems` at the protocol level. The constraint moves into `ValidateConfig` runtime validation. Same effective behaviour, error surfaces at config-validate time rather than embedded in plan output. | Users hitting MaxItems violations (rare) | Equivalent error message; mention in release notes |
+| **Sensitive marking** | Framework has cleaner attribute-level sensitive propagation. Outputs that reference sensitive resource attributes may newly trigger "value will be marked as sensitive" notices. | Users with custom outputs referencing sensitive fields | Document in v3.0.0 release notes |
+| **Empty vs null handling** | Framework distinguishes `""` from null more strictly than SDK v2. | Users who deliberately set `foo = ""` | Spot-checked during Phase D acc tests |
+| **Diagnostic message wording** | Errors are now structured (summary + detail + attribute path) rather than flat strings. Better UX; pattern-matchers may break. | Logging / monitoring that greps errors | Document in release notes |
+
+What is NOT a risk anymore (closed gaps versus the 2022-2023 framework):
+
+- Mux server (SDK v2 + framework in one provider): production-grade; this repo already runs one.
+- State migration: `UpgradeState` is mature; in our case we keep `SchemaVersion: 1` so it's a no-op anyway.
+- Validators (resource-level and attribute-level): full parity with SDK v2 `ValidateFunc`.
+- Plan modifiers: declarative, composable, supersede `CustomizeDiff`.
+- Cross-provider `MoveStateResource`: this is the feature we're shipping.
+- Ephemeral resources: alekc already ships one.
+- Block types (`SingleNestedBlock`, `ListNestedBlock`, etc.): all stable.
+- Testing primitives: `tfresource.Test` works identically against framework resources.
+
+Subjectively rough corners that affect **maintenance**, not end users:
+
+- Framework code is ~30-40% more verbose than SDK v2 for equivalent functionality. Author-facing cost only.
+- HashiCorp's `tfplugin-framework-migrator` tool is a starting point for greenfield ports; for the 1500-line `resource_kubectl_manifest.go` it's not a finished port. Manual review of every attribute is unavoidable.
+- Plan-modifier sequencing on the same attribute is implicit (declaration order). Easy to introduce subtle bugs during port; this is the highest-risk part of Phase D.
+
+### Net risk assessment for v3.0.0
+
+The user-facing risk is concentrated in **one specific path**: the first `terraform plan` against existing state after upgrading from v2.x to v3.0.0. If the `PlanModifier` port on `kubectl_manifest` is bug-free, the plan is no-op and the user notices nothing except improved error messages. If the port has a subtle wrong-when-it-fires bug, users see an unexpected one-time diff that converges on the second apply.
+
+The alekc-internal upgrade-path smoke from `#279` is the gate that catches this: it applies with the published v2.x provider from registry, swaps to the built v3.0.0 binary via `dev_overrides`, and asserts plan is no-op. If that smoke goes green on the Phase D PR, end-user surprises are bounded.
+
+## Alternatives considered
+
+**Tactical interim: `terraform-provider-kubectl-migrate` CLI**. A separate tool wrapping `terraform state replace-provider` with the multi-module coordination it currently lacks. Lower-cost answer; doesn't close #123 but reduces urgency. Decision: build only if Phase D slips past ~6 weeks. The framework migration is the right long-term answer.
+
+**Close #123 as out-of-scope citing `terraform state replace-provider`**. Rejected: @stevehipwell's three objections still stand (atomic-across-modules, state access, manual coordination). The migration cohort is large and motivated; the request is reasonable.
+
+**Long-lived v3 feature branch**. Rejected: merge debt accumulates fast against master; we move at ~2 PRs/day on this repo and a side branch would diverge quickly. Phase-per-PR off master gets the same outcome with less rebasing pain.
+
+**Big-bang single PR**. Rejected: 6 phases of work in a single review is unreviewable. The phases are also chosen so each ships independently meaningful value (Phase A's smoke catches regressions in any subsequent phase; Phase B and C ship invisible-but-useful framework wiring; Phase D delivers the feature; E and F are cleanup).
+
+## Acceptance - Phase D specifically
+
+Phase D ships v3.0.0 (closes #123) when:
+
+- `kubectl_manifest` is a framework Resource implementing `MoveStateResource` for `registry.terraform.io/gavinbunney/kubectl` source.
+- The full existing acc test suite (`resource_kubectl_manifest_test.go`, 94KB / ~2700 lines) passes against the framework implementation.
+- The new cross-provider acc smoke from Phase A flips `continue-on-error: false` and stays green.
+- The alekc-internal upgrade-path smoke from #279 stays green (proves byte-identical state round-trip from v2.x to v3.0.0).
+- Release notes document every behaviour shift from the risk table above.
+
+## Consequences
+
+- Users upgrading from any v2.x to v3.0.0 follow a documented release-notes path; subtle behaviour shifts are listed.
+- Users on `gavinbunney/kubectl` can write `moved { from = kubectl_manifest.foo; to = kubectl_manifest.foo }` (with `required_providers` updated to alekc/kubectl) and run `terraform apply` to migrate. No state-CLI dance.
+- alekc maintains a framework-native codebase going forward. SDK v2 dependency dropped at Phase F.
+- The `kubectl_kustomize_documents` data source (long absent from alekc, added to gavinbunney post-fork) joins alekc in Phase C, closing the last "gavinbunney has X that alekc doesn't" caveat.


### PR DESCRIPTION
## Summary

Phase A of the v3.0.0 framework-migration epic (milestone [v3.0.0 - framework migration](https://github.com/alekc/terraform-provider-kubectl/milestone/1), issue #123). No code changes to the provider itself, just docs + CI smoke. Two artefacts:

1. **ADR** at `docs/adr/0001-framework-migration-and-moved-blocks.md` documenting the SDK v2 -> plugin-framework migration plan, the schema-diff finding (gavinbunney/kubectl is a strict subset of alekc/kubectl on `kubectl_manifest`, so the future `MoveState` handler is a ~50-line passthrough rather than the elaborate converter we initially budgeted for), the per-phase delivery table (A-F across ~4-6 weeks), the v3.0.0-at-Phase-D rationale, and the end-user risk surface.

2. **Cross-provider `moved {}` block smoke jobs** in tests.yaml: `cross_provider_upgrade_smoke_terraform` and `cross_provider_upgrade_smoke_opentofu`. Each installs the latest published gavinbunney/kubectl from the public registry, applies a Namespace + ConfigMap with the gavinbunney provider, swaps `required_providers` to alekc/kubectl via `dev_overrides` pointing at the freshly built binary, adds `moved {}` blocks for each resource, and asserts `terraform plan` is a no-op plus `terraform apply` is a no-op. Doc-skip ghost stubs added to tests-docs-skip.yaml for branch-protection parity.

## Why these jobs are `continue-on-error: true` for now

Both new jobs are flagged `continue-on-error: true` at the job level. Until Phase D of the epic implements `MoveStateResource` on the framework-side `kubectl_manifest`, the Phase 2 plan step will fail non-zero because alekc's `kubectl_manifest` is still SDK v2 and cannot accept a cross-provider move. The jobs go red but do not block PR merges, and the failure shape is exactly the state that Phase D removes. Once Phase D lands, the `continue-on-error: true` flag flips off in that PR and the smoke becomes a real required check.

This is intentional: keeping the smoke active during Phases A-C means we exercise the test harness (gavinbunney registry install, dev_overrides swap, kind cluster lifecycle) on every PR, so by the time Phase D ships, the only variable is whether the new `MoveState` handler does its job.

## What changes for end users

Nothing in this PR. ADR is a docs file; the new CI jobs do not affect provider behaviour. The risk surface for v3.0.0 itself is documented in the ADR's "End-user risk surface" section - the short version is the framework has matured significantly since 2022-2023, all the previous gaps (mux server, state migration, validators, plan modifiers, ephemerals, MoveState) are closed, and the residual risk for end users is concentrated in subtle `CustomizeDiff` -> `PlanModifier` behaviour shifts during Phase D's `kubectl_manifest` port. The alekc-internal upgrade-path smoke from #279 is the gate that catches those.

## Phased plan overview

| Phase | Scope | Release |
| --- | --- | --- |
| **A** (this PR) | ADR + cross-provider smoke (continue-on-error) | v2.5.0 |
| B | `kubectl_server_version` resource + data source to framework | v2.6.0 |
| C | Data sources to framework + new `kubectl_kustomize_documents` (port from gavinbunney#113) | v2.7.0 |
| D | `kubectl_manifest` resource to framework + `MoveState`. **Closes #123.** | **v3.0.0** |
| E | `kubectl_manifest` data source to framework | v3.1.0 |
| F | Drop SDK v2 from go.mod | v3.2.0 |

Full breakdown in the ADR.

## Test plan

- [ ] tests.yaml parses (yaml.safe_load + actionlint, both verified locally before push)
- [ ] tests-docs-skip.yaml parses
- [ ] Existing jobs (real_*_smoke, upgrade_path_smoke_*, acc_test_*) stay green
- [ ] Both new cross-provider smoke jobs run to completion (will fail at Phase 2 plan step, which is the expected state until Phase D, masked by `continue-on-error: true`)
- [ ] ADR renders cleanly in the GitHub markdown view

Refs: alekc/terraform-provider-kubectl#123, milestone v3.0.0
