### PR TITLE
feat(framework): port kubectl_manifest to plugin-framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,11 +173,47 @@ Building from source, pointing Terraform at a local build with
 documented in [CONTRIBUTING.md](./CONTRIBUTING.md). Start there if you
 want to try an unreleased fix from `master` or submit a change.
 
-## Changing providers for existing resources
+## Migrating from gavinbunney/kubectl
 
-When you used another fork of this provider in the past, you can switch the provider on all existing resources within your state. A common use-case is moving from `gavinbunney/kubectl` to this fork.
+If you previously used `gavinbunney/kubectl`, you can switch existing `kubectl_manifest` resources to this fork without destroying and recreating anything. There are two ways to do it; pick based on your Terraform / OpenTofu version.
 
-Change the `required_providers` block in your root module and all child modules to use `alekc/kubectl` as shown in the [Installation](#terraform-013) section above. Then use `state replace-provider` to update existing state:
+### Recommended: a `moved` block (Terraform 1.8+ / OpenTofu 1.8+)
+
+This provider implements native cross-provider state move for `kubectl_manifest`, so a `moved` block migrates state in place during a normal `plan` / `apply`, with no separate state surgery and no resource churn. Cross-provider move support requires the framework-based release of this provider (the release that ships the plugin-framework `kubectl_manifest`); pin to that release or newer in `required_providers`.
+
+Point `required_providers` at this fork and add a `moved` block whose `from` is the gavinbunney address and whose `to` is the same resource under this provider:
+
+```hcl
+terraform {
+  required_providers {
+    kubectl = {
+      source = "alekc/kubectl"
+    }
+  }
+}
+
+moved {
+  from = kubectl_manifest.my_app   # was gavinbunney/kubectl
+  to   = kubectl_manifest.my_app   # now alekc/kubectl
+}
+```
+
+Run `terraform init -upgrade` then `terraform plan`. The plan should report the resource as moved with no in-place changes (an empty diff). Run `terraform apply` to commit the move. Once the move has applied, delete the `moved` block.
+
+The 20 attributes shared with gavinbunney carry over unchanged. The four attributes that exist only on this fork take their defaults on the moved resource, all of which are no-ops for an unchanged manifest:
+
+| Attribute | Default after move | Effect |
+| --- | --- | --- |
+| `upgrade_api_version` | `false` | Keeps the conservative behaviour: an `api_version` change still forces replacement unless you opt in. |
+| `field_manager` | `kubectl` | Only consulted when `server_side_apply = true`; matches the historic default. |
+| `wait_for` | unset | No extra cluster-side wait conditions. |
+| `delete_cascade` | unset | Delete propagation stays automatic (`Foreground` when `wait = true`, else `Background`). |
+
+One behaviour changes, for the better: on `gavinbunney/kubectl` an `api_version` change always forced a destroy-and-recreate; on this fork it applies in place when `upgrade_api_version = true`. The default (`false`) matches gavinbunney, so the move itself never changes how your existing resources plan.
+
+### Alternative: `state replace-provider` (older Terraform)
+
+On Terraform older than 1.8 (which has no cross-provider `moved` support), switch the provider across all existing resources with `state replace-provider`. Change the `required_providers` block in your root module and all child modules to use `alekc/kubectl` as shown in the [Installation](#terraform-013) section above, then:
 
 ```sh
 terraform state replace-provider gavinbunney/kubectl alekc/kubectl
@@ -185,6 +221,10 @@ terraform state replace-provider gavinbunney/kubectl alekc/kubectl
 
 Run `terraform init` afterwards; subsequent terraform actions will use this provider.
 
+### Note on `kubectl_kustomize_documents`
+
+`gavinbunney/kubectl` added a `kubectl_kustomize_documents` data source after this fork diverged, and this fork does not (yet) provide it. If your configuration uses that data source, a full switch is not possible without re-architecting that part (for example, rendering `kustomize build` output through the `external` data source, or keeping `gavinbunney/kubectl` aliased alongside this provider for that one data source). Everything else migrates cleanly.
+
 ### Inspiration
 
-Thanks to the original provider by [gavinbunney](https://github.com/gavinbunney/terraform-provider-kubectl) — this fork was originally based on version 1.14 and has followed a separate development path since.
+Thanks to the original provider by [gavinbunney](https://github.com/gavinbunney/terraform-provider-kubectl), this fork was originally based on version 1.14 and has followed a separate development path since.

--- a/internal/framework/ephemeral_kubectl_manifest_test.go
+++ b/internal/framework/ephemeral_kubectl_manifest_test.go
@@ -76,7 +76,7 @@ check "ns_active" {
 // TestAccKubectlEphemeralManifest_namespacedConfigMap seeds a ConfigMap via
 // the SDK v2 kubectl_manifest resource (same muxed provider) and reads it
 // back via the ephemeral resource, asserting on an extracted scalar field.
-// Confirms the namespaced path through getRestClientFromUnstructured works
+// Confirms the namespaced path through GetRestClientFromUnstructured works
 // from the framework half too, not just cluster-scoped.
 //
 // Split across two TestSteps because Terraform evaluates ephemeral resources

--- a/internal/framework/resource_kubectl_manifest.go
+++ b/internal/framework/resource_kubectl_manifest.go
@@ -1,0 +1,736 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	internaltypes "github.com/alekc/terraform-provider-kubectl/internal/types"
+	"github.com/alekc/terraform-provider-kubectl/kubernetes"
+	"github.com/alekc/terraform-provider-kubectl/yaml"
+)
+
+// manifestResource is the plugin-framework port of the SDK v2
+// `kubectl_manifest` resource. The schema, semantics, and state shape are
+// designed to be byte-compatible with the SDK v2 implementation so existing
+// users see no state churn after the cutover. See the Phase D plan in
+// work/standalone/terraform-provider-kubectl-123/plan.md and ADR-0001.
+//
+// CRUD methods delegate to kubernetes.ApplyManifest / ReadManifest /
+// DeleteManifest (the SDK-v2-agnostic helpers extracted in Phase D.0).
+// Plan-time concerns (CustomizeDiff, DiffSuppressFunc, UpgradeState,
+// MoveState) land in follow-up commits on this branch; until the atomic
+// cutover commit, the resource is NOT registered in provider.Resources()
+// so the SDK v2 implementation remains the live one.
+type manifestResource struct {
+	sdkV2Meta func() any
+}
+
+var (
+	_ resource.Resource                 = (*manifestResource)(nil)
+	_ resource.ResourceWithConfigure    = (*manifestResource)(nil)
+	_ resource.ResourceWithModifyPlan   = (*manifestResource)(nil)
+	_ resource.ResourceWithUpgradeState = (*manifestResource)(nil)
+)
+
+// NewManifestResource is the constructor registered in
+// kubectlFrameworkProvider.Resources() at cutover time.
+func NewManifestResource() resource.Resource {
+	return &manifestResource{}
+}
+
+// manifestResourceModel mirrors the SDK v2 schema. Field ordering matches
+// the SDK v2 file for diff review. The tfsdk tags are the source of truth
+// for attribute names.
+type manifestResourceModel struct {
+	ID                    types.String `tfsdk:"id"`
+	UID                   types.String `tfsdk:"uid"`
+	LiveUID               types.String `tfsdk:"live_uid"`
+	YAMLInCluster         types.String `tfsdk:"yaml_incluster"`
+	LiveManifestInCluster types.String `tfsdk:"live_manifest_incluster"`
+	APIVersion            types.String `tfsdk:"api_version"`
+	Kind                  types.String `tfsdk:"kind"`
+	Name                  types.String `tfsdk:"name"`
+	Namespace             types.String `tfsdk:"namespace"`
+	OverrideNamespace     types.String `tfsdk:"override_namespace"`
+	YAMLBody              types.String `tfsdk:"yaml_body"`
+	YAMLBodyParsed        types.String `tfsdk:"yaml_body_parsed"`
+	SensitiveFields       types.List   `tfsdk:"sensitive_fields"`
+	ForceNew              types.Bool   `tfsdk:"force_new"`
+	UpgradeAPIVersion     types.Bool   `tfsdk:"upgrade_api_version"`
+	ServerSideApply       types.Bool   `tfsdk:"server_side_apply"`
+	FieldManager          types.String `tfsdk:"field_manager"`
+	ForceConflicts        types.Bool   `tfsdk:"force_conflicts"`
+	ApplyOnly             types.Bool   `tfsdk:"apply_only"`
+	IgnoreFields          types.List   `tfsdk:"ignore_fields"`
+	Wait                  types.Bool   `tfsdk:"wait"`
+	WaitForRollout        types.Bool   `tfsdk:"wait_for_rollout"`
+	ValidateSchema        types.Bool   `tfsdk:"validate_schema"`
+	DeleteCascade         types.String `tfsdk:"delete_cascade"`
+	WaitFor               types.List   `tfsdk:"wait_for"`
+}
+
+// waitForBlockModel is the inline shape of a single wait_for block.
+type waitForBlockModel struct {
+	Condition []waitForConditionModel `tfsdk:"condition"`
+	Field     []waitForFieldModel     `tfsdk:"field"`
+}
+
+type waitForConditionModel struct {
+	Type   types.String `tfsdk:"type"`
+	Status types.String `tfsdk:"status"`
+}
+
+type waitForFieldModel struct {
+	Key       types.String `tfsdk:"key"`
+	Value     types.String `tfsdk:"value"`
+	ValueType types.String `tfsdk:"value_type"`
+}
+
+// defaultLifecycleTimeout is used for Create / Update / Delete until the
+// timeouts {} block plumbing lands (separate Phase D follow-up commit).
+const defaultLifecycleTimeout = 10 * time.Minute
+
+func (r *manifestResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_manifest"
+}
+
+func (r *manifestResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Version: 1,
+		Description: "Apply a Kubernetes manifest from raw YAML. Tracks the live resource by UID; reapplies " +
+			"on drift; surfaces full apply semantics (server-side apply, field manager, force conflicts, " +
+			"wait-for-rollout, wait_for conditions). Cross-provider state move from `gavinbunney/kubectl` " +
+			"is supported via `moved {}` blocks; see README \"Migrating from gavinbunney/kubectl\".",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Self-link of the Kubernetes object, used as the Terraform resource ID. Carries through unchanged from SDK v2 state for round-trip compatibility.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"uid": schema.StringAttribute{
+				Computed:    true,
+				Description: "UID of the Kubernetes object at the time of the last apply.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"live_uid": schema.StringAttribute{
+				Computed:    true,
+				Description: "UID of the Kubernetes object as observed during the most recent Read.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"yaml_incluster": schema.StringAttribute{
+				Computed:    true,
+				Sensitive:   true,
+				Description: "Fingerprint of the canonical YAML at the time of the last apply. Drift detection compares this to live_manifest_incluster.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"live_manifest_incluster": schema.StringAttribute{
+				Computed:    true,
+				Sensitive:   true,
+				Description: "Fingerprint of the canonical YAML as observed during the most recent Read.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"api_version": schema.StringAttribute{
+				Computed: true,
+				Description: "apiVersion of the manifest, derived from `yaml_body`. By default a change to this " +
+					"value re-creates the resource; set `upgrade_api_version = true` to allow an in-place update.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"kind": schema.StringAttribute{
+				Computed:    true,
+				Description: "kind of the manifest, derived from `yaml_body`. Changing it forces resource replacement.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Computed:    true,
+				Description: "metadata.name of the manifest, derived from `yaml_body`. Changing it forces resource replacement.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"namespace": schema.StringAttribute{
+				Computed:    true,
+				Description: "metadata.namespace of the manifest. Changing it forces resource replacement.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"override_namespace": schema.StringAttribute{
+				Optional:    true,
+				Description: "Override the namespace declared in `yaml_body`. Useful when applying a generic manifest into a parameterised namespace.",
+			},
+			"yaml_body": schema.StringAttribute{
+				Required:    true,
+				Sensitive:   true,
+				Description: "The Kubernetes manifest as a YAML string. Multi-document YAML is not supported on this resource; use `kubectl_path_documents` or a `for_each` with `kubectl_file_documents` to fan out.",
+			},
+			"yaml_body_parsed": schema.StringAttribute{
+				Computed:    true,
+				Description: "The YAML body as applied to the cluster, with any field listed in `sensitive_fields` replaced by `(sensitive value)`. Surfaced for plan-output review without leaking secret values.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"sensitive_fields": schema.ListAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
+				Description: "Dot-paths into the manifest whose values should be masked in `yaml_body_parsed`. For `Kind: Secret` resources, defaults to `[\"data\", \"stringData\"]` when unset.",
+			},
+			"force_new": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+				Description: "When true, any change to `yaml_body` re-creates the resource instead of updating it in place. Default false.",
+			},
+			"upgrade_api_version": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(false),
+				Description: "When true, a change to `api_version` is applied as an in-place update rather than a delete-and-recreate. Relies on the Kubernetes API server's ability to represent the same object across multiple API versions. Default false.",
+			},
+			"server_side_apply": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+				Description: "When true, use Kubernetes server-side apply instead of the default client-side apply. Pairs with `field_manager` and `force_conflicts`.",
+			},
+			"field_manager": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("kubectl"),
+				Description: "Override the field manager name for server-side apply. Only consulted when `server_side_apply = true`. Default `kubectl`.",
+			},
+			"force_conflicts": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+				Description: "When true, server-side apply takes ownership of conflicting fields. Only consulted when `server_side_apply = true`. Default false.",
+			},
+			"apply_only": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+				Description: "When true, Delete is a no-op. Useful for resources that other systems own the lifecycle of but Terraform still asserts the spec. Default false.",
+			},
+			"ignore_fields": schema.ListAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
+				Description: "Dot-paths into the manifest whose drift should be ignored. Set for fields managed by Operators or other controllers that mutate values after apply.",
+			},
+			"wait": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+				Description: "When true, Delete blocks until the resource is gone from the cluster (Foreground propagation). Default false.",
+			},
+			"wait_for_rollout": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(true),
+				Description: "When true, Apply blocks until rollout completes for Deployment / DaemonSet / StatefulSet / APIService kinds. Default true.",
+			},
+			"validate_schema": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(true),
+				Description: "When true, validate the YAML against the cluster's OpenAPI schema before applying. Default true.",
+			},
+			"delete_cascade": schema.StringAttribute{
+				Optional: true,
+				Description: "Propagation policy for Delete. One of `Background` or `Foreground`. When unset, defaults to `Foreground` if `wait = true`, otherwise `Background`.",
+				Validators: []validator.String{
+					stringOneOfValidator{allowed: []string{"Background", "Foreground"}},
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"wait_for": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"condition": schema.ListNestedBlock{
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"type": schema.StringAttribute{
+										Required:    true,
+										Description: "The .status.conditions[].type to match.",
+									},
+									"status": schema.StringAttribute{
+										Required:    true,
+										Description: "The .status.conditions[].status value to wait for (typically `True`).",
+									},
+								},
+							},
+						},
+						"field": schema.ListNestedBlock{
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"key": schema.StringAttribute{
+										Required:    true,
+										Description: "Dot-path into the live object (e.g. `status.phase`).",
+									},
+									"value": schema.StringAttribute{
+										Required:    true,
+										Description: "Expected value at `key`. Compared as a string.",
+									},
+									"value_type": schema.StringAttribute{
+										Optional:    true,
+										Computed:    true,
+										Default:     stringdefault.StaticString("eq"),
+										Description: "How to compare `value`: `eq` for equality (default) or `regex` for a regular-expression match.",
+										Validators: []validator.String{
+											stringOneOfValidator{allowed: []string{"eq", "regex"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Description: "Wait for cluster-side conditions or field values after Apply. A single block is supported; nested `condition` and `field` blocks combine (all must be satisfied) before the apply completes. MaxItems = 1 is not enforced in the schema (framework limitation) and is checked in ModifyPlan instead.",
+			},
+		},
+	}
+}
+
+func (r *manifestResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	cb, ok := req.ProviderData.(func() any)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"unexpected resource configuration",
+			fmt.Sprintf("expected func() any from provider data, got %T", req.ProviderData),
+		)
+		return
+	}
+	r.sdkV2Meta = cb
+}
+
+// kubeProvider resolves the SDK v2 *KubeProvider from the configured
+// sdkV2Meta callback. Returns nil + an error diagnostic if the callback
+// is missing or returns the wrong type.
+func (r *manifestResource) kubeProvider() (*kubernetes.KubeProvider, error) {
+	if r.sdkV2Meta == nil {
+		return nil, fmt.Errorf("provider not configured: the SDK v2 provider must configure before kubectl_manifest can run (mux wiring bug)")
+	}
+	p, ok := r.sdkV2Meta().(*kubernetes.KubeProvider)
+	if !ok {
+		return nil, fmt.Errorf("provider type mismatch: expected *kubernetes.KubeProvider from SDKv2Meta, got %T", r.sdkV2Meta())
+	}
+	return p, nil
+}
+
+// extractStringList materialises a types.List of strings into a plain
+// []string. Null and unknown lists become nil.
+func extractStringList(ctx context.Context, list types.List) ([]string, diag.Diagnostics) {
+	if list.IsNull() || list.IsUnknown() {
+		return nil, nil
+	}
+	var out []string
+	d := list.ElementsAs(ctx, &out, false)
+	return out, d
+}
+
+// extractWaitFor materialises the wait_for ListNestedBlock into a pointer
+// to internal/types.WaitFor (nil if the block is absent). Only the first
+// block is read; the MaxItems = 1 constraint is enforced upstream in
+// ModifyPlan.
+func extractWaitFor(ctx context.Context, list types.List) (*internaltypes.WaitFor, diag.Diagnostics) {
+	if list.IsNull() || list.IsUnknown() {
+		return nil, nil
+	}
+	var blocks []waitForBlockModel
+	d := list.ElementsAs(ctx, &blocks, false)
+	if d.HasError() || len(blocks) == 0 {
+		return nil, d
+	}
+	b := blocks[0]
+	wf := internaltypes.WaitFor{}
+	for _, c := range b.Condition {
+		wf.Condition = append(wf.Condition, internaltypes.WaitForStatusCondition{
+			Type:   c.Type.ValueString(),
+			Status: c.Status.ValueString(),
+		})
+	}
+	for _, f := range b.Field {
+		wf.Field = append(wf.Field, internaltypes.WaitForField{
+			Key:       f.Key.ValueString(),
+			Value:     f.Value.ValueString(),
+			ValueType: f.ValueType.ValueString(),
+		})
+	}
+	return &wf, d
+}
+
+// buildApplyOptions constructs an ApplyManifestOptions struct from the
+// plan model. Shared between Create and Update. Returns any decoding
+// diagnostics so the caller can short-circuit on error.
+func (r *manifestResource) buildApplyOptions(ctx context.Context, data manifestResourceModel) (kubernetes.ApplyManifestOptions, diag.Diagnostics) {
+	var allDiags diag.Diagnostics
+	waitFor, d := extractWaitFor(ctx, data.WaitFor)
+	allDiags.Append(d...)
+	ignoreFields, d := extractStringList(ctx, data.IgnoreFields)
+	allDiags.Append(d...)
+	return kubernetes.ApplyManifestOptions{
+		YAMLBody:          data.YAMLBody.ValueString(),
+		OverrideNamespace: data.OverrideNamespace.ValueString(),
+		ValidateSchema:    boolOrTrue(data.ValidateSchema),
+		ServerSideApply:   data.ServerSideApply.ValueBool(),
+		FieldManager:      stringOrDefault(data.FieldManager, "kubectl"),
+		ForceConflicts:    data.ForceConflicts.ValueBool(),
+		WaitForRollout:    boolOrTrue(data.WaitForRollout),
+		WaitFor:           waitFor,
+		Timeout:           defaultLifecycleTimeout,
+		IgnoreFields:      ignoreFields,
+	}, allDiags
+}
+
+// applyResultToModel writes the ApplyManifest output values onto the
+// resource model.
+func applyResultToModel(result *kubernetes.ApplyManifestResult, data *manifestResourceModel) {
+	data.ID = types.StringValue(result.SelfLink)
+	data.UID = types.StringValue(result.UID)
+	data.LiveUID = types.StringValue(result.LiveUID)
+	data.YAMLInCluster = types.StringValue(result.YAMLInClusterFingerprint)
+	data.LiveManifestInCluster = types.StringValue(result.LiveManifestInClusterFingerprint)
+}
+
+func (r *manifestResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data manifestResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	provider, err := r.kubeProvider()
+	if err != nil {
+		resp.Diagnostics.AddError("kubectl_manifest Create: provider unavailable", err.Error())
+		return
+	}
+
+	opts, d := r.buildApplyOptions(ctx, data)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	result, applyErr := kubernetes.ApplyManifest(ctx, provider, opts)
+	if applyErr != nil {
+		resp.Diagnostics.AddError("kubectl_manifest Create: apply failed", applyErr.Error())
+		return
+	}
+
+	applyResultToModel(result, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *manifestResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data manifestResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	provider, err := r.kubeProvider()
+	if err != nil {
+		resp.Diagnostics.AddError("kubectl_manifest Read: provider unavailable", err.Error())
+		return
+	}
+
+	ignoreFields, d := extractStringList(ctx, data.IgnoreFields)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	opts := kubernetes.ReadManifestOptions{
+		YAMLBody:          data.YAMLBody.ValueString(),
+		OverrideNamespace: data.OverrideNamespace.ValueString(),
+		IgnoreFields:      ignoreFields,
+	}
+
+	result, readErr := kubernetes.ReadManifest(ctx, provider, opts)
+	if readErr != nil {
+		resp.Diagnostics.AddError("kubectl_manifest Read: read failed", readErr.Error())
+		return
+	}
+	if result.InvalidType || !result.Found {
+		// Resource no longer exists in the cluster; remove from state by
+		// not setting it again. The framework treats unset state as removed.
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	data.LiveUID = types.StringValue(result.LiveUID)
+	data.LiveManifestInCluster = types.StringValue(result.LiveManifestInClusterFingerprint)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *manifestResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data manifestResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	provider, err := r.kubeProvider()
+	if err != nil {
+		resp.Diagnostics.AddError("kubectl_manifest Update: provider unavailable", err.Error())
+		return
+	}
+
+	opts, d := r.buildApplyOptions(ctx, data)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	result, applyErr := kubernetes.ApplyManifest(ctx, provider, opts)
+	if applyErr != nil {
+		resp.Diagnostics.AddError("kubectl_manifest Update: apply failed", applyErr.Error())
+		return
+	}
+
+	applyResultToModel(result, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *manifestResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data manifestResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	provider, err := r.kubeProvider()
+	if err != nil {
+		resp.Diagnostics.AddError("kubectl_manifest Delete: provider unavailable", err.Error())
+		return
+	}
+
+	opts := kubernetes.DeleteManifestOptions{
+		YAMLBody:          data.YAMLBody.ValueString(),
+		OverrideNamespace: data.OverrideNamespace.ValueString(),
+		ApplyOnly:         data.ApplyOnly.ValueBool(),
+		Wait:              data.Wait.ValueBool(),
+		DeleteCascade:     data.DeleteCascade.ValueString(),
+		Timeout:           defaultLifecycleTimeout,
+	}
+
+	if delErr := kubernetes.DeleteManifest(ctx, provider, opts); delErr != nil {
+		resp.Diagnostics.AddError("kubectl_manifest Delete: delete failed", delErr.Error())
+		return
+	}
+}
+
+// ModifyPlan ports the SDK v2 CustomizeDiff logic to the framework's
+// plan-modification phase. Responsibilities, in order:
+//
+//  1. Honour force_new: any yaml_body change replaces the resource.
+//  2. Skip when yaml_body is interpolated (Unknown); the framework already
+//     leaves Computed attributes Unknown by default.
+//  3. Parse the YAML, apply override_namespace, and push the resulting
+//     api_version / kind / name / namespace into the plan.
+//  4. If upgrade_api_version is false and api_version changed, require
+//     replacement.
+//  5. UID divergence between state.uid and state.live_uid means the
+//     cluster-side object was recreated; mark uid as Unknown so it is
+//     refreshed during Apply.
+//  6. Drift detection: yaml_incluster vs live_manifest_incluster
+//     mismatch means an external change occurred; mark yaml_incluster
+//     Unknown.
+//  7. Build yaml_body_parsed by obfuscating sensitive_fields (or the
+//     default Secret v1 fields) and write it into the plan.
+func (r *manifestResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() {
+		// Destroy plan; nothing to modify.
+		return
+	}
+
+	var plan manifestResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if plan.ForceNew.ValueBool() {
+		resp.RequiresReplace = append(resp.RequiresReplace, path.Root("yaml_body"))
+	}
+
+	if plan.YAMLBody.IsUnknown() {
+		return
+	}
+
+	parsed, err := yaml.ParseYAML(plan.YAMLBody.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("yaml_body"),
+			"kubectl_manifest plan: failed to parse yaml_body",
+			err.Error(),
+		)
+		return
+	}
+
+	overrideNs := plan.OverrideNamespace.ValueString()
+	if overrideNs != "" {
+		parsed.SetNamespace(overrideNs)
+	}
+
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("api_version"), parsed.GetAPIVersion())...)
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("kind"), parsed.GetKind())...)
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("name"), parsed.GetName())...)
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("namespace"), parsed.GetNamespace())...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !req.State.Raw.IsNull() {
+		var state manifestResourceModel
+		resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if !plan.UpgradeAPIVersion.ValueBool() && state.APIVersion.ValueString() != parsed.GetAPIVersion() {
+			resp.RequiresReplace = append(resp.RequiresReplace, path.Root("api_version"))
+		}
+
+		if state.LiveUID.ValueString() != state.UID.ValueString() {
+			resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("uid"), types.StringUnknown())...)
+		}
+
+		if state.YAMLInCluster.ValueString() != state.LiveManifestInCluster.ValueString() {
+			resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("yaml_incluster"), types.StringUnknown())...)
+		}
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	sensitiveFields, d := extractStringList(ctx, plan.SensitiveFields)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	obfuscated, obfErr := kubernetes.BuildObfuscatedYAML(plan.YAMLBody.ValueString(), overrideNs, sensitiveFields)
+	if obfErr != nil {
+		resp.Diagnostics.AddError(
+			"kubectl_manifest plan: failed to obfuscate yaml_body",
+			obfErr.Error(),
+		)
+		return
+	}
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("yaml_body_parsed"), obfuscated)...)
+}
+
+// UpgradeState ports the SDK v2 v0 -> v1 state upgrader. v0 stored the
+// raw canonicalised YAML strings in yaml_incluster and
+// live_manifest_incluster; v1 stores their sha256 fingerprints. The
+// upgrader simply hashes both fields if they look unhashed. The v0
+// schema was structurally identical to v1 so we reuse the v1 model for
+// decoding; only the value transform changes.
+func (r *manifestResource) UpgradeState(_ context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		0: {
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var data manifestResourceModel
+				resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+				if !data.YAMLInCluster.IsNull() && !data.YAMLInCluster.IsUnknown() {
+					data.YAMLInCluster = types.StringValue(
+						kubernetes.GetFingerprint(data.YAMLInCluster.ValueString()))
+				}
+				if !data.LiveManifestInCluster.IsNull() && !data.LiveManifestInCluster.IsUnknown() {
+					data.LiveManifestInCluster = types.StringValue(
+						kubernetes.GetFingerprint(data.LiveManifestInCluster.ValueString()))
+				}
+				resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+			},
+		},
+	}
+}
+
+// stringOneOfValidator is a small inline validator mirroring SDK v2's
+// validate.StringInSlice. Kept here to avoid pulling in the
+// terraform-plugin-framework-validators module for two call sites; if more
+// validators are needed in follow-up commits, swap to that module wholesale.
+type stringOneOfValidator struct {
+	allowed []string
+}
+
+func (v stringOneOfValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("value must be one of %v", v.allowed)
+}
+
+func (v stringOneOfValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v stringOneOfValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	got := req.ConfigValue.ValueString()
+	for _, a := range v.allowed {
+		if got == a {
+			return
+		}
+	}
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"invalid value",
+		fmt.Sprintf("expected one of %v, got %q", v.allowed, got),
+	)
+}
+
+// boolOrTrue returns the value of the bool, or true if it is null/unknown
+// (used for Optional+Computed booleans whose Default is true).
+func boolOrTrue(b types.Bool) bool {
+	if b.IsNull() || b.IsUnknown() {
+		return true
+	}
+	return b.ValueBool()
+}
+
+// stringOrDefault returns the string value, or fallback if null/unknown.
+func stringOrDefault(s types.String, fallback string) string {
+	if s.IsNull() || s.IsUnknown() {
+		return fallback
+	}
+	v := s.ValueString()
+	if v == "" {
+		return fallback
+	}
+	return v
+}

