### PR TITLE
fix(kubectl_manifest): reject force_conflicts without server_side_apply at plan time

### DIFF
--- a/internal/framework/resource_kubectl_manifest.go
+++ b/internal/framework/resource_kubectl_manifest.go
@@ -626,6 +626,28 @@ func (r *manifestResource) ModifyPlan(ctx context.Context, req resource.ModifyPl
 		return
 	}
 
+	// Reject force_conflicts = true without server_side_apply = true.
+	// kubectl's apply.ApplyOptions.Validate() rejects this combination
+	// upstream, but ApplyOptions.Run() (the path the provider uses as
+	// a library consumer) never calls Validate(), so on the client-side
+	// apply branch ForceConflicts is silently dropped. Catching it
+	// here surfaces a clear diagnostic during `terraform plan` rather
+	// than at apply time and prevents a no-op flag from masquerading
+	// as configured behaviour. Unknown values on either side fall
+	// through; the check re-runs once they resolve.
+	if !plan.ForceConflicts.IsUnknown() && !plan.ServerSideApply.IsUnknown() &&
+		plan.ForceConflicts.ValueBool() && !plan.ServerSideApply.ValueBool() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("force_conflicts"),
+			"force_conflicts requires server_side_apply",
+			"force_conflicts = true has no effect with the default client-side "+
+				"apply (server_side_apply = false). Set server_side_apply = true "+
+				"if you want server-side apply with conflict overrides, or remove "+
+				"force_conflicts.",
+		)
+		return
+	}
+
 	if plan.YAMLBody.IsUnknown() {
 		return
 	}

--- a/internal/framework/resource_kubectl_manifest_modifyplan_test.go
+++ b/internal/framework/resource_kubectl_manifest_modifyplan_test.go
@@ -99,3 +99,86 @@ func TestModifyPlan_WaitForMaxItems(t *testing.T) {
 		}
 	})
 }
+
+// TestModifyPlan_ForceConflictsRequiresSSA asserts ModifyPlan rejects
+// force_conflicts = true when server_side_apply = false (the silent
+// no-op that drives #309) and accepts every other combination,
+// including the Unknown-on-either-side case where the check cannot
+// yet decide and must fall through.
+func TestModifyPlan_ForceConflictsRequiresSSA(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := &manifestResource{}
+
+	cases := []struct {
+		name           string
+		forceConflicts types.Bool
+		serverSide     types.Bool
+		wantErr        bool
+		wantDetailSub  string
+	}{
+		{
+			name:           "both false: ok",
+			forceConflicts: types.BoolValue(false),
+			serverSide:     types.BoolValue(false),
+			wantErr:        false,
+		},
+		{
+			name:           "ssa true, force false: ok",
+			forceConflicts: types.BoolValue(false),
+			serverSide:     types.BoolValue(true),
+			wantErr:        false,
+		},
+		{
+			name:           "ssa true, force true: ok",
+			forceConflicts: types.BoolValue(true),
+			serverSide:     types.BoolValue(true),
+			wantErr:        false,
+		},
+		{
+			name:           "force true, ssa false: rejected",
+			forceConflicts: types.BoolValue(true),
+			serverSide:     types.BoolValue(false),
+			wantErr:        true,
+			wantDetailSub:  "force_conflicts = true has no effect with the default client-side apply",
+		},
+		{
+			name:           "force unknown: falls through (no error)",
+			forceConflicts: types.BoolUnknown(),
+			serverSide:     types.BoolValue(false),
+			wantErr:        false,
+		},
+		{
+			name:           "ssa unknown: falls through (no error)",
+			forceConflicts: types.BoolValue(true),
+			serverSide:     types.BoolUnknown(),
+			wantErr:        false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m := baseModel()
+			m.ForceConflicts = tc.forceConflicts
+			m.ServerSideApply = tc.serverSide
+			req, resp := newCreatePlan(ctx, t, m)
+
+			r.ModifyPlan(ctx, req, resp)
+
+			if tc.wantErr {
+				if !resp.Diagnostics.HasError() {
+					t.Fatalf("expected an error, got none")
+				}
+				if !strings.Contains(resp.Diagnostics.Errors()[0].Detail(), tc.wantDetailSub) {
+					t.Errorf("unexpected diagnostic: %s", resp.Diagnostics.Errors()[0].Detail())
+				}
+				return
+			}
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("unexpected error: %+v", resp.Diagnostics)
+			}
+		})
+	}
+}

