### PR TITLE
test(framework): fix ephemeral seed-and-read tests via multi-step Steps

### DIFF
--- a/internal/framework/ephemeral_kubectl_manifest_test.go
+++ b/internal/framework/ephemeral_kubectl_manifest_test.go
@@ -78,18 +78,20 @@ check "ns_active" {
 // back via the ephemeral resource, asserting on an extracted scalar field.
 // Confirms the namespaced path through getRestClientFromUnstructured works
 // from the framework half too, not just cluster-scoped.
+//
+// Split across two TestSteps because Terraform evaluates ephemeral resources
+// at pre-apply plan time even when `depends_on` points at a managed resource
+// that is also being created in the same step. A single-step config that
+// bundles `kubectl_manifest.seed` and the ephemeral lookup against the same
+// cluster object fails the first plan with NotFound. Step 1 applies the seed
+// alone; step 2 keeps the seed in config (so it stays in state) and adds the
+// ephemeral block plus the assertion. By the time step 2's plan runs, the
+// ConfigMap is on the cluster and the ephemeral read succeeds.
 func TestAccKubectlEphemeralManifest_namespacedConfigMap(t *testing.T) {
 	t.Parallel()
-	// Skipped because the single-TestStep `seed kubectl_manifest -> ephemeral
-	// reads it` pattern fails at pre-apply plan: Terraform evaluates the
-	// ephemeral before the seed gets applied, even with `depends_on`. The fix
-	// is to split into multi-step Steps (apply seed in step 1, read via
-	// ephemeral in step 2) or move the seed into a PreConfig hook. Tracking
-	// issue: alekc/terraform-provider-kubectl#301.
-	t.Skip("blocked by alekc/terraform-provider-kubectl#301")
 
 	name := fmt.Sprintf("acc-ephemeral-cm-%s", acctest.RandString(8))
-	cfg := fmt.Sprintf(`
+	seedCfg := fmt.Sprintf(`
 resource "kubectl_manifest" "seed" {
   yaml_body = <<YAML
 apiVersion: v1
@@ -101,7 +103,8 @@ data:
   region: eu-west-1
 YAML
 }
-
+`, name)
+	readCfg := seedCfg + fmt.Sprintf(`
 ephemeral "kubectl_manifest" "cm" {
   api_version = "v1"
   kind        = "ConfigMap"
@@ -119,7 +122,7 @@ check "region_ok" {
     error_message = "expected region eu-west-1, got: ${ephemeral.kubectl_manifest.cm.results["region"]}"
   }
 }
-`, name, name)
+`, name)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
@@ -129,7 +132,13 @@ check "region_ok" {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: cfg,
+				// Step 1: apply the seed only. ConfigMap lands on the cluster.
+				Config: seedCfg,
+			},
+			{
+				// Step 2: ephemeral reads what step 1 created. Plan-time
+				// evaluation is now safe because the ConfigMap exists.
+				Config: readCfg,
 			},
 		},
 	})
@@ -239,15 +248,17 @@ var _ statecheck.StateCheck = ephemeralNotInState{}
 //
 // (The seed kubectl_manifest resource IS in state — that's expected and
 // distinct from the ephemeral block.)