--- a/internal/framework/resource_kubectl_manifest.go
+++ b/internal/framework/resource_kubectl_manifest.go
@@ -585,6 +585,18 @@ func (r *manifestResource) ModifyPlan(ctx context.Context, req resource.ModifyPl
 		resp.RequiresReplace = append(resp.RequiresReplace, path.Root("yaml_body"))
 	}
 
+	// Enforce MaxItems = 1 on wait_for here, since the schema's ListNestedBlock
+	// cannot express it (framework limitation). Runs for both create and update
+	// plans because ModifyPlan fires for both.
+	if !plan.WaitFor.IsNull() && !plan.WaitFor.IsUnknown() && len(plan.WaitFor.Elements()) > 1 {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("wait_for"),
+			"too many wait_for blocks",
+			"only a single wait_for block is allowed (MaxItems=1)",
+		)
+		return
+	}
+
 	if plan.YAMLBody.IsUnknown() {
 		return
 	}

--- a/internal/framework/resource_kubectl_manifest_modifyplan_test.go
+++ b/internal/framework/resource_kubectl_manifest_modifyplan_test.go
@@ -1,0 +1,101 @@
+package framework
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// waitForListWith builds a wait_for list with n empty blocks (condition and
+// field both null), typed to match the schema's ListNestedBlock element.
+func waitForListWith(n int) types.List {
+	blockType := waitForObjectType()
+	condType := blockType.AttrTypes["condition"].(types.ListType).ElementType()
+	fieldType := blockType.AttrTypes["field"].(types.ListType).ElementType()
+	blocks := make([]attr.Value, 0, n)
+	for i := 0; i < n; i++ {
+		blocks = append(blocks, types.ObjectValueMust(blockType.AttrTypes, map[string]attr.Value{
+			"condition": types.ListNull(condType),
+			"field":     types.ListNull(fieldType),
+		}))
+	}
+	return types.ListValueMust(blockType, blocks)
+}
+
+// newCreatePlan builds a ModifyPlanRequest / Response pair for a create plan
+// (null prior state) carrying the given model.
+func newCreatePlan(ctx context.Context, t *testing.T, model manifestResourceModel) (resource.ModifyPlanRequest, *resource.ModifyPlanResponse) {
+	t.Helper()
+	r := &manifestResource{}
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("building schema: %+v", schemaResp.Diagnostics)
+	}
+	s := schemaResp.Schema
+	tfType := s.Type().TerraformType(ctx)
+
+	plan := tfsdk.Plan{Schema: s, Raw: tftypes.NewValue(tfType, nil)}
+	if diags := plan.Set(ctx, &model); diags.HasError() {
+		t.Fatalf("seeding plan: %+v", diags)
+	}
+	req := resource.ModifyPlanRequest{
+		Plan:  plan,
+		State: tfsdk.State{Schema: s, Raw: tftypes.NewValue(tfType, nil)},
+	}
+	resp := &resource.ModifyPlanResponse{Plan: plan}
+	return req, resp
+}
+
+func baseModel() manifestResourceModel {
+	return manifestResourceModel{
+		YAMLBody:        types.StringValue("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n"),
+		SensitiveFields: types.ListNull(types.StringType),
+		IgnoreFields:    types.ListNull(types.StringType),
+		WaitFor:         types.ListNull(waitForObjectType()),
+	}
+}
+
+// TestModifyPlan_WaitForMaxItems asserts ModifyPlan rejects more than one
+// wait_for block (MaxItems=1, which the schema cannot express) and accepts a
+// single block.
+func TestModifyPlan_WaitForMaxItems(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := &manifestResource{}
+
+	t.Run("two blocks rejected", func(t *testing.T) {
+		t.Parallel()
+		m := baseModel()
+		m.WaitFor = waitForListWith(2)
+		req, resp := newCreatePlan(ctx, t, m)
+
+		r.ModifyPlan(ctx, req, resp)
+
+		if !resp.Diagnostics.HasError() {
+			t.Fatalf("expected an error for two wait_for blocks")
+		}
+		if !strings.Contains(resp.Diagnostics.Errors()[0].Detail(), "single wait_for block") {
+			t.Errorf("unexpected diagnostic: %s", resp.Diagnostics.Errors()[0].Detail())
+		}
+	})
+
+	t.Run("one block accepted", func(t *testing.T) {
+		t.Parallel()
+		m := baseModel()
+		m.WaitFor = waitForListWith(1)
+		req, resp := newCreatePlan(ctx, t, m)
+
+		r.ModifyPlan(ctx, req, resp)
+
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("unexpected error for a single wait_for block: %+v", resp.Diagnostics)
+		}
+	})
+}

