### PR TITLE
fix(framework): preserve prior state when Update fails

### DIFF
--- a/internal/framework/resource_kubectl_manifest.go
+++ b/internal/framework/resource_kubectl_manifest.go
@@ -545,8 +545,23 @@ func (r *manifestResource) Read(ctx context.Context, req resource.ReadRequest, r
 // Update reapplies the manifest in place. The shared kubernetes.ApplyManifest
 // helper is idempotent, so Create and Update share the same code path; the
 // only difference is which framework request type the plan arrives on.
-// Implements resource.Resource.
+//
+// On any error before or during the apply, the prior state captured from
+// req.State is restored verbatim to resp.State. Without this, a failed
+// apply would leave Terraform thinking the new yaml_body has landed
+// (because resp.State.Set was the only state-mutating call and we'd
+// return without it), and the next plan would compare config to the
+// planned-but-unapplied state and report no changes (#60). HashiCorp's
+// framework guidance is explicit on this: providers must reset state to
+// the prior value on error rather than relying on a default. Implements
+// resource.Resource.
 func (r *manifestResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var priorData manifestResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &priorData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	var data manifestResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -556,12 +571,14 @@ func (r *manifestResource) Update(ctx context.Context, req resource.UpdateReques
 	provider, err := r.kubeProvider()
 	if err != nil {
 		resp.Diagnostics.AddError("kubectl_manifest Update: provider unavailable", err.Error())
+		resp.Diagnostics.Append(resp.State.Set(ctx, &priorData)...)
 		return
 	}
 
 	timeout, d := data.Timeouts.Update(ctx, defaultLifecycleTimeout)
 	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {
+		resp.Diagnostics.Append(resp.State.Set(ctx, &priorData)...)
 		return
 	}
 
@@ -573,12 +590,14 @@ func (r *manifestResource) Update(ctx context.Context, req resource.UpdateReques
 	opts, d := r.buildApplyOptions(ctx, data, timeout)
 	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {
+		resp.Diagnostics.Append(resp.State.Set(ctx, &priorData)...)
 		return
 	}
 
 	result, applyErr := kubernetes.ApplyManifest(ctx, provider, opts)
 	if applyErr != nil {
 		resp.Diagnostics.AddError("kubectl_manifest Update: apply failed", applyErr.Error())
+		resp.Diagnostics.Append(resp.State.Set(ctx, &priorData)...)
 		return
 	}
 

--- a/internal/framework/resource_kubectl_manifest_acc_test.go
+++ b/internal/framework/resource_kubectl_manifest_acc_test.go
@@ -1059,11 +1059,14 @@ YAML
 `, name)
 	// The framework error formatter wraps the K8s API error across
 	// multiple lines, including breaks inside what the SDK v2 wrapper
-	// kept as one line. Match on the two stable substrings ("nginx
-	// service-name DNS label" and "DNS-1035 label") that bracket the
-	// failure rather than trying to thread an exact phrase through
-	// the formatter's line breaks.
-	expectedError := regexp.MustCompile(`(?s)nginx\.test-a\.svc\.cluster\.local.*DNS-1035 label`)
+	// kept as one line. Match on the bad service name plus an
+	// alternation of the validation reasons the apiserver has used
+	// over the matrix range: "DNS-1035 label" (k8s 1.32 - 1.35) and
+	// "must not contain dots" (k8s 1.36+; the apiserver tightened
+	// the Ingress backend validation message). Either phrasing
+	// satisfies the test's "server-side validation rejected this
+	// before any cluster object was created" contract.
+	expectedError := regexp.MustCompile(`(?s)nginx\.test-a\.svc\.cluster\.local.*(DNS-1035 label|must not contain dots)`)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/framework/resource_kubectl_manifest_update_test.go
+++ b/internal/framework/resource_kubectl_manifest_update_test.go
@@ -1,0 +1,94 @@
+package framework
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// TestUpdate_PreservesStateOnApplyError pins the fix for issue #60.
+// When ApplyManifest errors partway through Update, the prior state
+// must be restored verbatim to resp.State so the next plan compares
+// config against the actual (pre-failed-apply) state and reports the
+// intended change again. Without the restoration, Terraform persists
+// the planned but unapplied yaml_body and the next plan reports a
+// false "no changes".
+//
+// The test drives Update down its earliest error branch by leaving
+// the manifestResource's kubeProviderCache unset; the production code
+// then surfaces "provider not configured: kubeProviderCache unset" and
+// must restore prior state before returning. The branch is exercised
+// without a real cluster connection or fake kubernetes client, which
+// keeps the test deterministic and Go-only.
+func TestUpdate_PreservesStateOnApplyError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	priorYAML := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\ndata:\n  k: old\n"
+	plannedYAML := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\ndata:\n  k: new\n"
+
+	priorState := baseModel()
+	priorState.YAMLBody = types.StringValue(priorYAML)
+	priorState.UID = types.StringValue("uid-existing")
+	priorState.LiveUID = types.StringValue("uid-existing")
+	priorState.YAMLInCluster = types.StringValue("prior-fingerprint")
+	priorState.LiveManifestInCluster = types.StringValue("prior-fingerprint")
+	priorState.APIVersion = types.StringValue("v1")
+	priorState.Kind = types.StringValue("ConfigMap")
+	priorState.Name = types.StringValue("x")
+
+	plan := baseModel()
+	plan.YAMLBody = types.StringValue(plannedYAML)
+
+	r := &manifestResource{}
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("building schema: %+v", schemaResp.Diagnostics)
+	}
+	s := schemaResp.Schema
+	tfType := s.Type().TerraformType(ctx)
+
+	stateBlob := tfsdk.State{Schema: s, Raw: tftypes.NewValue(tfType, nil)}
+	if diags := stateBlob.Set(ctx, &priorState); diags.HasError() {
+		t.Fatalf("seeding prior state: %+v", diags)
+	}
+	planBlob := tfsdk.Plan{Schema: s, Raw: tftypes.NewValue(tfType, nil)}
+	if diags := planBlob.Set(ctx, &plan); diags.HasError() {
+		t.Fatalf("seeding plan: %+v", diags)
+	}
+
+	req := resource.UpdateRequest{State: stateBlob, Plan: planBlob}
+	resp := &resource.UpdateResponse{State: tfsdk.State{Schema: s, Raw: tftypes.NewValue(tfType, nil)}}
+
+	r.Update(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected an error diagnostic from Update with no kubeProvider, got none")
+	}
+
+	var got manifestResourceModel
+	if diags := resp.State.Get(ctx, &got); diags.HasError() {
+		t.Fatalf("reading post-Update state: %+v", diags)
+	}
+
+	if got.YAMLBody.ValueString() != priorYAML {
+		t.Errorf("yaml_body should be the prior value after a failed Update; got %q want %q",
+			got.YAMLBody.ValueString(), priorYAML)
+	}
+	if got.YAMLBody.ValueString() == plannedYAML {
+		t.Errorf("yaml_body must NOT be the planned value after a failed Update; #60 regression")
+	}
+	if got.YAMLInCluster.ValueString() != "prior-fingerprint" {
+		t.Errorf("yaml_incluster should be the prior fingerprint after a failed Update; got %q",
+			got.YAMLInCluster.ValueString())
+	}
+	if got.UID.ValueString() != "uid-existing" {
+		t.Errorf("uid should be the prior value after a failed Update; got %q",
+			got.UID.ValueString())
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #60. When `ApplyManifest` errors partway through a `kubectl_manifest` Update (expired credentials, transient API errors, partial network failure), the prior state is now restored to `resp.State` instead of being left as Terraform's default. Without this, the next plan compared config to the planned-but-unapplied state and reported a misleading "no changes", forcing users to roll back the statefile by hand.

HashiCorp's framework guidance is explicit: providers must reset state to the prior value when returning error diagnostics. Phase D (#314) moved the resource to plugin-framework but did not add this restoration step. This PR closes the gap.

## What changed

- `internal/framework/resource_kubectl_manifest.go` Update: capture prior state into `priorData` at function entry. On every error branch (`kubeProvider` lookup, `data.Timeouts.Update`, `buildApplyOptions`, `kubernetes.ApplyManifest` itself), explicitly `resp.State.Set(ctx, &priorData)` before returning. Success path is unchanged.
- `internal/framework/resource_kubectl_manifest_update_test.go` (new): `TestUpdate_PreservesStateOnApplyError` seeds prior state with `yaml_body = old`, plan with `yaml_body = new`, drives Update down its `kubeProvider unset` error branch, and asserts the post-Update state has the prior `yaml_body`, `yaml_incluster`, and `uid` rather than the planned values. Test verified to fail against the pre-fix code (without the explicit restore, `resp.State` is left as the framework default, which round-trips through `Get` as a null `manifestResourceModel`) and to pass with the fix in place.

## Behaviour

User-visible only on the failure path. Before this change, an Update that errored after the plan had been written into `data` would result in `resp.State` carrying the planned (unapplied) yaml. After this change, `resp.State` carries the prior (last-successfully-applied) yaml, which matches the actual cluster state and lets the next plan correctly re-propose the same change.

Create is untouched: on Create error the resource is correctly treated as never having existed (the framework's default for a Create with no `resp.State.Set` call is "no state written"), which is the right behaviour for that path. A future follow-up could harden Create against partial-success (apply touched the cluster but errored before returning) by reading the cluster post-error; out of scope for #60 as reported.

## Tests

- `go build ./... && go vet ./... && go test ./...` clean.
- Doc-coverage 48/48 (100%).
- `TestUpdate_PreservesStateOnApplyError` deliberately drives the earliest error branch (no kubeProvider). Verified by temporarily reverting just that branch's restore: test fails with the same null-model symptom users would see in production.

## Closes

Fixes: alekc/terraform-provider-kubectl#60


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed state preservation during failed update operations. Updates now safely restore the prior resource state when errors occur, preventing partial mutations and maintaining system consistency when update operations fail mid-process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->