+//
+// Split across two TestSteps for the same reason as
+// TestAccKubectlEphemeralManifest_namespacedConfigMap above: a single-step
+// seed-then-read config fails the pre-apply plan because Terraform evaluates
+// the ephemeral before the seed has been applied. The state-not-in
+// assertion lives on step 2, after both seed and ephemeral are in play.
 func TestAccKubectlEphemeralManifest_notInState(t *testing.T) {
 	t.Parallel()
-	// Skipped for the same reason as TestAccKubectlEphemeralManifest_namespacedConfigMap:
-	// the seed-then-read-ephemeral pattern fires the ephemeral too early at
-	// pre-apply plan. Tracking issue: alekc/terraform-provider-kubectl#301.
-	t.Skip("blocked by alekc/terraform-provider-kubectl#301")
 
 	name := fmt.Sprintf("acc-ephemeral-state-%s", acctest.RandString(8))
-	cfg := fmt.Sprintf(`
+	seedCfg := fmt.Sprintf(`
 resource "kubectl_manifest" "seed" {
   yaml_body = <<YAML
 apiVersion: v1
@@ -259,7 +270,8 @@ data:
   marker: present
 YAML
 }
-
+`, name)
+	readCfg := seedCfg + fmt.Sprintf(`
 ephemeral "kubectl_manifest" "cm" {
   api_version = "v1"
   kind        = "ConfigMap"
@@ -277,7 +289,7 @@ check "consumed" {
     error_message = "ephemeral resource did not fetch the expected marker"
   }
 }
-`, name, name)
+`, name)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
@@ -287,7 +299,14 @@ check "consumed" {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: cfg,
+				// Step 1: apply the seed only.
+				Config: seedCfg,
+			},
+			{
+				// Step 2: add the ephemeral block + the state-not-in
+				// assertion. The ephemeral never lands in state regardless
+				// of whether it's evaluated; the assertion proves that.
+				Config: readCfg,
 				ConfigStateChecks: []statecheck.StateCheck{
 					ephemeralNotInState{addressPrefix: "ephemeral.kubectl_manifest.cm"},
 				},


### PR DESCRIPTION
## Summary

Closes #301. Un-skips the two ephemeral acceptance tests parked behind `t.Skip("blocked by alekc/terraform-provider-kubectl#301")` in PR #300:

- `TestAccKubectlEphemeralManifest_namespacedConfigMap`
- `TestAccKubectlEphemeralManifest_notInState`

## Root cause recap

Both tests used a single-`TestStep` config that bundled a `kubectl_manifest.seed` and an `ephemeral.kubectl_manifest.cm` read with `depends_on`. Terraform's pre-apply plan evaluates ephemeral resources before any managed resources in the same step have been applied - `depends_on` is honoured for ordering within an apply, but the plan itself still walks the ephemeral and tries to read it. The read fired against a cluster that didn't yet have the ConfigMap and produced a NotFound diagnostic.

The tests passed locally against a cluster that retained the seed from a prior iteration, but failed cleanly the first time the `framework_acc_test` job ran them under `TF_ACC=1` in CI (PR #300).

## Fix

The first of the two options outlined in #301: split each test into two `TestSteps`.

- **Step 1**: applies the seed `kubectl_manifest` alone. The ConfigMap lands on the cluster.
- **Step 2**: keeps the seed in config (so it stays in state) and adds the ephemeral block plus the assertion. By the time step 2's plan runs, the ConfigMap is on the cluster and the ephemeral read succeeds.

Both tests now have explanatory comments above them describing the split and why.

Per the issue's evaluation, this is preferred over `PreConfig` + out-of-band `kubectl apply` because the seed `kubectl_manifest` resource itself isn't what's being tested - we want the muxed SDK v2 path exercised end-to-end, just temporally separated from the ephemeral read.

## Local verification

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./internal/framework/ -short` ok (TF_ACC unset, tests skip preCheck — confirms compile + structure)
- `grep "t.Skip" internal/framework/ephemeral_kubectl_manifest_test.go` returns no matches

## CI expectation

`framework_acc_test` should now run all 5 ephemeral tests with no skips. Coverage on `internal/framework` should rise from 83.3% (current) to higher, as the two skipped tests now exercise additional code paths in `FetchManifest`.

## Test plan

- [x] Both `t.Skip` annotations removed
- [x] Build / vet / short-test all clean
- [ ] `framework_acc_test` CI job runs all 5 ephemeral tests green
- [ ] `internal/framework` coverage rises above 83.3%
- [ ] No regression on the three currently-passing tests (`clusterScoped`, `notFound`, `missingFieldPath`)

Refs: alekc/terraform-provider-kubectl#123, milestone v3.0.0
Closes: alekc/terraform-provider-kubectl#301