--- a/internal/framework/resource_kubectl_manifest_move.go
+++ b/internal/framework/resource_kubectl_manifest_move.go
@@ -1,0 +1,214 @@
+package framework
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Cross-provider state move support: lets practitioners migrate existing
+// gavinbunney/kubectl `kubectl_manifest` resources into this provider with a
+// Terraform 1.8+ `moved {}` block, no `terraform state replace-provider`
+// dance. See ADR-0001 and README "Migrating from gavinbunney/kubectl".
+//
+// The schema diff (work/standalone/terraform-provider-kubectl-123/data/
+// schema-diff.md) established that gavinbunney's 20 kubectl_manifest
+// attributes map 1:1 to this provider by name and type, both at
+// SchemaVersion 1. So the move is a passthrough of those 20 (plus the
+// implicit SDK v2 `id`) with the 4 alekc-only attributes taking their
+// defaults.
+
+var _ resource.ResourceWithMoveState = (*manifestResource)(nil)
+
+const (
+	// gavinbunneyManifestTypeName is the source resource type name we move
+	// from. gavinbunney and this provider share the same type name, which is
+	// exactly why a mux-server sibling type could not solve #123 and a real
+	// framework MoveState handler is required.
+	gavinbunneyManifestTypeName = "kubectl_manifest"
+
+	// gavinbunneyProviderAddressSuffix matches the source provider address in
+	// HOSTNAME/NAMESPACE/TYPE form. The hostname is intentionally ignored
+	// (per framework guidance) so a move works regardless of which registry
+	// mirror the source provider was pulled from.
+	gavinbunneyProviderAddressSuffix = "gavinbunney/kubectl"
+
+	// defaultFieldManager matches the SDK v2 field_manager default. A moved
+	// resource that never set field_manager (gavinbunney has no such
+	// attribute) adopts the same default it would get on a fresh apply.
+	defaultFieldManager = "kubectl"
+)
+
+// gavinbunneyManifestSourceModel mirrors the persisted state shape of
+// gavinbunney/kubectl's kubectl_manifest at SchemaVersion 1: the 20 shared
+// attributes plus the implicit SDK v2 `id`. The 4 alekc-only attributes
+// (upgrade_api_version, field_manager, wait_for, delete_cascade) are absent
+// from gavinbunney state and are filled with defaults on the target side.
+type gavinbunneyManifestSourceModel struct {
+	ID                    types.String `tfsdk:"id"`
+	UID                   types.String `tfsdk:"uid"`
+	LiveUID               types.String `tfsdk:"live_uid"`
+	YAMLInCluster         types.String `tfsdk:"yaml_incluster"`
+	LiveManifestInCluster types.String `tfsdk:"live_manifest_incluster"`
+	APIVersion            types.String `tfsdk:"api_version"`
+	Kind                  types.String `tfsdk:"kind"`
+	Name                  types.String `tfsdk:"name"`
+	Namespace             types.String `tfsdk:"namespace"`
+	OverrideNamespace     types.String `tfsdk:"override_namespace"`
+	YAMLBody              types.String `tfsdk:"yaml_body"`
+	YAMLBodyParsed        types.String `tfsdk:"yaml_body_parsed"`
+	SensitiveFields       types.List   `tfsdk:"sensitive_fields"`
+	ForceNew              types.Bool   `tfsdk:"force_new"`
+	ServerSideApply       types.Bool   `tfsdk:"server_side_apply"`
+	ForceConflicts        types.Bool   `tfsdk:"force_conflicts"`
+	ApplyOnly             types.Bool   `tfsdk:"apply_only"`
+	IgnoreFields          types.List   `tfsdk:"ignore_fields"`
+	Wait                  types.Bool   `tfsdk:"wait"`
+	WaitForRollout        types.Bool   `tfsdk:"wait_for_rollout"`
+	ValidateSchema        types.Bool   `tfsdk:"validate_schema"`
+}
+
+// gavinbunneyManifestSourceSchema is the source schema handed to the
+// framework so it can decode SourceRawState into a typed SourceState. Only
+// the attribute types matter for decoding; the Optional/Computed flags are
+// cosmetic here. The framework decodes with IgnoreUndefinedAttributes, so any
+// attribute gavinbunney might add in a future release is silently dropped
+// rather than breaking the move.
+func gavinbunneyManifestSourceSchema() *schema.Schema {
+	str := schema.StringAttribute{Optional: true, Computed: true}
+	b := schema.BoolAttribute{Optional: true, Computed: true}
+	strList := schema.ListAttribute{Optional: true, Computed: true, ElementType: types.StringType}
+	return &schema.Schema{
+		Version: 1,
+		Attributes: map[string]schema.Attribute{
+			"id":                      str,
+			"uid":                     str,
+			"live_uid":                str,
+			"yaml_incluster":          str,
+			"live_manifest_incluster": str,
+			"api_version":             str,
+			"kind":                    str,
+			"name":                    str,
+			"namespace":               str,
+			"override_namespace":      str,
+			"yaml_body":               str,
+			"yaml_body_parsed":        str,
+			"sensitive_fields":        strList,
+			"force_new":               b,
+			"server_side_apply":       b,
+			"force_conflicts":         b,
+			"apply_only":              b,
+			"ignore_fields":           strList,
+			"wait":                    b,
+			"wait_for_rollout":        b,
+			"validate_schema":         b,
+		},
+	}
+}
+
+// waitForObjectType is the attr.Type of a single wait_for block element,
+// matching the ListNestedBlock declared in Schema(). Used to build a
+// correctly-typed null list for resources moved from gavinbunney (which has
+// no wait_for attribute).
+func waitForObjectType() types.ObjectType {
+	conditionObj := types.ObjectType{AttrTypes: map[string]attr.Type{
+		"type":   types.StringType,
+		"status": types.StringType,
+	}}
+	fieldObj := types.ObjectType{AttrTypes: map[string]attr.Type{
+		"key":        types.StringType,
+		"value":      types.StringType,
+		"value_type": types.StringType,
+	}}
+	return types.ObjectType{AttrTypes: map[string]attr.Type{
+		"condition": types.ListType{ElemType: conditionObj},
+		"field":     types.ListType{ElemType: fieldObj},
+	}}
+}
+
+// MoveState returns the ordered list of cross-provider state movers. Only one
+// source is supported today: gavinbunney/kubectl's kubectl_manifest.
+func (r *manifestResource) MoveState(_ context.Context) []resource.StateMover {
+	return []resource.StateMover{
+		{
+			SourceSchema: gavinbunneyManifestSourceSchema(),
+			StateMover:   moveFromGavinbunneyManifest,
+		},
+	}
+}
+
+// moveFromGavinbunneyManifest transforms a gavinbunney/kubectl kubectl_manifest
+// state into this provider's state. It is deliberately cautious: if the source
+// type name or provider address does not match, it returns an unmodified
+// response so the framework treats this mover as skipped (per StateMover
+// contract). Only once both match does it commit to producing state or an
+// error.
+func moveFromGavinbunneyManifest(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+	if req.SourceTypeName != gavinbunneyManifestTypeName {
+		return
+	}
+	if !strings.HasSuffix(req.SourceProviderAddress, gavinbunneyProviderAddressSuffix) {
+		return
+	}
+
+	// From here the request is unambiguously ours, so a failure must surface
+	// as an error rather than a silent skip (a silent skip would make the
+	// framework report "implementation not found", masking the real cause).
+	if req.SourceState == nil {
+		resp.Diagnostics.AddError(
+			"Unable to move kubectl_manifest from gavinbunney/kubectl",
+			"The source state could not be decoded against the expected gavinbunney schema "+
+				"(schema version "+strconv.FormatInt(req.SourceSchemaVersion, 10)+"). This provider supports "+
+				"moving from gavinbunney/kubectl kubectl_manifest at schema version 1. "+
+				"Check the terraform-provider-kubectl debug log for the underlying decode error.",
+		)
+		return
+	}
+
+	var src gavinbunneyManifestSourceModel
+	resp.Diagnostics.Append(req.SourceState.Get(ctx, &src)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Passthrough of the 20 shared attributes plus id. The 4 alekc-only
+	// attributes take their schema defaults: upgrade_api_version=false
+	// (matches gavinbunney's always-recreate-on-api_version behaviour being
+	// the conservative default), field_manager="kubectl", and wait_for /
+	// delete_cascade null (unset, no-op).
+	target := manifestResourceModel{
+		ID:                    src.ID,
+		UID:                   src.UID,
+		LiveUID:               src.LiveUID,
+		YAMLInCluster:         src.YAMLInCluster,
+		LiveManifestInCluster: src.LiveManifestInCluster,
+		APIVersion:            src.APIVersion,
+		Kind:                  src.Kind,
+		Name:                  src.Name,
+		Namespace:             src.Namespace,
+		OverrideNamespace:     src.OverrideNamespace,
+		YAMLBody:              src.YAMLBody,
+		YAMLBodyParsed:        src.YAMLBodyParsed,
+		SensitiveFields:       src.SensitiveFields,
+		ForceNew:              src.ForceNew,
+		ServerSideApply:       src.ServerSideApply,
+		ForceConflicts:        src.ForceConflicts,
+		ApplyOnly:             src.ApplyOnly,
+		IgnoreFields:          src.IgnoreFields,
+		Wait:                  src.Wait,
+		WaitForRollout:        src.WaitForRollout,
+		ValidateSchema:        src.ValidateSchema,
+
+		UpgradeAPIVersion: types.BoolValue(false),
+		FieldManager:      types.StringValue(defaultFieldManager),
+		DeleteCascade:     types.StringNull(),
+		WaitFor:           types.ListNull(waitForObjectType()),
+	}
+
+	resp.Diagnostics.Append(resp.TargetState.Set(ctx, &target)...)
+}

--- a/internal/framework/resource_kubectl_manifest_move.go
+++ b/internal/framework/resource_kubectl_manifest_move.go
@@ -159,6 +159,18 @@ func moveFromGavinbunneyManifest(ctx context.Context, req resource.MoveStateRequ
 	// From here the request is unambiguously ours, so a failure must surface
 	// as an error rather than a silent skip (a silent skip would make the
 	// framework report "implementation not found", masking the real cause).
+
+	// gavinbunneyManifestSourceSchema is Version 1. Refuse any other source
+	// schema version rather than decoding an incompatible shape against it.
+	if req.SourceSchemaVersion != 1 {
+		resp.Diagnostics.AddError(
+			"Unable to move kubectl_manifest from gavinbunney/kubectl",
+			"Unsupported source schema version "+strconv.FormatInt(req.SourceSchemaVersion, 10)+". "+
+				"This provider can only move from gavinbunney/kubectl kubectl_manifest at schema version 1.",
+		)
+		return
+	}
+
 	if req.SourceState == nil {
 		resp.Diagnostics.AddError(
 			"Unable to move kubectl_manifest from gavinbunney/kubectl",

--- a/internal/framework/resource_kubectl_manifest_move_test.go
+++ b/internal/framework/resource_kubectl_manifest_move_test.go
@@ -170,6 +170,28 @@ func TestMoveFromGavinbunney_Skips(t *testing.T) {
 	}
 }
 
+// TestMoveFromGavinbunney_UnsupportedSchemaVersion asserts that a matched
+// request with a source schema version other than 1 is rejected with an
+// error rather than decoded against the version-1 source schema.
+func TestMoveFromGavinbunney_UnsupportedSchemaVersion(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	req := resource.MoveStateRequest{
+		SourceTypeName:        gavinbunneyManifestTypeName,
+		SourceProviderAddress: "registry.terraform.io/gavinbunney/kubectl",
+		SourceSchemaVersion:   2,
+		SourceState:           newSourceState(ctx, t, sampleGavinbunneySource()),
+	}
+	resp := &resource.MoveStateResponse{TargetState: newTargetState(ctx, t)}
+
+	moveFromGavinbunneyManifest(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected an error diagnostic for unsupported source schema version")
+	}
+}
+
 // TestMoveFromGavinbunney_MatchedButNilSource asserts that once the type name
 // and provider address match, a nil SourceState is a hard error (not a silent
 // skip), so the practitioner sees a real message instead of "implementation

--- a/internal/framework/resource_kubectl_manifest_move_test.go
+++ b/internal/framework/resource_kubectl_manifest_move_test.go
@@ -1,0 +1,194 @@
+package framework
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// newSourceState builds a tfsdk.State bound to the gavinbunney source schema
+// and populated from src, mimicking what the framework hands a StateMover
+// when SourceSchema is set.
+func newSourceState(ctx context.Context, t *testing.T, src gavinbunneyManifestSourceModel) *tfsdk.State {
+	t.Helper()
+	srcSchema := gavinbunneyManifestSourceSchema()
+	state := &tfsdk.State{
+		Schema: *srcSchema,
+		Raw:    tftypes.NewValue(srcSchema.Type().TerraformType(ctx), nil),
+	}
+	if diags := state.Set(ctx, &src); diags.HasError() {
+		t.Fatalf("seeding source state: %+v", diags)
+	}
+	return state
+}
+
+// newTargetState builds an empty tfsdk.State bound to the real resource
+// schema, mimicking the framework's pre-population of MoveStateResponse.
+func newTargetState(ctx context.Context, t *testing.T) tfsdk.State {
+	t.Helper()
+	r := &manifestResource{}
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("building target schema: %+v", schemaResp.Diagnostics)
+	}
+	return tfsdk.State{
+		Schema: schemaResp.Schema,
+		Raw:    tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), nil),
+	}
+}
+
+func sampleGavinbunneySource() gavinbunneyManifestSourceModel {
+	return gavinbunneyManifestSourceModel{
+		ID:                    types.StringValue("/api/v1/namespaces/default/configmaps/demo"),
+		UID:                   types.StringValue("uid-abc"),
+		LiveUID:               types.StringValue("uid-abc"),
+		YAMLInCluster:         types.StringValue("fp-1"),
+		LiveManifestInCluster: types.StringValue("fp-1"),
+		APIVersion:            types.StringValue("v1"),
+		Kind:                  types.StringValue("ConfigMap"),
+		Name:                  types.StringValue("demo"),
+		Namespace:             types.StringValue("default"),
+		OverrideNamespace:     types.StringNull(),
+		YAMLBody:              types.StringValue("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n"),
+		YAMLBodyParsed:        types.StringValue("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\n"),
+		SensitiveFields:       types.ListValueMust(types.StringType, []attr.Value{}),
+		ForceNew:              types.BoolValue(false),
+		ServerSideApply:       types.BoolValue(true),
+		ForceConflicts:        types.BoolValue(false),
+		ApplyOnly:             types.BoolValue(false),
+		IgnoreFields:          types.ListValueMust(types.StringType, []attr.Value{types.StringValue("status")}),
+		Wait:                  types.BoolValue(false),
+		WaitForRollout:        types.BoolValue(true),
+		ValidateSchema:        types.BoolValue(true),
+	}
+}
+
+// TestMoveFromGavinbunney_HappyPath asserts the 20 shared attributes pass
+// through verbatim, id is preserved, and the 4 alekc-only attributes take
+// their documented defaults.
+func TestMoveFromGavinbunney_HappyPath(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	req := resource.MoveStateRequest{
+		SourceTypeName:        gavinbunneyManifestTypeName,
+		SourceProviderAddress: "registry.terraform.io/gavinbunney/kubectl",
+		SourceSchemaVersion:   1,
+		SourceState:           newSourceState(ctx, t, sampleGavinbunneySource()),
+	}
+	resp := &resource.MoveStateResponse{TargetState: newTargetState(ctx, t)}
+
+	moveFromGavinbunneyManifest(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
+	}
+
+	var got manifestResourceModel
+	if diags := resp.TargetState.Get(ctx, &got); diags.HasError() {
+		t.Fatalf("reading target state: %+v", diags)
+	}
+
+	// Shared passthrough spot-checks.
+	if got.ID.ValueString() != "/api/v1/namespaces/default/configmaps/demo" {
+		t.Errorf("id not preserved: %q", got.ID.ValueString())
+	}
+	if got.UID.ValueString() != "uid-abc" {
+		t.Errorf("uid not preserved: %q", got.UID.ValueString())
+	}
+	if got.Kind.ValueString() != "ConfigMap" {
+		t.Errorf("kind not preserved: %q", got.Kind.ValueString())
+	}
+	if !got.ServerSideApply.ValueBool() {
+		t.Errorf("server_side_apply not preserved")
+	}
+	if got.IgnoreFields.IsNull() || len(got.IgnoreFields.Elements()) != 1 {
+		t.Errorf("ignore_fields not preserved: %+v", got.IgnoreFields)
+	}
+
+	// alekc-only defaults.
+	if got.UpgradeAPIVersion.ValueBool() != false {
+		t.Errorf("upgrade_api_version default: got %v, want false", got.UpgradeAPIVersion.ValueBool())
+	}
+	if got.FieldManager.ValueString() != defaultFieldManager {
+		t.Errorf("field_manager default: got %q, want %q", got.FieldManager.ValueString(), defaultFieldManager)
+	}
+	if !got.DeleteCascade.IsNull() {
+		t.Errorf("delete_cascade should be null, got %q", got.DeleteCascade.ValueString())
+	}
+	if !got.WaitFor.IsNull() {
+		t.Errorf("wait_for should be null, got %+v", got.WaitFor)
+	}
+}
+
+// TestMoveFromGavinbunney_Skips asserts the mover stays silent (no state, no
+// diagnostics) when the source is not gavinbunney/kubectl kubectl_manifest, so
+// the framework can try other movers.
+func TestMoveFromGavinbunney_Skips(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cases := []struct {
+		name     string
+		typeName string
+		address  string
+	}{
+		{"wrong type name", "kubectl_server_version", "registry.terraform.io/gavinbunney/kubectl"},
+		{"wrong provider", gavinbunneyManifestTypeName, "registry.terraform.io/hashicorp/kubernetes"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := resource.MoveStateRequest{
+				SourceTypeName:        tc.typeName,
+				SourceProviderAddress: tc.address,
+				SourceSchemaVersion:   1,
+				SourceState:           newSourceState(ctx, t, sampleGavinbunneySource()),
+			}
+			target := newTargetState(ctx, t)
+			resp := &resource.MoveStateResponse{TargetState: target}
+
+			moveFromGavinbunneyManifest(ctx, req, resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Errorf("expected no diagnostics on skip, got %+v", resp.Diagnostics)
+			}
+			// A skipped mover must leave the target state untouched (still the
+			// all-null object the framework pre-populated).
+			if !resp.TargetState.Raw.Equal(target.Raw) {
+				t.Errorf("expected target state untouched on skip")
+			}
+		})
+	}
+}
+
+// TestMoveFromGavinbunney_MatchedButNilSource asserts that once the type name
+// and provider address match, a nil SourceState is a hard error (not a silent
+// skip), so the practitioner sees a real message instead of "implementation
+// not found".
+func TestMoveFromGavinbunney_MatchedButNilSource(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	req := resource.MoveStateRequest{
+		SourceTypeName:        gavinbunneyManifestTypeName,
+		SourceProviderAddress: "registry.terraform.io/gavinbunney/kubectl",
+		SourceSchemaVersion:   1,
+		SourceState:           nil,
+	}
+	resp := &resource.MoveStateResponse{TargetState: newTargetState(ctx, t)}
+
+	moveFromGavinbunneyManifest(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected an error diagnostic for matched request with nil source state")
+	}
+}

