### PR TITLE
security(kubectl_manifest): redact sensitive YAML in DEBUG logs

### DIFF
--- a/internal/framework/resource_kubectl_manifest.go
+++ b/internal/framework/resource_kubectl_manifest.go
@@ -415,6 +415,10 @@ func (r *manifestResource) buildApplyOptions(ctx context.Context, data manifestR
 	allDiags.Append(d...)
 	sensitiveFields, d := extractStringList(ctx, data.SensitiveFields)
 	allDiags.Append(d...)
+	// Drop empty / whitespace-only entries so a misconfigured
+	// sensitive_fields = [""] does not suppress the Secret v1 default
+	// masking inside BuildObfuscatedYAML.
+	sensitiveFields = kubernetes.NormalizeSensitiveFields(sensitiveFields)
 	return kubernetes.ApplyManifestOptions{
 		YAMLBody:          data.YAMLBody.ValueString(),
 		OverrideNamespace: data.OverrideNamespace.ValueString(),
@@ -573,6 +577,7 @@ func (r *manifestResource) Delete(ctx context.Context, req resource.DeleteReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	sensitiveFields = kubernetes.NormalizeSensitiveFields(sensitiveFields)
 
 	opts := kubernetes.DeleteManifestOptions{
 		YAMLBody:          data.YAMLBody.ValueString(),

--- a/internal/framework/resource_kubectl_manifest.go
+++ b/internal/framework/resource_kubectl_manifest.go
@@ -413,6 +413,8 @@ func (r *manifestResource) buildApplyOptions(ctx context.Context, data manifestR
 	allDiags.Append(d...)
 	ignoreFields, d := extractStringList(ctx, data.IgnoreFields)
 	allDiags.Append(d...)
+	sensitiveFields, d := extractStringList(ctx, data.SensitiveFields)
+	allDiags.Append(d...)
 	return kubernetes.ApplyManifestOptions{
 		YAMLBody:          data.YAMLBody.ValueString(),
 		OverrideNamespace: data.OverrideNamespace.ValueString(),
@@ -424,6 +426,7 @@ func (r *manifestResource) buildApplyOptions(ctx context.Context, data manifestR
 		WaitFor:           waitFor,
 		Timeout:           defaultLifecycleTimeout,
 		IgnoreFields:      ignoreFields,
+		SensitiveFields:   sensitiveFields,
 	}, allDiags
 }
 
@@ -565,6 +568,12 @@ func (r *manifestResource) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
+	sensitiveFields, d := extractStringList(ctx, data.SensitiveFields)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	opts := kubernetes.DeleteManifestOptions{
 		YAMLBody:          data.YAMLBody.ValueString(),
 		OverrideNamespace: data.OverrideNamespace.ValueString(),
@@ -572,6 +581,7 @@ func (r *manifestResource) Delete(ctx context.Context, req resource.DeleteReques
 		Wait:              data.Wait.ValueBool(),
 		DeleteCascade:     data.DeleteCascade.ValueString(),
 		Timeout:           defaultLifecycleTimeout,
+		SensitiveFields:   sensitiveFields,
 	}
 
 	if delErr := kubernetes.DeleteManifest(ctx, provider, opts); delErr != nil {

--- a/kubernetes/manifest_lifecycle.go
+++ b/kubernetes/manifest_lifecycle.go
@@ -283,7 +283,13 @@ func BuildObfuscatedYAML(yamlBody, overrideNamespace string, sensitiveFields []s
 	if overrideNamespace != "" {
 		obfuscated.SetNamespace(overrideNamespace)
 	}
-	fields := sensitiveFields
+	// Normalize before the Secret v1 default check. Without this,
+	// sensitiveFields = [""] (a common shape from a misconfigured HCL
+	// list or a templated variable that resolves to "") would make
+	// len(fields) != 0 and silently suppress the default "data" /
+	// "stringData" masking on a Secret manifest, leaking the very
+	// payload the masking exists to hide.
+	fields := NormalizeSensitiveFields(sensitiveFields)
 	if len(fields) == 0 && obfuscated.GetKind() == "Secret" && obfuscated.GetAPIVersion() == "v1" {
 		fields = []string{"data", "stringData"}
 	}
@@ -306,6 +312,31 @@ func BuildObfuscatedYAML(yamlBody, overrideNamespace string, sensitiveFields []s
 		return "", fmt.Errorf("failed to serialise obfuscated yaml: %v", marshalErr)
 	}
 	return string(out), nil
+}
+
+// NormalizeSensitiveFields returns s with empty / whitespace-only
+// entries removed. Returns nil rather than an empty slice so callers
+// that use `len(out) == 0` to detect "no fields" (e.g. for the
+// Secret v1 default in BuildObfuscatedYAML) behave the same way they
+// would for an unset input. SDK v2 and plugin-framework adapters
+// call this on user input from the sensitive_fields attribute
+// before populating ApplyManifestOptions / DeleteManifestOptions, so
+// a misconfigured `sensitive_fields = [""]` collapses to nil rather
+// than masking the default-secret-field path.
+func NormalizeSensitiveFields(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(s))
+	for _, v := range s {
+		if strings.TrimSpace(v) != "" {
+			out = append(out, v)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // obfuscateForLog returns the manifest YAML with sensitive fields

--- a/kubernetes/manifest_lifecycle.go
+++ b/kubernetes/manifest_lifecycle.go
@@ -42,6 +42,11 @@ type ApplyManifestOptions struct {
 	WaitFor           *types.WaitFor // nil if no wait_for block
 	Timeout           time.Duration  // applies to wait_for_rollout and wait_for
 	IgnoreFields      []string       // for fingerprint calc
+	// SensitiveFields lists dotted paths whose values are masked in
+	// any [DEBUG]-level log emission of the manifest. Defaults to
+	// "data" and "stringData" on Secret v1 when empty; same semantics
+	// as BuildObfuscatedYAML. Apply does not otherwise interpret it.
+	SensitiveFields []string
 }
 
 // ApplyManifestResult captures everything the caller needs to write back
@@ -69,7 +74,8 @@ func ApplyManifest(ctx context.Context, provider *KubeProvider, opts ApplyManife
 		manifest.SetNamespace(opts.OverrideNamespace)
 	}
 
-	log.Printf("[DEBUG] %v apply kubernetes resource:\n%s", manifest, opts.YAMLBody)
+	log.Printf("[DEBUG] %v apply kubernetes resource:\n%s",
+		manifest, obfuscateForLog(opts.YAMLBody, opts.OverrideNamespace, opts.SensitiveFields))
 
 	restClient := GetRestClientFromUnstructured(manifest, provider)
 	if restClient.Error != nil {
@@ -302,6 +308,29 @@ func BuildObfuscatedYAML(yamlBody, overrideNamespace string, sensitiveFields []s
 	return string(out), nil
 }
 
+// obfuscateForLog returns the manifest YAML with sensitive fields
+// masked, suitable for inclusion in [DEBUG] log output. Fails closed:
+// if BuildObfuscatedYAML errors (malformed YAML, invalid sensitive
+// field path) the raw body is suppressed and a placeholder is
+// returned, so secret material never reaches the log even when the
+// caller's sensitive_fields config is wrong.
+//
+// The wrapped error is deliberately NOT included in the returned
+// string. BuildObfuscatedYAML surfaces errors from the k8s
+// nested-field machinery, which embed the offending value verbatim
+// ("supersecret is of the type string, expected ..."); echoing the
+// error into the log would defeat the obfuscation. Operators can
+// re-derive the failure by running `terraform plan`, where the same
+// helper runs against yaml_body_parsed and the error surfaces as a
+// regular (non-secret) plan diagnostic.
+func obfuscateForLog(yamlBody, overrideNamespace string, sensitiveFields []string) string {
+	out, err := BuildObfuscatedYAML(yamlBody, overrideNamespace, sensitiveFields)
+	if err != nil {
+		return "(yaml obfuscation failed; body suppressed)"
+	}
+	return out
+}
+
 // DeleteManifestOptions captures everything DeleteManifest reads from the
 // caller.
 type DeleteManifestOptions struct {
@@ -311,6 +340,11 @@ type DeleteManifestOptions struct {
 	Wait              bool
 	DeleteCascade     string // "Background" | "Foreground" | "" (auto)
 	Timeout           time.Duration
+	// SensitiveFields lists dotted paths whose values are masked in
+	// any [DEBUG]-level log emission of the manifest. Defaults to
+	// "data" and "stringData" on Secret v1 when empty; same semantics
+	// as BuildObfuscatedYAML. Delete does not otherwise interpret it.
+	SensitiveFields []string
 }
 
 // DeleteManifest deletes the manifest from the cluster and (optionally)
@@ -327,7 +361,8 @@ func DeleteManifest(ctx context.Context, provider *KubeProvider, opts DeleteMani
 		manifest.SetNamespace(opts.OverrideNamespace)
 	}
 
-	log.Printf("[DEBUG] %v delete kubernetes resource:\n%s", manifest, opts.YAMLBody)
+	log.Printf("[DEBUG] %v delete kubernetes resource:\n%s",
+		manifest, obfuscateForLog(opts.YAMLBody, opts.OverrideNamespace, opts.SensitiveFields))
 
 	restClient := GetRestClientFromUnstructured(manifest, provider)
 	if restClient.Error != nil {

--- a/kubernetes/manifest_lifecycle_test.go
+++ b/kubernetes/manifest_lifecycle_test.go
@@ -54,6 +54,61 @@ data:
 		"non-sensitive sibling values must round-trip")
 }
 
+// TestObfuscateForLog_BlankEntriesDontSuppressSecretDefault covers the
+// CodeRabbit follow-up to #308: a misconfigured sensitive_fields list
+// like [""] previously made `len(fields) != 0` in BuildObfuscatedYAML,
+// silently skipping the Secret v1 default ("data" + "stringData") and
+// leaking the very payload the masking exists to hide. With the
+// NormalizeSensitiveFields fix, blank-only input collapses to nil and
+// the default re-activates.
+func TestObfuscateForLog_BlankEntriesDontSuppressSecretDefault(t *testing.T) {
+	const yamlBody = `apiVersion: v1
+kind: Secret
+metadata:
+  name: leak-demo
+  namespace: default
+stringData:
+  password: supersecret
+`
+	for name, in := range map[string][]string{
+		"single empty":     {""},
+		"whitespace only":  {"   ", "\t"},
+		"mixed empty real": {"", "   "},
+	} {
+		t.Run(name, func(t *testing.T) {
+			out := obfuscateForLog(yamlBody, "", in)
+			assert.NotContains(t, out, "supersecret",
+				"blank-only sensitive_fields must still trigger Secret v1 default masking, got: %q", out)
+			assert.Contains(t, out, "(sensitive value)")
+		})
+	}
+}
+
+// TestNormalizeSensitiveFields exercises the exported normalizer
+// directly: empties / whitespace / nil collapse to nil; real entries
+// pass through unchanged.
+func TestNormalizeSensitiveFields(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"nil", nil, nil},
+		{"empty slice", []string{}, nil},
+		{"single empty", []string{""}, nil},
+		{"whitespace only", []string{"  ", "\t\n"}, nil},
+		{"real entry", []string{"data.password"}, []string{"data.password"}},
+		{"real + blank", []string{"data.password", ""}, []string{"data.password"}},
+		{"blank + real", []string{"", "data.token"}, []string{"data.token"}},
+		{"two reals", []string{"a", "b"}, []string{"a", "b"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, NormalizeSensitiveFields(tc.in))
+		})
+	}
+}
+
 // TestObfuscateForLog_FailsClosed covers the security-critical fallback:
 // a malformed sensitive_fields path makes BuildObfuscatedYAML return an
 // error, and the helper must NOT emit the raw body in that case.

--- a/kubernetes/manifest_lifecycle_test.go
+++ b/kubernetes/manifest_lifecycle_test.go
@@ -1,0 +1,79 @@
+package kubernetes
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestObfuscateForLog_SecretDefaults locks in the default behaviour
+// that drives #308: a Secret v1 manifest with no explicit
+// sensitive_fields still has its data / stringData values replaced by
+// the placeholder, so the [DEBUG] log path cannot leak the values.
+func TestObfuscateForLog_SecretDefaults(t *testing.T) {
+	const yamlBody = `apiVersion: v1
+kind: Secret
+metadata:
+  name: leak-demo
+  namespace: default
+stringData:
+  password: supersecret
+data:
+  api_token: dG9wc2VjcmV0
+`
+	out := obfuscateForLog(yamlBody, "", nil)
+
+	require.Contains(t, out, "(sensitive value)", "obfuscation placeholder must appear")
+	assert.NotContains(t, out, "supersecret",
+		"raw stringData value must not appear in the log payload")
+	assert.NotContains(t, out, "dG9wc2VjcmV0",
+		"raw data value must not appear in the log payload")
+	// metadata.name is not sensitive and should round-trip so the
+	// operator can still identify which manifest the log refers to.
+	assert.Contains(t, out, "leak-demo")
+}
+
+// TestObfuscateForLog_CustomFields exercises the explicit
+// sensitive_fields path (any Kind, any apiVersion).
+func TestObfuscateForLog_CustomFields(t *testing.T) {
+	const yamlBody = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+data:
+  api_key: hunter2
+  log_level: info
+`
+	out := obfuscateForLog(yamlBody, "", []string{"data.api_key"})
+
+	assert.NotContains(t, out, "hunter2",
+		"sensitive_fields path must replace the value")
+	assert.Contains(t, out, "log_level: info",
+		"non-sensitive sibling values must round-trip")
+}
+
+// TestObfuscateForLog_FailsClosed covers the security-critical fallback:
+// a malformed sensitive_fields path makes BuildObfuscatedYAML return an
+// error, and the helper must NOT emit the raw body in that case.
+func TestObfuscateForLog_FailsClosed(t *testing.T) {
+	const yamlBody = `apiVersion: v1
+kind: Secret
+metadata:
+  name: leak-demo
+stringData:
+  password: supersecret
+`
+	// Path that resolves to a scalar rather than a map; BuildObfuscatedYAML
+	// rejects this with "only map values are supported".
+	out := obfuscateForLog(yamlBody, "", []string{"stringData.password.deeper"})
+
+	assert.NotContains(t, out, "supersecret",
+		"fail-closed: raw body must be suppressed when obfuscation errors")
+	assert.True(t,
+		strings.Contains(out, "obfuscation failed") &&
+			strings.Contains(out, "body suppressed"),
+		"placeholder must mention both 'obfuscation failed' and 'body suppressed', got: %q",
+		out)
+}

--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -537,6 +537,7 @@ func NewApplyOptions(yamlBody string) *apply.ApplyOptions {
 	}
 	return applyOptions
 }
+
 // resourceKubectlManifestApply is the SDK v2 adapter: it shapes
 // ApplyManifestOptions from *schema.ResourceData, calls the shared
 // ApplyManifest helper in manifest_lifecycle.go, and writes the result
@@ -546,6 +547,10 @@ func resourceKubectlManifestApply(ctx context.Context, d *schema.ResourceData, m
 	var ignoreFields []string
 	if raw, ok := d.GetOk("ignore_fields"); ok {
 		ignoreFields = expandStringList(raw.([]interface{}))
+	}
+	var sensitiveFields []string
+	if raw, ok := d.GetOk("sensitive_fields"); ok {
+		sensitiveFields = expandStringList(raw.([]interface{}))
 	}
 	var waitFor *types.WaitFor
 	if raw, ok := d.GetOk("wait_for"); ok {
@@ -571,6 +576,7 @@ func resourceKubectlManifestApply(ctx context.Context, d *schema.ResourceData, m
 		WaitFor:           waitFor,
 		Timeout:           d.Timeout(timeoutKey),
 		IgnoreFields:      ignoreFields,
+		SensitiveFields:   sensitiveFields,
 	})
 	if err != nil {
 		return err
@@ -628,6 +634,10 @@ func resourceKubectlManifestDelete(ctx context.Context, d *schema.ResourceData, 
 	if v, ok := d.GetOk("override_namespace"); ok {
 		overrideNs = v.(string)
 	}
+	var sensitiveFields []string
+	if raw, ok := d.GetOk("sensitive_fields"); ok {
+		sensitiveFields = expandStringList(raw.([]interface{}))
+	}
 	if err := DeleteManifest(ctx, meta.(*KubeProvider), DeleteManifestOptions{
 		YAMLBody:          d.Get("yaml_body").(string),
 		OverrideNamespace: overrideNs,
@@ -635,6 +645,7 @@ func resourceKubectlManifestDelete(ctx context.Context, d *schema.ResourceData, 
 		Wait:              d.Get("wait").(bool),
 		DeleteCascade:     d.Get("delete_cascade").(string),
 		Timeout:           d.Timeout(schema.TimeoutDelete),
+		SensitiveFields:   sensitiveFields,
 	}); err != nil {
 		return err
 	}

--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -550,7 +550,7 @@ func resourceKubectlManifestApply(ctx context.Context, d *schema.ResourceData, m
 	}
 	var sensitiveFields []string
 	if raw, ok := d.GetOk("sensitive_fields"); ok {
-		sensitiveFields = expandStringList(raw.([]interface{}))
+		sensitiveFields = NormalizeSensitiveFields(expandStringList(raw.([]interface{})))
 	}
 	var waitFor *types.WaitFor
 	if raw, ok := d.GetOk("wait_for"); ok {
@@ -636,7 +636,7 @@ func resourceKubectlManifestDelete(ctx context.Context, d *schema.ResourceData, 
 	}
 	var sensitiveFields []string
 	if raw, ok := d.GetOk("sensitive_fields"); ok {
-		sensitiveFields = expandStringList(raw.([]interface{}))
+		sensitiveFields = NormalizeSensitiveFields(expandStringList(raw.([]interface{})))
 	}
 	if err := DeleteManifest(ctx, meta.(*KubeProvider), DeleteManifestOptions{
 		YAMLBody:          d.Get("yaml_body").(string),


### PR DESCRIPTION
## Summary

Closes #308. `ApplyManifest` and `DeleteManifest` in `kubernetes/manifest_lifecycle.go` were logging `opts.YAMLBody` verbatim at `[DEBUG]`, so Secret material (`data`, `stringData`, anything listed in `sensitive_fields`) ended up in provider logs whenever an operator ran with `TF_LOG=DEBUG`. The leak applied uniformly to every apply and every delete on both halves of the muxed provider after #306.

## What changed

Both debug-log sites now route through a new unexported `obfuscateForLog` helper that wraps `BuildObfuscatedYAML` (the same routine that already drives `yaml_body_parsed`). The helper fails closed: if obfuscation errors the raw body is suppressed and a fixed placeholder is logged instead, so secret material never reaches the log even when a user's `sensitive_fields` path is malformed.

`SensitiveFields []string` is now a member of both `ApplyManifestOptions` and `DeleteManifestOptions`. The SDK v2 adapters (`resourceKubectlManifestApply`, `resourceKubectlManifestDelete`) and the plugin-framework resource (`buildApplyOptions`, `Delete`) both populate it from the existing `sensitive_fields` attribute, so the behaviour is identical on both code paths.

## A subtle leak the tests caught

The wrapped error is deliberately NOT included in the placeholder. `BuildObfuscatedYAML` surfaces errors from the k8s nested-field machinery, and those errors embed the offending value verbatim (`"supersecret is of the type string, expected ..."`). An earlier draft of `obfuscateForLog` used `fmt.Sprintf("(yaml obfuscation failed: %v; body suppressed)", err)` and the new `TestObfuscateForLog_FailsClosed` test caught the secondary leak immediately. The committed version strips the wrapped error entirely; operators can re-derive the failure by running `terraform plan` (where `BuildObfuscatedYAML` already runs against `yaml_body_parsed` and any error surfaces as a non-secret plan diagnostic).

## Verification

`go build ./...`, `go vet ./...`, `go test ./kubernetes/ ./internal/framework/...`, `gofmt -l` all pass. `make doc-coverage` reports 23/23 = 100% (the unexported helper does not count toward exported-symbol coverage). Three new unit tests in `kubernetes/manifest_lifecycle_test.go` cover the Secret v1 default fields, an explicit `sensitive_fields` path, and the fail-closed path that initially regressed during development.

## Reproduce on master

```hcl
resource "kubectl_manifest" "leak" {
  yaml_body = <<-YAML
    apiVersion: v1
    kind: Secret
    metadata:
      name: leak-demo
      namespace: default
    stringData:
      password: supersecret
  YAML
}
```

Before this PR: `TF_LOG=DEBUG terraform apply 2>&1 | grep 'apply kubernetes resource'` prints `password: supersecret`. After: the same line prints `password: (sensitive value)`.

## Out of scope

Provider-level log redaction (a `TF_LOG_PROVIDER`-aware filter that scrubs other potentially-sensitive lines emitted by the k8s client libraries) remains a separate, larger task. This PR addresses the two log sites that the provider itself owns; the rest of the log surface continues to obey whatever `TF_LOG` set on the Terraform run.

Fixes: alekc/terraform-provider-kubectl#308


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable sensitive field masking in debug logs during manifest apply and delete operations.
  * Fields specified in configuration are automatically obfuscated in log output; defaults to `data` and `stringData` for Kubernetes Secrets.

* **Tests**
  * Added unit tests for sensitive field obfuscation behavior, including default Secret handling, custom field configuration, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->