### PR TITLE
Allow extractFields to handle null values

### DIFF
--- a/kubernetes/manifest_fetch.go
+++ b/kubernetes/manifest_fetch.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/thedevsaddam/gojsonq/v2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -103,7 +105,13 @@ func extractFields(jsonBody string, fields map[string]string) (map[string]string
 	for key, path := range fields {
 		value := gq.Reset().Find(path)
 		if value == nil {
-			return nil, fmt.Errorf("fields[%q]: path %q not found in fetched object", key, path)
+			exists, err := jsonPathExists(jsonBody, path)
+			if err != nil {
+				return nil, fmt.Errorf("fields[%q]: %w", key, err)
+			}
+			if !exists {
+				return nil, fmt.Errorf("fields[%q]: path %q not found in fetched object", key, path)
+			}
 		}
 		s, err := stringifyValue(value)
 		if err != nil {
@@ -112,6 +120,49 @@ func extractFields(jsonBody string, fields map[string]string) (map[string]string
 		out[key] = s
 	}
 	return out, nil
+}
+
+func jsonPathExists(jsonBody, path string) (bool, error) {
+	var doc interface{}
+	if err := json.Unmarshal([]byte(jsonBody), &doc); err != nil {
+		return false, fmt.Errorf("failed to parse fetched object JSON: %w", err)
+	}
+
+	current := doc
+	for _, part := range strings.Split(path, ".") {
+		if part == "" {
+			return false, nil
+		}
+
+		switch node := current.(type) {
+		case map[string]interface{}:
+			value, ok := node[part]
+			if !ok {
+				return false, nil
+			}
+			current = value
+		case []interface{}:
+			index, ok := parsePathIndex(part)
+			if !ok || index < 0 || index >= len(node) {
+				return false, nil
+			}
+			current = node[index]
+		default:
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func parsePathIndex(part string) (int, bool) {
+	if strings.HasPrefix(part, "[") && strings.HasSuffix(part, "]") {
+		part = strings.TrimPrefix(strings.TrimSuffix(part, "]"), "[")
+	}
+	index, err := strconv.Atoi(part)
+	if err != nil {
+		return 0, false
+	}
+	return index, true
 }
 
 func stringifyValue(v interface{}) (string, error) {

--- a/kubernetes/manifest_fetch.go
+++ b/kubernetes/manifest_fetch.go
@@ -124,6 +124,7 @@ func extractFields(jsonBody string, fields map[string]string) (map[string]string
 
 // jsonPathExists checks whether a dot-separated path exists in a JSON body.
 // Array segments may use bare or bracketed indices, as parsed by parsePathIndex.
+// Keep this path parsing behavior aligned with gojsonq path resolution semantics.
 func jsonPathExists(jsonBody, path string) (bool, error) {
 	var doc interface{}
 	if err := json.Unmarshal([]byte(jsonBody), &doc); err != nil {

--- a/kubernetes/manifest_fetch.go
+++ b/kubernetes/manifest_fetch.go
@@ -122,6 +122,8 @@ func extractFields(jsonBody string, fields map[string]string) (map[string]string
 	return out, nil
 }
 
+// jsonPathExists checks whether a dot-separated path exists in a JSON body.
+// Array segments may use bare or bracketed indices, as parsed by parsePathIndex.
 func jsonPathExists(jsonBody, path string) (bool, error) {
 	var doc interface{}
 	if err := json.Unmarshal([]byte(jsonBody), &doc); err != nil {
@@ -154,6 +156,8 @@ func jsonPathExists(jsonBody, path string) (bool, error) {
 	return true, nil
 }
 
+// parsePathIndex parses an array index from either "N" or "[N]" path segments.
+// It returns the parsed index and whether the segment was a valid index.
 func parsePathIndex(part string) (int, bool) {
 	if strings.HasPrefix(part, "[") && strings.HasSuffix(part, "]") {
 		part = strings.TrimPrefix(strings.TrimSuffix(part, "]"), "[")

--- a/kubernetes/manifest_fetch_test.go
+++ b/kubernetes/manifest_fetch_test.go
@@ -28,6 +28,7 @@ func TestStringifyValue(t *testing.T) {
 		{"map encoded as JSON", map[string]interface{}{"a": "b", "c": float64(1)}, `{"a":"b","c":1}`},
 		{"slice of strings encoded as JSON", []interface{}{"a", "b"}, `["a","b"]`},
 		{"nested map+slice encoded as JSON", map[string]interface{}{"x": []interface{}{float64(1), float64(2)}}, `{"x":[1,2]}`},
+		{"nil encoded as JSON null", nil, "null"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -126,11 +127,33 @@ func TestExtractFields(t *testing.T) {
 		assert.Equal(t, "null", got["resources"])
 	})
 
+	t.Run("bare array index against null field is extracted as JSON null", func(t *testing.T) {
+		got, err := extractFields(body, map[string]string{"resources": "spec.containers.1.resources"})
+		require.NoError(t, err)
+		assert.Equal(t, "null", got["resources"])
+	})
+
 	t.Run("missing path returns error naming the field key", func(t *testing.T) {
 		_, err := extractFields(body, map[string]string{"oops": "spec.doesnt.exist"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), `fields["oops"]`)
 		assert.Contains(t, err.Error(), `"spec.doesnt.exist"`)
+	})
+
+	t.Run("out-of-range array index returns not found", func(t *testing.T) {
+		_, err := extractFields(body, map[string]string{"oops": "spec.containers.[2].image"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `fields["oops"]`)
+		assert.Contains(t, err.Error(), `"spec.containers.[2].image"`)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("traversal through null returns not found", func(t *testing.T) {
+		_, err := extractFields(body, map[string]string{"oops": "spec.lastScheduleTime.foo"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `fields["oops"]`)
+		assert.Contains(t, err.Error(), `"spec.lastScheduleTime.foo"`)
+		assert.Contains(t, err.Error(), "not found")
 	})
 
 	t.Run("multiple fields extracted independently", func(t *testing.T) {

--- a/kubernetes/manifest_fetch_test.go
+++ b/kubernetes/manifest_fetch_test.go
@@ -47,9 +47,10 @@ func TestExtractFields(t *testing.T) {
       "spec": {
         "replicas": 3,
         "active": true,
+        "lastScheduleTime": null,
         "containers": [
           {"name": "main", "image": "nginx:1.25"},
-          {"name": "sidecar", "image": "envoy:1.30"}
+          {"name": "sidecar", "image": "envoy:1.30", "resources": null}
         ]
       }
     }`
@@ -111,6 +112,18 @@ func TestExtractFields(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(got["first_container"]), &container))
 		assert.Equal(t, "main", container["name"])
 		assert.Equal(t, "nginx:1.25", container["image"])
+	})
+
+	t.Run("null object field is extracted as JSON null", func(t *testing.T) {
+		got, err := extractFields(body, map[string]string{"last_schedule": "spec.lastScheduleTime"})
+		require.NoError(t, err)
+		assert.Equal(t, "null", got["last_schedule"])
+	})
+
+	t.Run("null array element field is extracted as JSON null", func(t *testing.T) {
+		got, err := extractFields(body, map[string]string{"resources": "spec.containers.[1].resources"})
+		require.NoError(t, err)
+		assert.Equal(t, "null", got["resources"])
 	})
 
 	t.Run("missing path returns error naming the field key", func(t *testing.T) {


### PR DESCRIPTION
Fixes #270.

This change makes extractFields distinguish between a missing path and a present path whose value is null.

Changes:
- keep the existing missing-path error behavior
- allow present-but-null values to be extracted
- add regression coverage for null values in objects and array elements

Validation:
- gofmt -w kubernetes/manifest_fetch.go kubernetes/manifest_fetch_test.go
- GOCACHE="$PWD/.gocache" GOPATH="$PWD/.gopath" go test ./kubernetes -run TestExtractFields -count=1
- git diff --check

Notes:
- Present-but-null values are returned as string "null", consistent with the existing stringifyValue JSON encoding behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Manifest fetching now validates that requested fields exist in the JSON data and returns an appropriate error when a path cannot be found.
  * Improved error handling for invalid or missing field paths during manifest extraction.

* **Tests**
  * Added test coverage for null field extraction scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alekc/terraform-provider-kubectl/pull/305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->