--- a/internal/framework/resource_kubectl_manifest_test.go
+++ b/internal/framework/resource_kubectl_manifest_test.go
@@ -1,0 +1,82 @@
+package framework
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+// TestManifestResource_SchemaShape verifies the Schema() call returns a
+// well-formed schema with the expected attribute count, attribute names,
+// the wait_for block, and Version: 1 to match the SDK v2 schema's
+// SchemaVersion. Fails fast if a future commit accidentally drops or
+// renames any attribute.
+func TestManifestResource_SchemaShape(t *testing.T) {
+	t.Parallel()
+
+	r := NewManifestResource()
+
+	mdResp := &resource.MetadataResponse{}
+	r.Metadata(context.Background(), resource.MetadataRequest{ProviderTypeName: "kubectl"}, mdResp)
+	if mdResp.TypeName != "kubectl_manifest" {
+		t.Fatalf("Metadata TypeName: got %q, want %q", mdResp.TypeName, "kubectl_manifest")
+	}
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(context.Background(), resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("Schema returned diagnostics: %+v", schemaResp.Diagnostics)
+	}
+
+	s := schemaResp.Schema
+	if s.Version != 1 {
+		t.Fatalf("Schema Version: got %d, want 1", s.Version)
+	}
+
+	// 24 attributes total (id + the 23 mirrored from SDK v2). wait_for is
+	// modelled as a Block, not an Attribute (matches SDK v2's TypeList +
+	// nested Resource shape), so it appears in s.Blocks instead.
+	wantAttrs := []string{
+		"id", "uid", "live_uid", "yaml_incluster", "live_manifest_incluster",
+		"api_version", "kind", "name", "namespace", "override_namespace",
+		"yaml_body", "yaml_body_parsed", "sensitive_fields", "force_new",
+		"upgrade_api_version", "server_side_apply", "field_manager",
+		"force_conflicts", "apply_only", "ignore_fields", "wait",
+		"wait_for_rollout", "validate_schema", "delete_cascade",
+	}
+	for _, name := range wantAttrs {
+		if _, ok := s.Attributes[name]; !ok {
+			t.Errorf("Schema.Attributes missing %q", name)
+		}
+	}
+	if len(s.Attributes) != len(wantAttrs) {
+		t.Errorf("Schema.Attributes count: got %d, want %d (extras: %v)",
+			len(s.Attributes), len(wantAttrs), extraAttrs(s.Attributes, wantAttrs))
+	}
+
+	if _, ok := s.Blocks["wait_for"]; !ok {
+		t.Errorf("Schema.Blocks missing %q", "wait_for")
+	}
+	if len(s.Blocks) != 1 {
+		t.Errorf("Schema.Blocks count: got %d, want 1", len(s.Blocks))
+	}
+}
+
+// extraAttrs returns the attribute names present in got but not in want, so
+// the failure message points at the actual drift rather than just a count
+// mismatch.
+func extraAttrs[T any](got map[string]T, want []string) []string {
+	expected := make(map[string]struct{}, len(want))
+	for _, n := range want {
+		expected[n] = struct{}{}
+	}
+	var extras []string
+	for n := range got {
+		if _, ok := expected[n]; !ok {
+			extras = append(extras, n)
+		}
+	}
+	return extras
+}
+