--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -228,6 +228,22 @@ metadata:
 		},
 		CustomizeDiff: func(context context.Context, d *schema.ResourceDiff, meta interface{}) error {
 
+			// Reject force_conflicts = true without server_side_apply = true.
+			// kubectl's apply.ApplyOptions.Validate() rejects this combination
+			// upstream, but ApplyOptions.Run() (the path the provider uses as a
+			// library consumer) never calls Validate(), so on the client-side
+			// apply branch ForceConflicts is silently dropped. Surfacing it
+			// here during `terraform plan` is the same gate the framework half
+			// applies in ModifyPlan; both paths must catch the misconfig so
+			// the muxed provider's behaviour is consistent. Unknown values on
+			// either side fall through; the check re-runs once they resolve.
+			if d.NewValueKnown("force_conflicts") && d.NewValueKnown("server_side_apply") &&
+				d.Get("force_conflicts").(bool) && !d.Get("server_side_apply").(bool) {
+				return fmt.Errorf("force_conflicts = true has no effect with the default " +
+					"client-side apply (server_side_apply = false). Set server_side_apply = true " +
+					"if you want server-side apply with conflict overrides, or remove force_conflicts")
+			}
+
 			// trigger a recreation if the yaml-body has any pending changes
 			if d.Get("force_new").(bool) {
 				_ = d.ForceNew("yaml_body")
@@ -537,6 +553,7 @@ func NewApplyOptions(yamlBody string) *apply.ApplyOptions {
 	}
 	return applyOptions
 }
+
 // resourceKubectlManifestApply is the SDK v2 adapter: it shapes
 // ApplyManifestOptions from *schema.ResourceData, calls the shared
 // ApplyManifest helper in manifest_lifecycle.go, and writes the result

--- a/kubernetes/resource_kubectl_manifest_customizediff_test.go
+++ b/kubernetes/resource_kubectl_manifest_customizediff_test.go
@@ -1,0 +1,80 @@
+package kubernetes
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// TestCustomizeDiff_ForceConflictsRequiresSSA mirrors the framework-half
+// TestModifyPlan_ForceConflictsRequiresSSA: the SDK v2 path must reject
+// force_conflicts = true when server_side_apply = false (#309), and
+// pass every other combination.
+func TestCustomizeDiff_ForceConflictsRequiresSSA(t *testing.T) {
+	t.Parallel()
+	res := resourceKubectlManifest()
+	const baseYAML = "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n"
+
+	cases := []struct {
+		name          string
+		raw           map[string]interface{}
+		wantErrSubstr string
+	}{
+		{
+			name: "both false: ok",
+			raw: map[string]interface{}{
+				"yaml_body":         baseYAML,
+				"force_conflicts":   false,
+				"server_side_apply": false,
+			},
+		},
+		{
+			name: "ssa true, force false: ok",
+			raw: map[string]interface{}{
+				"yaml_body":         baseYAML,
+				"force_conflicts":   false,
+				"server_side_apply": true,
+			},
+		},
+		{
+			name: "ssa true, force true: ok",
+			raw: map[string]interface{}{
+				"yaml_body":         baseYAML,
+				"force_conflicts":   true,
+				"server_side_apply": true,
+			},
+		},
+		{
+			name: "force true, ssa false: rejected",
+			raw: map[string]interface{}{
+				"yaml_body":         baseYAML,
+				"force_conflicts":   true,
+				"server_side_apply": false,
+			},
+			wantErrSubstr: "force_conflicts = true has no effect with the default client-side apply",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := terraform.NewResourceConfigRaw(tc.raw)
+			_, err := res.Diff(context.Background(), nil, cfg, nil)
+			if tc.wantErrSubstr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErrSubstr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrSubstr) {
+					t.Errorf("expected error containing %q, got: %s", tc.wantErrSubstr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #309. `force_conflicts = true` was silently accepted alongside `server_side_apply = false`, even though `force_conflicts` is documented as a server-side-apply-only flag and the resulting client-side apply has nowhere to consult the flag. kubectl's `apply.ApplyOptions.Validate()` rejects this combination upstream, but `ApplyOptions.Run()` (the path the provider uses as a library consumer) never calls `Validate()`, so the misconfig silently passed through and users got the opposite of what their HCL suggested.

## What changed

Both halves of the muxed provider now reject the combination at plan time so the diagnostic surfaces during `terraform plan` rather than at apply time.

The plugin-framework half's `ModifyPlan` adds an attribute-scoped diagnostic on `force_conflicts` (so the error pins to the offending field in editor output). The SDK v2 half's `CustomizeDiff` returns the same diagnostic verbatim. Both checks fall through when either value is Unknown (interpolated from a variable or upstream resource that has not yet resolved) and re-run on the next plan once the values are known. The order of checks in `ModifyPlan` puts the new gate after the existing `wait_for` MaxItems check and before any YAML parsing, so a bad plan fails fast without touching the manifest.

## Verification

- Framework: `TestModifyPlan_ForceConflictsRequiresSSA` adds 6 subtests covering `false/false`, `false/true`, `true/true`, `true/false` (the negative path), and two Unknown-on-either-side fall-through cases.
- SDK v2: `TestCustomizeDiff_ForceConflictsRequiresSSA` adds 4 subtests invoking `resourceKubectlManifest().Diff(...)` directly so the CustomizeDiff path is exercised without a live cluster.
- `go build ./...`, `go vet ./...`, all unit tests across `kubernetes/` and `internal/framework/`, `gofmt -l`, and `make doc-coverage` all pass. Coverage gate stays at 23/23 (no new exported symbols).

## Reproduce on master

```hcl
resource "kubectl_manifest" "bad" {
  server_side_apply = false
  force_conflicts   = true
  yaml_body         = "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n"
}
```

Before this PR: `terraform plan` accepts the config; `terraform apply` succeeds; `force_conflicts` has zero effect.

After this PR: `terraform plan` fails with `force_conflicts = true has no effect with the default client-side apply (server_side_apply = false). Set server_side_apply = true if you want server-side apply with conflict overrides, or remove force_conflicts.`

## Why a plan-time check rather than calling kubectl's Validate()

The two natural fixes are (a) a plan-time check in `ModifyPlan` + `CustomizeDiff` and (b) calling `applyOptions.Validate()` at the top of `ApplyManifest` to mirror what the kubectl CLI does. Option (a) wins on UX because the error surfaces during `terraform plan` instead of `terraform apply`, which is the right time to catch contract violations. It also keeps `kubernetes/manifest_lifecycle.go` agnostic of kubectl's CLI-specific validation pipeline.

Fixes: alekc/terraform-provider-kubectl#309


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation that prevents setting force_conflicts when server-side apply is disabled. Incompatible attribute combinations now produce an error during planning, ensuring consistent behavior across operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->