### PR TITLE
ci(docstring): add 80% godoc coverage gate; doc framework manifest

### DIFF
--- a/.github/workflows/docstring-coverage.yaml
+++ b/.github/workflows/docstring-coverage.yaml
@@ -1,0 +1,54 @@
+name: "docstring-coverage"
+
+on:
+  pull_request:
+    branches:
+      - master
+    # Only run on PRs that touch Go source. Markdown / docs-only PRs cannot
+    # change the exported godoc surface, so skipping them saves runner time
+    # without weakening the gate. tests-docs-skip.yaml provides a paired
+    # ghost workflow for the docs-only path if this check ever becomes a
+    # required status; today it does not need one because the check is
+    # advisory and a missing run is treated as "not required" by branch
+    # protection.
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'tools/godoc-coverage/**'
+      - '.github/workflows/docstring-coverage.yaml'
+
+concurrency:
+  group: docstring-coverage-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - name: Run godoc-coverage
+        # Scope: the framework manifest port and the shared lifecycle
+        # helpers extracted in #306, plus the gate tool itself. Rest of
+        # internal/framework (data sources, ephemeral, server_version,
+        # provider) and the SDK v2 surface in kubernetes/ predate this
+        # gate and are intentionally out of scope until they are brought
+        # up to threshold or rewritten under the framework. Add files to
+        # this list (or switch to ./pkg/... once a whole package is
+        # documented) as the migration advances. Threshold matches the
+        # CodeRabbit pre-merge default; raise once the framework half is
+        # fully documented.
+        run: |
+          go run ./tools/godoc-coverage \
+            --threshold=80 \
+            ./internal/framework/resource_kubectl_manifest.go \
+            ./internal/framework/resource_kubectl_manifest_move.go \
+            ./kubernetes/manifest_lifecycle.go \
+            ./tools/godoc-coverage/...

--- a/Makefile
+++ b/Makefile
@@ -58,4 +58,14 @@ fmtcheck:
 errcheck:
 	@sh -c "'$(CURDIR)/scripts/errcheck.sh'"
 
-.PHONY: build dist test testacc publish vet fmt fmtcheck errcheck
+# Runs the same gate that .github/workflows/docstring-coverage.yaml runs in
+# CI. Keep the file list and threshold in lockstep with that workflow.
+doc-coverage:
+	go run ./tools/godoc-coverage \
+		--threshold=80 \
+		./internal/framework/resource_kubectl_manifest.go \
+		./internal/framework/resource_kubectl_manifest_move.go \
+		./kubernetes/manifest_lifecycle.go \
+		./tools/godoc-coverage/...
+
+.PHONY: build dist test testacc publish vet fmt fmtcheck errcheck doc-coverage