--- a/kubernetes/manifest_fetch.go
+++ b/kubernetes/manifest_fetch.go
@@ -54,7 +54,7 @@ func FetchManifest(
 	}
 	manifest := yaml.NewFromUnstructured(lookup)
 
-	clientResult := getRestClientFromUnstructured(manifest, provider)
+	clientResult := GetRestClientFromUnstructured(manifest, provider)
 	if clientResult.Error != nil {
 		return nil, clientResult.Error
 	}

--- a/kubernetes/manifest_lifecycle.go
+++ b/kubernetes/manifest_lifecycle.go
@@ -1,0 +1,356 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/alekc/terraform-provider-kubectl/internal/types"
+	"github.com/alekc/terraform-provider-kubectl/yaml"
+	"k8s.io/apimachinery/pkg/api/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	meta_v1_unstruct "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/printers"
+	k8sresource "k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/dynamic"
+	k8sdelete "k8s.io/kubectl/pkg/cmd/delete"
+	"k8s.io/kubectl/pkg/validation"
+	yamlWriter "sigs.k8s.io/yaml"
+)
+
+// manifest_lifecycle.go: pure-function implementations of the
+// kubectl_manifest CRUD lifecycle. Each function takes a struct of plain
+// inputs and returns a struct of plain outputs, so the caller (SDK v2
+// *schema.ResourceData or plugin-framework state) handles its own state
+// shaping. Used by both halves of the muxed provider during the v2 -> v3
+// framework migration (issue #295).
+
+// ApplyManifestOptions captures everything ApplyManifest reads from the
+// caller. All fields are plain types so the framework half can construct
+// the options without depending on the SDK v2 schema package.
+type ApplyManifestOptions struct {
+	YAMLBody          string
+	OverrideNamespace string // "" means use the namespace from yaml_body
+	ValidateSchema    bool   // pass false to skip schema validation
+	ServerSideApply   bool
+	FieldManager      string // only consulted if ServerSideApply
+	ForceConflicts    bool   // only consulted if ServerSideApply
+	WaitForRollout    bool
+	WaitFor           *types.WaitFor // nil if no wait_for block
+	Timeout           time.Duration  // applies to wait_for_rollout and wait_for
+	IgnoreFields      []string       // for fingerprint calc
+}
+
+// ApplyManifestResult captures everything the caller needs to write back
+// to state after a successful apply. All five values must be persisted.
+type ApplyManifestResult struct {
+	SelfLink                         string
+	UID                              string // from the apply response
+	LiveUID                          string // from the post-wait read
+	YAMLInClusterFingerprint         string // from the apply response
+	LiveManifestInClusterFingerprint string // from the post-wait read
+}
+
+// ApplyManifest runs `kubectl apply` against the given manifest, optionally
+// waits for rollout / user-supplied conditions, and returns the final state
+// the caller should persist.
+//
+// Errors are returned verbatim; the caller is responsible for wrapping
+// them in framework / SDK v2 diagnostics.
+func ApplyManifest(ctx context.Context, provider *KubeProvider, opts ApplyManifestOptions) (*ApplyManifestResult, error) {
+	manifest, err := yaml.ParseYAML(opts.YAMLBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse kubernetes resource: %+v", err)
+	}
+	if opts.OverrideNamespace != "" {
+		manifest.SetNamespace(opts.OverrideNamespace)
+	}
+
+	log.Printf("[DEBUG] %v apply kubernetes resource:\n%s", manifest, opts.YAMLBody)
+
+	restClient := GetRestClientFromUnstructured(manifest, provider)
+	if restClient.Error != nil {
+		return nil, fmt.Errorf("%v failed to create kubernetes rest client for update of resource: %+v", manifest, restClient.Error)
+	}
+
+	// Re-serialise after the namespace override so the temp file matches
+	// what we'll be diffing against the live state.
+	yamlBody, err := manifest.AsYAML()
+	if err != nil {
+		return nil, fmt.Errorf("%v failed to convert to yaml: %+v", manifest, err)
+	}
+
+	tmpfile, _ := os.CreateTemp("", "*kubectl_manifest.yaml")
+	_, _ = tmpfile.Write([]byte(yamlBody))
+	_ = tmpfile.Close()
+	defer os.Remove(tmpfile.Name())
+
+	applyOptions := NewApplyOptions(yamlBody)
+	applyOptions.Builder = k8sresource.NewBuilder(k8sresource.RESTClientGetter(provider))
+	applyOptions.DeleteOptions = &k8sdelete.DeleteOptions{
+		FilenameOptions: k8sresource.FilenameOptions{
+			Filenames: []string{tmpfile.Name()},
+		},
+	}
+	applyOptions.ToPrinter = func(string) (printers.ResourcePrinter, error) {
+		return printers.NewDiscardingPrinter(), nil
+	}
+	if !opts.ValidateSchema {
+		applyOptions.Validator = validation.NullSchema{}
+	}
+	if opts.ServerSideApply {
+		applyOptions.ServerSideApply = true
+		applyOptions.FieldManager = opts.FieldManager
+	}
+	if opts.ForceConflicts {
+		applyOptions.ForceConflicts = true
+	}
+	if manifest.HasNamespace() {
+		applyOptions.Namespace = manifest.GetNamespace()
+	}
+	// Reference genericclioptions to keep the import meaningful even if a
+	// future refactor drops some of the fields above; the apply options
+	// constructor itself uses the package internally.
+	_ = genericclioptions.NoopRecorder{}
+
+	log.Printf("[INFO] %s perform apply of manifest", manifest)
+
+	if err := applyOptions.Run(); err != nil {
+		return nil, fmt.Errorf("%v failed to run apply: %+v", manifest, err)
+	}
+
+	log.Printf("[INFO] %v manifest applied, fetch resource from kubernetes", manifest)
+
+	rawResponse, err := restClient.ResourceInterface.Get(ctx, manifest.GetName(), meta_v1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("%v failed to fetch resource from kubernetes: %+v", manifest, err)
+	}
+	response := yaml.NewFromUnstructured(rawResponse)
+
+	result := &ApplyManifestResult{
+		SelfLink:                         response.GetSelfLink(),
+		UID:                              string(response.GetUID()),
+		LiveUID:                          string(response.GetUID()),
+		YAMLInClusterFingerprint:         GetLiveManifestFields(opts.IgnoreFields, manifest, response),
+		LiveManifestInClusterFingerprint: GetLiveManifestFields(opts.IgnoreFields, manifest, response),
+	}
+
+	if opts.WaitForRollout {
+		switch {
+		case manifest.GetKind() == "Deployment":
+			log.Printf("[INFO] %v waiting for Deployment rollout for %vmin", manifest, opts.Timeout.Minutes())
+			if err := WaitForDeploymentRollout(ctx, provider, manifest.GetNamespace(), manifest.GetName(), opts.Timeout); err != nil {
+				return nil, err
+			}
+		case manifest.GetKind() == "DaemonSet":
+			log.Printf("[INFO] %v waiting for DaemonSet rollout for %vmin", manifest, opts.Timeout.Minutes())
+			if err := WaitForDaemonSetRollout(ctx, provider, manifest.GetNamespace(), manifest.GetName(), opts.Timeout); err != nil {
+				return nil, err
+			}
+		case manifest.GetKind() == "StatefulSet":
+			log.Printf("[INFO] %v waiting for StatefulSet rollout for %vmin", manifest, opts.Timeout.Minutes())
+			if err := WaitForStatefulSetRollout(ctx, provider, manifest.GetNamespace(), manifest.GetName(), opts.Timeout); err != nil {
+				return nil, err
+			}
+		case manifest.GetKind() == "APIService" && manifest.GetAPIVersion() == "apiregistration.k8s.io/v1":
+			log.Printf("[INFO] %v waiting for APIService for %vmin", manifest, opts.Timeout.Minutes())
+			if err := WaitForApiService(ctx, provider, manifest.GetName(), opts.Timeout); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if opts.WaitFor != nil {
+		if len(opts.WaitFor.Field) == 0 && len(opts.WaitFor.Condition) == 0 {
+			return nil, fmt.Errorf("at least one of `field` or `condition` must be provided in `wait_for` block")
+		}
+		log.Printf("[INFO] %v waiting for wait conditions for %vmin", manifest, opts.Timeout.Minutes())
+		if err := WaitForConditions(ctx, restClient, opts.WaitFor.Field, opts.WaitFor.Condition, manifest.GetName(), opts.Timeout); err != nil {
+			return nil, err
+		}
+	}
+
+	// Re-read after waits so live_uid and live_manifest_incluster reflect
+	// any post-wait drift the controllers introduced (status fields, etc.).
+	readResult, err := readManifestUsingClient(ctx, restClient.ResourceInterface, manifest, opts.IgnoreFields) //nolint:contextcheck // ctx is the apply ctx, intentionally reused for the post-wait read
+	if err != nil {
+		return nil, err
+	}
+	if readResult.Found {
+		result.LiveUID = readResult.LiveUID
+		result.LiveManifestInClusterFingerprint = readResult.LiveManifestInClusterFingerprint
+	}
+
+	return result, nil
+}
+
+// ReadManifestOptions captures everything ReadManifest reads from the
+// caller. All fields are plain types.
+type ReadManifestOptions struct {
+	YAMLBody          string
+	OverrideNamespace string
+	IgnoreFields      []string
+}
+
+// ReadManifestResult captures the live state observed during a Read.
+// Found = false means the resource no longer exists in the cluster; the
+// caller should clear it from state.
+type ReadManifestResult struct {
+	Found                            bool
+	InvalidType                      bool // RestClientInvalidTypeError
+	LiveUID                          string
+	LiveManifestInClusterFingerprint string
+}
+
+// ReadManifest fetches the current state of the manifest from the cluster
+// and returns the live UID and fingerprint. Not-found is signalled via
+// Found = false rather than an error so the caller can clear state cleanly.
+func ReadManifest(ctx context.Context, provider *KubeProvider, opts ReadManifestOptions) (*ReadManifestResult, error) {
+	manifest, err := yaml.ParseYAML(opts.YAMLBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse kubernetes resource: %+v", err)
+	}
+	if opts.OverrideNamespace != "" {
+		manifest.SetNamespace(opts.OverrideNamespace)
+	}
+
+	restClient := GetRestClientFromUnstructured(manifest, provider)
+	if restClient.Status == RestClientInvalidTypeError {
+		return &ReadManifestResult{Found: false, InvalidType: true}, nil
+	}
+	if restClient.Error != nil {
+		return nil, fmt.Errorf("failed to create kubernetes rest client for read of resource: %+v", restClient.Error)
+	}
+
+	return readManifestUsingClient(ctx, restClient.ResourceInterface, manifest, opts.IgnoreFields)
+}
+
+// readManifestUsingClient is the inner Read used both by ReadManifest and
+// by ApplyManifest's post-wait re-read. Takes an already-resolved client
+// so the apply path can reuse the one it built.
+func readManifestUsingClient(ctx context.Context, client dynamic.ResourceInterface, manifest *yaml.Manifest, ignoreFields []string) (*ReadManifestResult, error) {
+	rawResponse, err := client.Get(ctx, manifest.GetName(), meta_v1.GetOptions{})
+	if err != nil {
+		if errors.IsGone(err) || errors.IsNotFound(err) {
+			return &ReadManifestResult{Found: false}, nil
+		}
+		return nil, fmt.Errorf("%v failed to get resource from kubernetes: %+v", manifest, err)
+	}
+	if rawResponse.GetUID() == "" {
+		return nil, fmt.Errorf("%v failed to parse item and get UUID: %+v", manifest, rawResponse)
+	}
+
+	live := yaml.NewFromUnstructured(rawResponse)
+	return &ReadManifestResult{
+		Found:                            true,
+		LiveUID:                          string(live.GetUID()),
+		LiveManifestInClusterFingerprint: GetLiveManifestFields(ignoreFields, manifest, live),
+	}, nil
+}
+
+// BuildObfuscatedYAML returns the manifest with any field listed in
+// sensitiveFields (or, for Kind: Secret apiVersion: v1, "data" and
+// "stringData" by default) replaced by the literal `(sensitive value)`
+// string. Useful for surfacing a plan-friendly representation of the
+// manifest that does not leak secret values into Terraform plan output.
+//
+// Only map values are supported; passing a sensitiveFields path that
+// resolves to a non-map returns an error.
+func BuildObfuscatedYAML(yamlBody, overrideNamespace string, sensitiveFields []string) (string, error) {
+	obfuscated, err := yaml.ParseYAML(yamlBody)
+	if err != nil {
+		return "", err
+	}
+	if obfuscated.Raw.Object == nil {
+		obfuscated.Raw.Object = make(map[string]interface{})
+	}
+	if overrideNamespace != "" {
+		obfuscated.SetNamespace(overrideNamespace)
+	}
+	fields := sensitiveFields
+	if len(fields) == 0 && obfuscated.GetKind() == "Secret" && obfuscated.GetAPIVersion() == "v1" {
+		fields = []string{"data", "stringData"}
+	}
+	for _, s := range fields {
+		path := strings.Split(s, ".")
+		_, exists, lookupErr := meta_v1_unstruct.NestedFieldNoCopy(obfuscated.Raw.Object, path...)
+		if lookupErr != nil {
+			return "", fmt.Errorf("failed to access sensitive field %q: %v", s, lookupErr)
+		}
+		if !exists {
+			log.Printf("[TRACE] sensitive field %s skipped, does not exist", s)
+			continue
+		}
+		if setErr := meta_v1_unstruct.SetNestedField(obfuscated.Raw.Object, "(sensitive value)", path...); setErr != nil {
+			return "", fmt.Errorf("failed to obfuscate sensitive field %q: %v (only map values are supported)", s, setErr)
+		}
+	}
+	out, marshalErr := yamlWriter.Marshal(obfuscated.Raw.Object)
+	if marshalErr != nil {
+		return "", fmt.Errorf("failed to serialise obfuscated yaml: %v", marshalErr)
+	}
+	return string(out), nil
+}
+
+// DeleteManifestOptions captures everything DeleteManifest reads from the
+// caller.
+type DeleteManifestOptions struct {
+	YAMLBody          string
+	OverrideNamespace string
+	ApplyOnly         bool
+	Wait              bool
+	DeleteCascade     string // "Background" | "Foreground" | "" (auto)
+	Timeout           time.Duration
+}
+
+// DeleteManifest deletes the manifest from the cluster and (optionally)
+// waits for it to disappear. ApplyOnly = true makes this a no-op.
+func DeleteManifest(ctx context.Context, provider *KubeProvider, opts DeleteManifestOptions) error {
+	if opts.ApplyOnly {
+		return nil
+	}
+	manifest, err := yaml.ParseYAML(opts.YAMLBody)
+	if err != nil {
+		return fmt.Errorf("failed to parse kubernetes resource: %+v", err)
+	}
+	if opts.OverrideNamespace != "" {
+		manifest.SetNamespace(opts.OverrideNamespace)
+	}
+
+	log.Printf("[DEBUG] %v delete kubernetes resource:\n%s", manifest, opts.YAMLBody)
+
+	restClient := GetRestClientFromUnstructured(manifest, provider)
+	if restClient.Error != nil {
+		return fmt.Errorf("%v failed to create kubernetes rest client for delete of resource: %+v", manifest, restClient.Error)
+	}
+
+	log.Printf("[INFO] %s perform delete of manifest", manifest)
+
+	var propagationPolicy meta_v1.DeletionPropagation
+	if len(opts.DeleteCascade) > 0 {
+		propagationPolicy = meta_v1.DeletionPropagation(opts.DeleteCascade)
+	} else if opts.Wait {
+		propagationPolicy = meta_v1.DeletePropagationForeground
+	} else {
+		propagationPolicy = meta_v1.DeletePropagationBackground
+	}
+
+	err = restClient.ResourceInterface.Delete(ctx, manifest.GetName(), meta_v1.DeleteOptions{PropagationPolicy: &propagationPolicy})
+	resourceGone := errors.IsGone(err) || errors.IsNotFound(err)
+	if err != nil && !resourceGone {
+		return fmt.Errorf("%v failed to delete kubernetes resource: %+v", manifest, err)
+	}
+
+	if opts.Wait && !resourceGone {
+		log.Printf("[INFO] %s waiting for delete of manifest to complete", manifest)
+		if err := WaitForDelete(ctx, restClient, manifest.GetName(), opts.Timeout); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/kubernetes/manifest_lifecycle.go
+++ b/kubernetes/manifest_lifecycle.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	meta_v1_unstruct "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	k8sresource "k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/dynamic"
@@ -84,10 +83,21 @@ func ApplyManifest(ctx context.Context, provider *KubeProvider, opts ApplyManife
 		return nil, fmt.Errorf("%v failed to convert to yaml: %+v", manifest, err)
 	}
 
-	tmpfile, _ := os.CreateTemp("", "*kubectl_manifest.yaml")
-	_, _ = tmpfile.Write([]byte(yamlBody))
-	_ = tmpfile.Close()
-	defer os.Remove(tmpfile.Name())
+	tmpfile, err := os.CreateTemp("", "*kubectl_manifest.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("%v failed to create temp file for apply: %+v", manifest, err)
+	}
+	defer func() {
+		if rmErr := os.Remove(tmpfile.Name()); rmErr != nil {
+			log.Printf("[WARN] failed to remove temp file %s: %v", tmpfile.Name(), rmErr)
+		}
+	}()
+	if _, err := tmpfile.Write([]byte(yamlBody)); err != nil {
+		return nil, fmt.Errorf("%v failed to write temp file for apply: %+v", manifest, err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		return nil, fmt.Errorf("%v failed to close temp file for apply: %+v", manifest, err)
+	}
 
 	applyOptions := NewApplyOptions(yamlBody)
 	applyOptions.Builder = k8sresource.NewBuilder(k8sresource.RESTClientGetter(provider))
@@ -112,10 +122,6 @@ func ApplyManifest(ctx context.Context, provider *KubeProvider, opts ApplyManife
 	if manifest.HasNamespace() {
 		applyOptions.Namespace = manifest.GetNamespace()
 	}
-	// Reference genericclioptions to keep the import meaningful even if a
-	// future refactor drops some of the fields above; the apply options
-	// constructor itself uses the package internally.
-	_ = genericclioptions.NoopRecorder{}
 
 	log.Printf("[INFO] %s perform apply of manifest", manifest)
 

--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -6,14 +6,12 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
-	"os"
 	"regexp"
 	"sort"
 	"strings"
 	"time"
 
 	"k8s.io/cli-runtime/pkg/genericiooptions"
-	k8sdelete "k8s.io/kubectl/pkg/cmd/delete"
 
 	"github.com/alekc/terraform-provider-kubectl/flatten"
 	"github.com/alekc/terraform-provider-kubectl/internal/types"
@@ -27,14 +25,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/kubectl/pkg/scheme"
-	"k8s.io/kubectl/pkg/validation"
 
 	backoff "github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	apiMachineryTypes "k8s.io/apimachinery/pkg/types"
-	k8sresource "k8s.io/cli-runtime/pkg/resource"
 	apiregistration "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"k8s.io/kubectl/pkg/cmd/apply"
 
@@ -44,7 +39,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	meta_v1_unstruct "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
-	yamlWriter "sigs.k8s.io/yaml"
 
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
@@ -171,7 +165,7 @@ metadata:
 				if err != nil {
 					return nil, err
 				}
-				restClient := getRestClientFromUnstructured(manifest, meta.(*KubeProvider))
+				restClient := GetRestClientFromUnstructured(manifest, meta.(*KubeProvider))
 
 				if restClient.Error != nil {
 					return []*schema.ResourceData{}, fmt.Errorf("failed to create kubernetes rest client for import of resource: %s %s %s %+v %s %s", apiVersion, kind, name, restClient.Error, yamlString, manifest.Raw)
@@ -193,7 +187,9 @@ metadata:
 				_ = d.Set("uid", metaObjLive.GetUID())
 				_ = d.Set("live_uid", metaObjLive.GetUID())
 
-				liveManifestFingerprint := getLiveManifestFingerprint(d, metaObjLive, metaObjLive)
+				// Import has no user-provided manifest yet, so ignore_fields
+				// is always empty; pass nil for the trim list.
+				liveManifestFingerprint := GetLiveManifestFields(nil, metaObjLive, metaObjLive)
 				_ = d.Set("yaml_incluster", liveManifestFingerprint)
 				_ = d.Set("live_manifest_incluster", liveManifestFingerprint)
 
@@ -266,45 +262,24 @@ metadata:
 				_ = d.ForceNew("api_version")
 			}
 
-			// set the yaml_body_parsed field to provided value and obfuscate the yaml_body values manually
-			// this allows us to show a nice diff to the users with specific fields obfuscated, whilst storing the
-			// real value to apply in yaml_body
-			obfuscatedYaml, _ := yaml.ParseYAML(d.Get("yaml_body").(string))
-			if obfuscatedYaml.Raw.Object == nil {
-				obfuscatedYaml.Raw.Object = make(map[string]interface{})
-			}
-
-			if overrideNamespace, ok := d.GetOk("override_namespace"); ok {
-				obfuscatedYaml.SetNamespace(overrideNamespace.(string))
-			}
-
+			// Set yaml_body_parsed to the manifest with sensitive fields
+			// masked, so the plan shows a useful diff without leaking secret
+			// values. Shared with the plugin-framework half via
+			// BuildObfuscatedYAML so both code paths obfuscate identically.
 			var sensitiveFields []string
-			sensitiveFieldsRaw, hasSensitiveFields := d.GetOk("sensitive_fields")
-			if hasSensitiveFields {
+			if sensitiveFieldsRaw, ok := d.GetOk("sensitive_fields"); ok {
 				sensitiveFields = expandStringList(sensitiveFieldsRaw.([]interface{}))
-			} else if parsedYaml.GetKind() == "Secret" && parsedYaml.GetAPIVersion() == "v1" {
-				sensitiveFields = []string{"data", "stringData"}
+			}
+			overrideNs := ""
+			if ns, ok := d.GetOk("override_namespace"); ok {
+				overrideNs = ns.(string)
+			}
+			obfuscatedYaml, obfErr := BuildObfuscatedYAML(d.Get("yaml_body").(string), overrideNs, sensitiveFields)
+			if obfErr != nil {
+				return obfErr
 			}
 
-			for _, s := range sensitiveFields {
-				fields := strings.Split(s, ".")
-				_, fieldExists, err := meta_v1_unstruct.NestedFieldNoCopy(obfuscatedYaml.Raw.Object, fields...)
-				if fieldExists {
-					err = meta_v1_unstruct.SetNestedField(obfuscatedYaml.Raw.Object, "(sensitive value)", fields...)
-					if err != nil {
-						return fmt.Errorf("failed to obfuscate sensitive field '%s': %+v\nNote: only map values are supported!", s, err)
-					}
-				} else {
-					log.Printf("[TRACE] sensitive field %s skipped does not exist", s)
-				}
-			}
-
-			obfuscatedYamlBytes, obfuscatedYamlBytesErr := yamlWriter.Marshal(obfuscatedYaml.Raw.Object)
-			if obfuscatedYamlBytesErr != nil {
-				return fmt.Errorf("failed to serialized obfuscated yaml: %+v", obfuscatedYamlBytesErr)
-			}
-
-			_ = d.SetNew("yaml_body_parsed", string(obfuscatedYamlBytes))
+			_ = d.SetNew("yaml_body_parsed", obfuscatedYaml)
 
 			// Get the UID of the K8s resource as it was when the `resourceKubectlManifestCreate` func completed.
 			createdAtUID := d.Get("uid").(string)
@@ -342,8 +317,8 @@ metadata:
 				Version: 0,
 				Type:    resourceKubectlManifestV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-					rawState["yaml_incluster"] = getFingerprint(rawState["yaml_incluster"].(string))
-					rawState["live_manifest_incluster"] = getFingerprint(rawState["live_manifest_incluster"].(string))
+					rawState["yaml_incluster"] = GetFingerprint(rawState["yaml_incluster"].(string))
+					rawState["live_manifest_incluster"] = GetFingerprint(rawState["live_manifest_incluster"].(string))
 					return rawState, nil
 				},
 			},
@@ -542,8 +517,8 @@ var (
 	}
 )
 
-// newApplyOptions defines flags and other configuration parameters for the `apply` command
-func newApplyOptions(yamlBody string) *apply.ApplyOptions {
+// NewApplyOptions defines flags and other configuration parameters for the `apply` command
+func NewApplyOptions(yamlBody string) *apply.ApplyOptions {
 	applyOptions := &apply.ApplyOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 
@@ -562,271 +537,108 @@ func newApplyOptions(yamlBody string) *apply.ApplyOptions {
 	}
 	return applyOptions
 }
-// resourceKubectlManifestApply applies the manifest and (when configured)
-// waits for the resource's rollout to complete. The caller passes the
-// timeout key matching the active operation (schema.TimeoutCreate or
-// schema.TimeoutUpdate); it determines which user-configured `timeouts`
-// block governs the wait_for_rollout / wait_for loops.
+// resourceKubectlManifestApply is the SDK v2 adapter: it shapes
+// ApplyManifestOptions from *schema.ResourceData, calls the shared
+// ApplyManifest helper in manifest_lifecycle.go, and writes the result
+// back to state. All real apply logic lives in ApplyManifest so the
+// plugin-framework half can call the same code path.
 func resourceKubectlManifestApply(ctx context.Context, d *schema.ResourceData, meta interface{}, timeoutKey string) error {
-	yamlBody := d.Get("yaml_body").(string)
-
-	// convert hcl into an unstructured object
-	manifest, err := yaml.ParseYAML(yamlBody)
-	if err != nil {
-		return fmt.Errorf("failed to parse kubernetes resource: %+v", err)
+	var ignoreFields []string
+	if raw, ok := d.GetOk("ignore_fields"); ok {
+		ignoreFields = expandStringList(raw.([]interface{}))
 	}
-
-	if overrideNamespace, ok := d.GetOk("override_namespace"); ok {
-		manifest.SetNamespace(overrideNamespace.(string))
-	}
-
-	log.Printf("[DEBUG] %v apply kubernetes resource:\n%s", manifest, yamlBody)
-
-	// Create a client to talk to the resource API based on the APIVersion and Kind
-	// defined in the YAML
-	restClient := getRestClientFromUnstructured(manifest, meta.(*KubeProvider))
-	if restClient.Error != nil {
-		return fmt.Errorf("%v failed to create kubernetes rest client for update of resource: %+v", manifest, restClient.Error)
-	}
-
-	// Update the resource in Kubernetes, using a temp file
-	yamlBody, err = manifest.AsYAML()
-	if err != nil {
-		return fmt.Errorf("%v failed to convert to yaml: %+v", manifest, err)
-	}
-
-	tmpfile, _ := os.CreateTemp("", "*kubectl_manifest.yaml")
-	_, _ = tmpfile.Write([]byte(yamlBody))
-	_ = tmpfile.Close()
-
-	applyOptions := newApplyOptions(yamlBody)
-	applyOptions.Builder = k8sresource.NewBuilder(k8sresource.RESTClientGetter(meta.(*KubeProvider)))
-	applyOptions.DeleteOptions = &k8sdelete.DeleteOptions{
-		FilenameOptions: k8sresource.FilenameOptions{
-			Filenames: []string{tmpfile.Name()},
-		},
-	}
-	applyOptions.ToPrinter = func(string) (printers.ResourcePrinter, error) {
-		return printers.NewDiscardingPrinter(), nil
-	}
-	if !d.Get("validate_schema").(bool) {
-		applyOptions.Validator = validation.NullSchema{}
-	}
-	if d.Get("server_side_apply").(bool) {
-		applyOptions.ServerSideApply = true
-		applyOptions.FieldManager = d.Get("field_manager").(string)
-	}
-	if d.Get("force_conflicts").(bool) {
-		applyOptions.ForceConflicts = true
-	}
-	if manifest.HasNamespace() {
-		applyOptions.Namespace = manifest.GetNamespace()
-	}
-
-	log.Printf("[INFO] %s perform apply of manifest", manifest)
-
-	err = applyOptions.Run()
-	_ = os.Remove(tmpfile.Name())
-	if err != nil {
-		return fmt.Errorf("%v failed to run apply: %+v", manifest, err)
-	}
-
-	log.Printf("[INFO] %v manifest applied, fetch resource from kubernetes", manifest)
-
-	// get the resource from Kubernetes
-	rawResponse, err := restClient.ResourceInterface.Get(ctx, manifest.GetName(), meta_v1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("%v failed to fetch resource from kubernetes: %+v", manifest, err)
-	}
-	// set a wrapper from unstructured raw manifest
-	response := yaml.NewFromUnstructured(rawResponse)
-
-	d.SetId(response.GetSelfLink())
-	log.Printf("[DEBUG] %v fetched successfully, set id to: %v", manifest, d.Id())
-
-	// Preserve config-only computed fields in state
-	_ = d.Set("upgrade_api_version", d.Get("upgrade_api_version").(bool))
-
-	// Capture the UID at time of update
-	// this allows us to diff these against the actual values
-	// read in by the 'resourceKubectlManifestRead'
-	_ = d.Set("uid", response.GetUID())
-	_ = d.Set("live_uid", response.GetUID())
-
-	liveManifestFingerprint := getLiveManifestFingerprint(d, manifest, response)
-	_ = d.Set("yaml_incluster", liveManifestFingerprint)
-	_ = d.Set("live_manifest_incluster", liveManifestFingerprint)
-
-	if d.Get("wait_for_rollout").(bool) {
-		timeout := d.Timeout(timeoutKey)
-
-		switch {
-		case manifest.GetKind() == "Deployment":
-			log.Printf("[INFO] %v waiting for Deployment rollout for %vmin", manifest, timeout.Minutes())
-			err = waitForDeploymentRollout(ctx, meta.(*KubeProvider), manifest.GetNamespace(), manifest.GetName(), timeout)
-			if err != nil {
-				return err
-			}
-		case manifest.GetKind() == "DaemonSet":
-			log.Printf("[INFO] %v waiting for DaemonSet rollout for %vmin", manifest, timeout.Minutes())
-			err = waitForDaemonSetRollout(ctx, meta.(*KubeProvider), manifest.GetNamespace(), manifest.GetName(), timeout)
-			if err != nil {
-				return err
-			}
-		case manifest.GetKind() == "StatefulSet":
-			log.Printf("[INFO] %v waiting for v rollout for %vmin", manifest, timeout.Minutes())
-			err = waitForStatefulSetRollout(ctx, meta.(*KubeProvider), manifest.GetNamespace(), manifest.GetName(), timeout)
-			if err != nil {
-				return err
-			}
-		case manifest.GetKind() == "APIService" && manifest.GetAPIVersion() == "apiregistration.k8s.io/v1":
-			log.Printf("[INFO] %v waiting for APIService for %vmin", manifest, timeout.Minutes())
-			err = waitForApiService(ctx, meta.(*KubeProvider), manifest.GetName(), timeout)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	if v, ok := d.GetOk("wait_for"); ok {
-		timeout := d.Timeout(timeoutKey)
-
-		waitFor := types.WaitFor{}
-		if err := mapstructure.Decode((v.([]interface{}))[0], &waitFor); err != nil {
+	var waitFor *types.WaitFor
+	if raw, ok := d.GetOk("wait_for"); ok {
+		wf := types.WaitFor{}
+		if err := mapstructure.Decode((raw.([]interface{}))[0], &wf); err != nil {
 			return fmt.Errorf("cannot decode wait for conditions %v", err)
 		}
-		if len(waitFor.Field) == 0 && len(waitFor.Condition) == 0 {
-			return fmt.Errorf("at least one of `field` or `condition` must be provided in `wait_for` block")
-		}
-
-		log.Printf("[INFO] %v waiting for wait conditions for %vmin", manifest, timeout.Minutes())
-		err = waitForConditions(ctx, restClient, waitFor.Field, waitFor.Condition, manifest.GetName(), timeout)
-		if err != nil {
-			return err
-		}
+		waitFor = &wf
+	}
+	overrideNs := ""
+	if v, ok := d.GetOk("override_namespace"); ok {
+		overrideNs = v.(string)
 	}
 
-	// So far we have set (live_)uid and (live_)yaml_incluster.
-	// Perform the full read of the object
-	return resourceKubectlManifestReadUsingClient(ctx, d, meta, restClient.ResourceInterface, manifest)
+	result, err := ApplyManifest(ctx, meta.(*KubeProvider), ApplyManifestOptions{
+		YAMLBody:          d.Get("yaml_body").(string),
+		OverrideNamespace: overrideNs,
+		ValidateSchema:    d.Get("validate_schema").(bool),
+		ServerSideApply:   d.Get("server_side_apply").(bool),
+		FieldManager:      d.Get("field_manager").(string),
+		ForceConflicts:    d.Get("force_conflicts").(bool),
+		WaitForRollout:    d.Get("wait_for_rollout").(bool),
+		WaitFor:           waitFor,
+		Timeout:           d.Timeout(timeoutKey),
+		IgnoreFields:      ignoreFields,
+	})
+	if err != nil {
+		return err
+	}
+
+	d.SetId(result.SelfLink)
+	_ = d.Set("uid", result.UID)
+	_ = d.Set("live_uid", result.LiveUID)
+	_ = d.Set("yaml_incluster", result.YAMLInClusterFingerprint)
+	_ = d.Set("live_manifest_incluster", result.LiveManifestInClusterFingerprint)
+	// Preserve config-only computed field; ApplyManifest doesn't carry it.
+	_ = d.Set("upgrade_api_version", d.Get("upgrade_api_version").(bool))
+	return nil
 }
 
+// resourceKubectlManifestRead is the SDK v2 adapter over ReadManifest.
 func resourceKubectlManifestRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
-	yamlBody := d.Get("yaml_body").(string)
-	manifest, err := yaml.ParseYAML(yamlBody)
+	var ignoreFields []string
+	if raw, ok := d.GetOk("ignore_fields"); ok {
+		ignoreFields = expandStringList(raw.([]interface{}))
+	}
+	overrideNs := ""
+	if v, ok := d.GetOk("override_namespace"); ok {
+		overrideNs = v.(string)
+	}
+
+	result, err := ReadManifest(ctx, meta.(*KubeProvider), ReadManifestOptions{
+		YAMLBody:          d.Get("yaml_body").(string),
+		OverrideNamespace: overrideNs,
+		IgnoreFields:      ignoreFields,
+	})
 	if err != nil {
-		return fmt.Errorf("failed to parse kubernetes resource: %+v", err)
+		return err
 	}
-
-	if overrideNamespace, ok := d.GetOk("override_namespace"); ok {
-		manifest.SetNamespace(overrideNamespace.(string))
-	}
-
-	// Create a client to talk to the resource API based on the APIVersion and Kind
-	// defined in the YAML
-	restClient := getRestClientFromUnstructured(manifest, meta.(*KubeProvider))
-	if restClient.Status == RestClientInvalidTypeError {
+	if result.InvalidType {
 		log.Printf("[WARN] kubernetes resource (%s) has an invalid type, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
-
-	if restClient.Error != nil {
-		return fmt.Errorf("failed to create kubernetes rest client for read of resource: %+v", restClient.Error)
+	if !result.Found {
+		log.Printf("[WARN] kubernetes resource (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
 	}
 
-	return resourceKubectlManifestReadUsingClient(ctx, d, meta, restClient.ResourceInterface, manifest)
-}
-
-// resourceKubectlManifestReadUsingClient reads the object data from the cluster based on it's UID
-// and sets live_uid and live_manifest_incluster to the latest values
-func resourceKubectlManifestReadUsingClient(ctx context.Context, d *schema.ResourceData, meta interface{}, client dynamic.ResourceInterface, manifest *yaml.Manifest) error {
-
-	log.Printf("[DEBUG] %v fetch from kubernetes", manifest)
-
-	// Get the resource from Kubernetes
-	metaObjLiveRaw, err := client.Get(ctx, manifest.GetName(), meta_v1.GetOptions{})
-	if err != nil {
-		if errors.IsGone(err) || errors.IsNotFound(err) {
-			log.Printf("[WARN] kubernetes resource (%s) not found, removing from state", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("%v failed to get resource from kubernetes: %+v", manifest, err)
-	}
-
-	if metaObjLiveRaw.GetUID() == "" {
-		return fmt.Errorf("%v failed to parse item and get UUID: %+v", manifest, metaObjLiveRaw)
-	}
-
-	metaObjLive := yaml.NewFromUnstructured(metaObjLiveRaw)
-
-	// Capture the UID from the cluster at the current time
-	_ = d.Set("live_uid", metaObjLive.GetUID())
-
-	// Preserve config-only computed fields in state
+	_ = d.Set("live_uid", result.LiveUID)
+	_ = d.Set("live_manifest_incluster", result.LiveManifestInClusterFingerprint)
+	// Preserve config-only computed field.
 	_ = d.Set("upgrade_api_version", d.Get("upgrade_api_version").(bool))
-
-	liveManifestFingerprint := getLiveManifestFingerprint(d, manifest, metaObjLive)
-	_ = d.Set("live_manifest_incluster", liveManifestFingerprint)
-
 	return nil
 }
 
 func resourceKubectlManifestDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
-	if d.Get("apply_only").(bool) {
-		return nil
+	overrideNs := ""
+	if v, ok := d.GetOk("override_namespace"); ok {
+		overrideNs = v.(string)
 	}
-	yamlBody := d.Get("yaml_body").(string)
-	manifest, err := yaml.ParseYAML(yamlBody)
-	if err != nil {
-		return fmt.Errorf("failed to parse kubernetes resource: %+v", err)
-	}
-
-	if overrideNamespace, ok := d.GetOk("override_namespace"); ok {
-		manifest.SetNamespace(overrideNamespace.(string))
-	}
-
-	log.Printf("[DEBUG] %v delete kubernetes resource:\n%s", manifest, yamlBody)
-
-	restClient := getRestClientFromUnstructured(manifest, meta.(*KubeProvider))
-	if restClient.Error != nil {
-		return fmt.Errorf("%v failed to create kubernetes rest client for delete of resource: %+v", manifest, restClient.Error)
+	if err := DeleteManifest(ctx, meta.(*KubeProvider), DeleteManifestOptions{
+		YAMLBody:          d.Get("yaml_body").(string),
+		OverrideNamespace: overrideNs,
+		ApplyOnly:         d.Get("apply_only").(bool),
+		Wait:              d.Get("wait").(bool),
+		DeleteCascade:     d.Get("delete_cascade").(string),
+		Timeout:           d.Timeout(schema.TimeoutDelete),
+	}); err != nil {
+		return err
 	}
 
-	log.Printf("[INFO] %s perform delete of manifest", manifest)
-
-	wait := d.Get("wait").(bool)
-
-	var propagationPolicy meta_v1.DeletionPropagation
-	cascadeInput := d.Get("delete_cascade").(string)
-	if len(cascadeInput) > 0 {
-		propagationPolicy = meta_v1.DeletionPropagation(cascadeInput)
-	} else if wait {
-		propagationPolicy = meta_v1.DeletePropagationForeground
-	} else {
-		propagationPolicy = meta_v1.DeletePropagationBackground
-	}
-
-	err = restClient.ResourceInterface.Delete(ctx, manifest.GetName(), meta_v1.DeleteOptions{PropagationPolicy: &propagationPolicy})
-	resourceGone := errors.IsGone(err) || errors.IsNotFound(err)
-	if err != nil && !resourceGone {
-		return fmt.Errorf("%v failed to delete kubernetes resource: %+v", manifest, err)
-	}
-
-	// The rest client doesn't wait for the delete so we need custom logic
-	if wait && !resourceGone {
-		log.Printf("[INFO] %s waiting for delete of manifest to complete", manifest)
-
-		timeout := d.Timeout(schema.TimeoutDelete)
-
-		err = waitForDelete(ctx, restClient, manifest.GetName(), timeout)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Success remove it from state
 	d.SetId("")
 	return nil
 }
@@ -869,8 +681,8 @@ func RestClientResultFromInvalidTypeErr(err error) *RestClientResult {
 	}
 }
 
-// getRestClientFromUnstructured creates a dynamic k8s client based on the provided manifest
-func getRestClientFromUnstructured(manifest *yaml.Manifest, provider *KubeProvider) *RestClientResult {
+// GetRestClientFromUnstructured creates a dynamic k8s client based on the provided manifest
+func GetRestClientFromUnstructured(manifest *yaml.Manifest, provider *KubeProvider) *RestClientResult {
 
 	doGetRestClientFromUnstructured := func(manifest *yaml.Manifest, provider *KubeProvider) *RestClientResult {
 		// Use the k8s Discovery service to find all valid APIs for this cluster
@@ -979,7 +791,7 @@ func checkAPIResourceIsPresent(available []*meta_v1.APIResourceList, resource me
 	return nil, false
 }
 
-func waitForDelete(ctx context.Context, restClient *RestClientResult, name string, timeout time.Duration) error {
+func WaitForDelete(ctx context.Context, restClient *RestClientResult, name string, timeout time.Duration) error {
 	timeoutSeconds := int64(timeout.Seconds())
 
 	rawResponse, err := restClient.ResourceInterface.Get(ctx, name, meta_v1.GetOptions{})
@@ -1054,7 +866,7 @@ func deploymentRolloutComplete(deployment *apps_v1.Deployment) bool {
 	return true
 }
 
-func waitForDeploymentRollout(ctx context.Context, provider *KubeProvider, ns string, name string, timeout time.Duration) error {
+func WaitForDeploymentRollout(ctx context.Context, provider *KubeProvider, ns string, name string, timeout time.Duration) error {
 	deploymentClient := provider.MainClientset.AppsV1().Deployments(ns)
 
 	// Probe current state and capture ResourceVersion before opening the
@@ -1139,7 +951,7 @@ func daemonSetRolloutComplete(daemon *apps_v1.DaemonSet) bool {
 	return true
 }
 
-func waitForDaemonSetRollout(ctx context.Context, provider *KubeProvider, ns string, name string, timeout time.Duration) error {
+func WaitForDaemonSetRollout(ctx context.Context, provider *KubeProvider, ns string, name string, timeout time.Duration) error {
 	daemonClient := provider.MainClientset.AppsV1().DaemonSets(ns)
 
 	// Probe the current state before opening a watch. The DaemonSet
@@ -1229,7 +1041,7 @@ func statefulSetRolloutComplete(sts *apps_v1.StatefulSet) bool {
 	return true
 }
 
-func waitForStatefulSetRollout(ctx context.Context, provider *KubeProvider, ns string, name string, timeout time.Duration) error {
+func WaitForStatefulSetRollout(ctx context.Context, provider *KubeProvider, ns string, name string, timeout time.Duration) error {
 	stsClient := provider.MainClientset.AppsV1().StatefulSets(ns)
 
 	resourceVersion := ""
@@ -1277,7 +1089,7 @@ func waitForStatefulSetRollout(ctx context.Context, provider *KubeProvider, ns s
 	}
 }
 
-func waitForApiService(ctx context.Context, provider *KubeProvider, name string, timeout time.Duration) error {
+func WaitForApiService(ctx context.Context, provider *KubeProvider, name string, timeout time.Duration) error {
 	timeoutSeconds := int64(timeout.Seconds())
 
 	watcher, err := provider.AggregatorClientset.ApiregistrationV1().APIServices().Watch(ctx, meta_v1.ListOptions{Watch: true, TimeoutSeconds: &timeoutSeconds, FieldSelector: fields.OneTermEqualSelector("metadata.name", name).String()})
@@ -1313,7 +1125,7 @@ func waitForApiService(ctx context.Context, provider *KubeProvider, name string,
 	return nil
 }
 
-func waitForConditions(ctx context.Context, restClient *RestClientResult, waitFields []types.WaitForField, waitConditions []types.WaitForStatusCondition, name string, timeout time.Duration) error {
+func WaitForConditions(ctx context.Context, restClient *RestClientResult, waitFields []types.WaitForField, waitConditions []types.WaitForStatusCondition, name string, timeout time.Duration) error {
 	timeoutSeconds := int64(timeout.Seconds())
 
 	watcher, err := restClient.ResourceInterface.Watch(
@@ -1426,22 +1238,13 @@ func expandStringList(configured []interface{}) []string {
 	return vs
 }
 
-func getLiveManifestFingerprint(d *schema.ResourceData, userProvided *yaml.Manifest, liveManifest *yaml.Manifest) string {
-	var ignoreFields []string = nil
-	ignoreFieldsRaw, hasIgnoreFields := d.GetOk("ignore_fields")
-	if hasIgnoreFields {
-		ignoreFields = expandStringList(ignoreFieldsRaw.([]interface{}))
-	}
-	return getLiveManifestFields_WithIgnoredFields(ignoreFields, userProvided, liveManifest)
-}
-
-func getFingerprint(s string) string {
+func GetFingerprint(s string) string {
 	fingerprint := sha256.New()
 	fingerprint.Write([]byte(s))
 	return fmt.Sprintf("%x", fingerprint.Sum(nil))
 }
 
-func getLiveManifestFields_WithIgnoredFields(ignoredFields []string, userProvided *yaml.Manifest, liveManifest *yaml.Manifest) string {
+func GetLiveManifestFields(ignoredFields []string, userProvided *yaml.Manifest, liveManifest *yaml.Manifest) string {
 
 	// there is a special user case for secrets.
 	// If they are defined as manifests with StringData, it will always provide a non-empty plan
@@ -1492,7 +1295,7 @@ func getLiveManifestFields_WithIgnoredFields(ignoredFields []string, userProvide
 			if normalizedUserValue != normalizedLiveValue {
 				log.Printf("[TRACE] yaml drift detected in %s for %s, was: %s now: %s", userProvided.GetSelfLink(), userKey, normalizedUserValue, normalizedLiveValue)
 			}
-			flattenedUser[userKey] = getFingerprint(normalizedLiveValue)
+			flattenedUser[userKey] = GetFingerprint(normalizedLiveValue)
 		} else {
 			if normalizedUserValue != "" {
 				log.Printf("[TRACE] yaml drift detected in %s for %s, was %s now blank", userProvided.GetSelfLink(), userKey, normalizedUserValue)

--- a/kubernetes/resource_kubectl_manifest_test.go
+++ b/kubernetes/resource_kubectl_manifest_test.go
@@ -1456,9 +1456,9 @@ func TestGetLiveManifestFilteredForUserProvidedOnly(t *testing.T) {
 			log.SetOutput(&out)
 			defer log.SetOutput(os.Stderr)
 
-			fields := getLiveManifestFields_WithIgnoredFields(tcase.ignored, userProvided, liveManifest)
+			fields := GetLiveManifestFields(tcase.ignored, userProvided, liveManifest)
 			assert.Equal(t, tcase.expectedFields, fields, "Expect the builder output to match")
-			fingerprint := getFingerprint(fields)
+			fingerprint := GetFingerprint(fields)
 			assert.Equal(t, tcase.expectedFingerprint, fingerprint, "Expect the builder output to match")
 
 			if tcase.expectedDrift {


### PR DESCRIPTION
Ports `kubectl_manifest` to terraform-plugin-framework alongside the existing SDK v2 resource, and adds a `MoveState` handler so existing `gavinbunney/kubectl` resources can migrate with a Terraform 1.8+ `moved {}` block. Schema, CRUD, ModifyPlan (the old CustomizeDiff), and the v0 to v1 state upgrade all carry over. State shape is unchanged, so existing users see no churn.

Apply, read, delete, and the `yaml_body_parsed` obfuscation now live in shared helpers in the `kubernetes` package, called by both the SDK v2 resource and the framework one. That keeps the two halves from drifting while they coexist.

### Not in this PR

The framework resource is not registered yet, so SDK v2 stays the live implementation. The atomic cutover (register the framework resource, deregister the SDK v2 one) and the acceptance-test migration land in a follow-up, where they can be validated against a live cluster. This slice is reviewable on its own: it builds, `go vet` is clean, and the unit tests pass, and because nothing is registered it changes no runtime behaviour. No release is cut here.

The README gains a "Migrating from gavinbunney/kubectl" section covering the `moved {}` path, the four alekc-only attributes and their post-move defaults, and the `kubectl_kustomize_documents` gap.

Refs: #295, #123


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native kubectl_manifest resource for managing Kubernetes manifests with server-side apply, wait_for conditions, rollout monitoring, field-manager control, and cascade-delete options.
  * Migration support from gavinbunney/kubectl via Terraform/OpenTofu 1.8+ moved blocks; alternative guidance for older Terraform versions.

* **Documentation**
  * Added dedicated migration guide including expected in-place vs replace behavior and note that kubectl_kustomize_documents is not yet provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->