--- a/internal/framework/resource_kubectl_manifest.go
+++ b/internal/framework/resource_kubectl_manifest.go
@@ -102,10 +102,17 @@ type waitForFieldModel struct {
 // timeouts {} block plumbing lands (separate Phase D follow-up commit).
 const defaultLifecycleTimeout = 10 * time.Minute
 
+// Metadata sets the Terraform type name for this resource to
+// "<provider>_manifest" (e.g. "kubectl_manifest"). Implements
+// resource.Resource.
 func (r *manifestResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_manifest"
 }
 
+// Schema returns the resource schema (Version 1) for kubectl_manifest.
+// The attribute set, types, and default values are byte-compatible with
+// the SDK v2 implementation so existing state round-trips without churn
+// after the cutover. Implements resource.Resource.
 func (r *manifestResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Version: 1,
@@ -211,9 +218,9 @@ func (r *manifestResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Description: "When true, any change to `yaml_body` re-creates the resource instead of updating it in place. Default false.",
 			},
 			"upgrade_api_version": schema.BoolAttribute{
-				Optional: true,
-				Computed: true,
-				Default:  booldefault.StaticBool(false),
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
 				Description: "When true, a change to `api_version` is applied as an in-place update rather than a delete-and-recreate. Relies on the Kubernetes API server's ability to represent the same object across multiple API versions. Default false.",
 			},
 			"server_side_apply": schema.BoolAttribute{
@@ -264,7 +271,7 @@ func (r *manifestResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Description: "When true, validate the YAML against the cluster's OpenAPI schema before applying. Default true.",
 			},
 			"delete_cascade": schema.StringAttribute{
-				Optional: true,
+				Optional:    true,
 				Description: "Propagation policy for Delete. One of `Background` or `Foreground`. When unset, defaults to `Foreground` if `wait = true`, otherwise `Background`.",
 				Validators: []validator.String{
 					stringOneOfValidator{allowed: []string{"Background", "Foreground"}},
@@ -320,6 +327,12 @@ func (r *manifestResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 	}
 }
 
+// Configure receives the muxed provider data: a callback that resolves
+// to the SDK v2 *KubeProvider once the SDK v2 half has Configure'd. The
+// callback is stored on the resource and dereferenced lazily inside
+// kubeProvider() so framework CRUD methods see the configured client
+// regardless of which half ran Configure first. Implements
+// resource.ResourceWithConfigure.
 func (r *manifestResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
@@ -424,6 +437,10 @@ func applyResultToModel(result *kubernetes.ApplyManifestResult, data *manifestRe
 	data.LiveManifestInCluster = types.StringValue(result.LiveManifestInClusterFingerprint)
 }
 
+// Create applies the manifest to the cluster and persists the resulting
+// fingerprints (uid, live_uid, yaml_incluster, live_manifest_incluster)
+// to state. Delegates to kubernetes.ApplyManifest, so behaviour matches
+// the SDK v2 half line-for-line. Implements resource.Resource.
 func (r *manifestResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data manifestResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -453,6 +470,10 @@ func (r *manifestResource) Create(ctx context.Context, req resource.CreateReques
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
+// Read refreshes live_uid and live_manifest_incluster from the cluster.
+// If the resource has disappeared (ReadManifest reports !Found, or the
+// REST mapper rejects the kind), the resource is removed from state so
+// the next plan recreates it. Implements resource.Resource.
 func (r *manifestResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var data manifestResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
@@ -494,6 +515,10 @@ func (r *manifestResource) Read(ctx context.Context, req resource.ReadRequest, r
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
+// Update reapplies the manifest in place. The shared kubernetes.ApplyManifest
+// helper is idempotent, so Create and Update share the same code path; the
+// only difference is which framework request type the plan arrives on.
+// Implements resource.Resource.
 func (r *manifestResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var data manifestResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -523,6 +548,10 @@ func (r *manifestResource) Update(ctx context.Context, req resource.UpdateReques
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
+// Delete removes the manifest from the cluster, honouring apply_only,
+// wait, and delete_cascade. Delegates to kubernetes.DeleteManifest; with
+// apply_only = true the call is a no-op so the resource is simply
+// dropped from state. Implements resource.Resource.
 func (r *manifestResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var data manifestResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
@@ -701,14 +730,23 @@ type stringOneOfValidator struct {
 	allowed []string
 }
 
+// Description returns a one-line plaintext summary of the allowed
+// values. Implements validator.String.
 func (v stringOneOfValidator) Description(_ context.Context) string {
 	return fmt.Sprintf("value must be one of %v", v.allowed)
 }
 
+// MarkdownDescription returns the same summary as Description; no
+// Markdown is needed for a list of allowed scalar values. Implements
+// validator.String.
 func (v stringOneOfValidator) MarkdownDescription(ctx context.Context) string {
 	return v.Description(ctx)
 }
 
+// ValidateString rejects any non-null, non-unknown value that does not
+// appear in the allowed slice. Null and unknown pass through so this
+// validator composes cleanly with Optional + Computed attributes.
+// Implements validator.String.
 func (v stringOneOfValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return

--- a/tools/godoc-coverage/main.go
+++ b/tools/godoc-coverage/main.go
@@ -1,0 +1,339 @@
+// godoc-coverage walks the Go packages or individual files matching the
+// supplied patterns and reports the fraction of exported identifiers
+// (functions, methods, types, vars, consts) that carry a doc comment.
+// Exits with a non-zero status if the overall coverage is below
+// --threshold.
+//
+// Two input shapes are accepted in the positional args:
+//
+//   - Package patterns: "./pkg" (single directory) or "./pkg/..."
+//     (recursive). Every non-test .go file in the matched directory
+//     contributes to the coverage stats.
+//   - Individual files: any positional arg ending in ".go". Only that
+//     file's exports count, even if it lives in a package whose other
+//     files would otherwise be in scope. Useful while a package is
+//     being documented incrementally and the gate should only cover the
+//     subset that has been brought up to the threshold so far.
+//
+// The two shapes can be mixed in a single invocation.
+//
+// Test files (_test.go) are ignored: documenting test fixtures adds
+// noise without value.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/doc"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// stats tracks the documented vs total exported identifier counts for a
+// single package or for the aggregate run.
+type stats struct {
+	total      int
+	documented int
+}
+
+// pct returns the documented / total ratio expressed as a percentage,
+// or 100 when total is zero (a package with no exported surface trivially
+// satisfies any threshold).
+func (s stats) pct() float64 {
+	if s.total == 0 {
+		return 100
+	}
+	return float64(s.documented) / float64(s.total) * 100
+}
+
+// missingEntry is a single undocumented exported identifier, used in the
+// final report so a contributor knows which symbols to fix.
+type missingEntry struct {
+	pkg  string
+	file string
+	line int
+	name string
+	kind string
+}
+
+func main() {
+	threshold := flag.Float64("threshold", 80, "minimum acceptable coverage percentage")
+	verbose := flag.Bool("verbose", false, "list every undocumented exported identifier")
+	flag.Parse()
+
+	patterns := flag.Args()
+	if len(patterns) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: godoc-coverage [--threshold=N] [--verbose] <pkg-path>...")
+		os.Exit(2)
+	}
+
+	scope, err := expandPatterns(patterns)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "expanding patterns: %v\n", err)
+		os.Exit(2)
+	}
+
+	var overall stats
+	var missing []missingEntry
+	perPkg := make(map[string]stats)
+
+	for dir, fileFilter := range scope.dirs {
+		ps, m, err := analysePackageDir(dir, fileFilter)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "analysing %s: %v\n", dir, err)
+			os.Exit(2)
+		}
+		for _, s := range ps {
+			perPkg[dir] = s
+			overall.total += s.total
+			overall.documented += s.documented
+		}
+		missing = append(missing, m...)
+	}
+
+	names := make([]string, 0, len(perPkg))
+	for n := range perPkg {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	fmt.Println("godoc coverage by package:")
+	for _, n := range names {
+		s := perPkg[n]
+		fmt.Printf("  %-60s %3d/%-3d  %6.2f%%\n", n, s.documented, s.total, s.pct())
+	}
+	fmt.Printf("\noverall: %d/%d  %.2f%%  (threshold %.2f%%)\n",
+		overall.documented, overall.total, overall.pct(), *threshold)
+
+	if *verbose || overall.pct() < *threshold {
+		if len(missing) > 0 {
+			fmt.Println("\nundocumented exported identifiers:")
+			sort.SliceStable(missing, func(i, j int) bool {
+				if missing[i].file != missing[j].file {
+					return missing[i].file < missing[j].file
+				}
+				return missing[i].line < missing[j].line
+			})
+			for _, m := range missing {
+				fmt.Printf("  %s:%d  %s %s\n", m.file, m.line, m.kind, m.name)
+			}
+		}
+	}
+
+	if overall.pct() < *threshold {
+		fmt.Fprintf(os.Stderr,
+			"\ndocstring coverage %.2f%% is below threshold %.2f%%\n",
+			overall.pct(), *threshold)
+		os.Exit(1)
+	}
+}
+
+// scopeSet captures the analyse-this set after pattern expansion. dirs
+// maps each package directory we will scan to an optional file
+// allowlist; a nil allowlist for a directory means "every .go file in
+// that dir", while a non-nil allowlist means "only these specific
+// basenames within that dir". File-path positional args populate the
+// allowlist form; package patterns ("./pkg" / "./pkg/...") populate the
+// all-files form.
+type scopeSet struct {
+	dirs map[string]map[string]bool
+}
+
+// addDir registers a package directory in the all-files form.
+func (s *scopeSet) addDir(dir string) {
+	if _, ok := s.dirs[dir]; ok {
+		return
+	}
+	s.dirs[dir] = nil
+}
+
+// addFile registers a single .go file as the only file of interest in
+// its parent directory. If the directory was previously registered in
+// the all-files form, the file allowlist is left unset so the directory
+// continues to be analysed in full (a more permissive scope always
+// wins).
+func (s *scopeSet) addFile(file string) {
+	dir := filepath.Dir(file)
+	base := filepath.Base(file)
+	existing, present := s.dirs[dir]
+	if present && existing == nil {
+		return
+	}
+	if existing == nil {
+		existing = map[string]bool{}
+	}
+	existing[base] = true
+	s.dirs[dir] = existing
+}
+
+// expandPatterns resolves the user-supplied positional args into a
+// scopeSet. Supported shapes:
+//
+//   - "./path/..." or "path/...": recursive directory walk; every
+//     package directory under root with at least one non-test .go file
+//     is registered in the all-files form.
+//   - "./path" or "path" (a directory): single package, all-files form.
+//   - Any arg ending in ".go" that refers to an existing file: file
+//     allowlist form for that file's parent directory.
+//
+// Filesystem paths are evaluated relative to the working directory.
+func expandPatterns(patterns []string) (*scopeSet, error) {
+	scope := &scopeSet{dirs: make(map[string]map[string]bool)}
+	for _, p := range patterns {
+		if strings.HasSuffix(p, ".go") {
+			info, err := os.Stat(p)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", p, err)
+			}
+			if info.IsDir() {
+				return nil, fmt.Errorf("%s: looks like a Go file but is a directory", p)
+			}
+			scope.addFile(filepath.Clean(p))
+			continue
+		}
+		recursive := strings.HasSuffix(p, "/...")
+		root := strings.TrimSuffix(p, "/...")
+		root = strings.TrimPrefix(root, "./")
+		if root == "" {
+			root = "."
+		}
+		if !recursive {
+			if _, err := os.Stat(root); err != nil {
+				return nil, fmt.Errorf("%s: %w", p, err)
+			}
+			scope.addDir(root)
+			continue
+		}
+		walkErr := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if !d.IsDir() {
+				return nil
+			}
+			base := filepath.Base(path)
+			if base == "vendor" || base == "testdata" || strings.HasPrefix(base, ".") && path != root {
+				return filepath.SkipDir
+			}
+			entries, readErr := os.ReadDir(path)
+			if readErr != nil {
+				return readErr
+			}
+			for _, e := range entries {
+				if e.IsDir() {
+					continue
+				}
+				if strings.HasSuffix(e.Name(), ".go") && !strings.HasSuffix(e.Name(), "_test.go") {
+					scope.addDir(path)
+					return nil
+				}
+			}
+			return nil
+		})
+		if walkErr != nil {
+			return nil, fmt.Errorf("%s: %w", p, walkErr)
+		}
+	}
+	return scope, nil
+}
+
+// analysePackageDir parses every non-test .go file in dir and returns
+// per-package stats plus the list of undocumented exported identifiers.
+// When fileFilter is non-nil, only identifiers declared in basenames
+// present in the map contribute to the stats; nil filter means count
+// everything.
+//
+// A single directory may host more than one package (rare: typically
+// `package foo` and `package foo_test`), so the result is a map.
+func analysePackageDir(dir string, fileFilter map[string]bool) (map[string]stats, []missingEntry, error) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, dir, func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, parser.ParseComments)
+	if err != nil {
+		return nil, nil, err
+	}
+	result := make(map[string]stats)
+	var missing []missingEntry
+	for name, pkg := range pkgs {
+		if strings.HasSuffix(name, "_test") {
+			continue
+		}
+		dpkg := doc.New(pkg, "./"+dir, doc.AllDecls)
+		s, m := walkDocPackage(dpkg, fset, fileFilter)
+		result[dir] = s
+		missing = append(missing, m...)
+	}
+	return result, missing, nil
+}
+
+// walkDocPackage counts documented vs undocumented exported identifiers
+// across the doc.Package. Method receivers count individually so an
+// interface implementation with seven undocumented methods registers
+// as seven missing entries, not one. When fileFilter is non-nil only
+// identifiers declared in matching basenames are recorded.
+func walkDocPackage(p *doc.Package, fset *token.FileSet, fileFilter map[string]bool) (stats, []missingEntry) {
+	var s stats
+	var missing []missingEntry
+
+	record := func(name, kind string, hasDoc bool, pos token.Pos) {
+		if !ast.IsExported(name) {
+			return
+		}
+		fp := fset.Position(pos)
+		if fileFilter != nil && !fileFilter[filepath.Base(fp.Filename)] {
+			return
+		}
+		s.total++
+		if hasDoc {
+			s.documented++
+			return
+		}
+		missing = append(missing, missingEntry{
+			pkg:  p.Name,
+			file: fp.Filename,
+			line: fp.Line,
+			name: name,
+			kind: kind,
+		})
+	}
+
+	for _, f := range p.Funcs {
+		record(f.Name, "func", strings.TrimSpace(f.Doc) != "", f.Decl.Pos())
+	}
+	for _, t := range p.Types {
+		record(t.Name, "type", strings.TrimSpace(t.Doc) != "", t.Decl.Pos())
+		for _, m := range t.Methods {
+			record(m.Name, "method", strings.TrimSpace(m.Doc) != "", m.Decl.Pos())
+		}
+		for _, fn := range t.Funcs {
+			record(fn.Name, "func", strings.TrimSpace(fn.Doc) != "", fn.Decl.Pos())
+		}
+		for _, v := range t.Vars {
+			for _, n := range v.Names {
+				record(n, "var", strings.TrimSpace(v.Doc) != "", v.Decl.Pos())
+			}
+		}
+		for _, c := range t.Consts {
+			for _, n := range c.Names {
+				record(n, "const", strings.TrimSpace(c.Doc) != "", c.Decl.Pos())
+			}
+		}
+	}
+	for _, v := range p.Vars {
+		for _, n := range v.Names {
+			record(n, "var", strings.TrimSpace(v.Doc) != "", v.Decl.Pos())
+		}
+	}
+	for _, c := range p.Consts {
+		for _, n := range c.Names {
+			record(n, "const", strings.TrimSpace(c.Doc) != "", c.Decl.Pos())
+		}
+	}
+	return s, missing
+}


### PR DESCRIPTION
## Summary

CodeRabbit pre-merge checks on #306 reported docstring coverage of 71.43% on the framework manifest port, below the 80% threshold. This PR brings the in-scope files to 100% and adds a CI gate so the regression cannot recur silently.

## What changed

Ten godoc comments were added in `internal/framework/resource_kubectl_manifest.go`. Seven cover the framework resource interface methods (`Metadata`, `Schema`, `Configure`, `Create`, `Read`, `Update`, `Delete`) and three cover the inline `stringOneOfValidator` (`Description`, `MarkdownDescription`, `ValidateString`). Each comment opens with the identifier name per Go convention and explains what the method does, not just which interface it implements. No code paths were touched.

The new `tools/godoc-coverage` is a small AST-based gate that walks Go packages or individual files, counts exported funcs / methods / types / vars / consts, and exits non-zero when documented / total drops below `--threshold`. It accepts both `./pkg/...` patterns and individual `.go` paths so the gate can be tightened file by file as the framework migration documents more of the surface, rather than waiting for a whole package to be done.

The new `.github/workflows/docstring-coverage.yaml` runs the gate on PRs that touch `**.go` (plus `go.mod` / `go.sum` / the tool itself / the workflow itself). Threshold is set to 80% to match the CodeRabbit pre-merge default. Scope today is the three files from #306 plus the gate tool. As more files reach the threshold, add them to the workflow's argument list (or switch to a `./pkg/...` glob once the whole package is documented).

A `make doc-coverage` target runs the same invocation locally so contributors can verify before pushing. Workflow and Makefile share a single argument list, kept in lockstep via the comment on the workflow run step.

## Scope choice

The SDK v2 surface in `kubernetes/` and the rest of `internal/framework/` (data sources, ephemeral, server_version, provider) predate this gate and are intentionally out of scope until they are either documented or rewritten under the framework half of the muxed provider. The gate is deliberately a per-file allowlist rather than a per-package one to make this incremental progression cheap and visible.

## Verification

`go build ./...`, `go vet ./...`, `go test ./internal/framework/...` all pass. `gofmt -l` is clean on the edited files. `make doc-coverage` reports 23/23 = 100.00% on the in-scope set. A negative-path run against an undocumented file (any of the existing data sources) exits 1 with an itemised list of missing identifiers, so the gate fails closed when coverage regresses.

## Out of scope

Not addressed here, intentionally: documenting the rest of `internal/framework/` (the four data sources, the ephemeral resource, the server_version resource, the provider), documenting the legacy SDK v2 helpers in `kubernetes/`, and raising the threshold above 80%. Each of those is its own follow-up and the per-file scope on the new gate makes them easy to land independently.

Refs: alekc/terraform-provider-kubectl#306
