### PR TITLE
fix(wait): surface watch.Error and accept Added events in wait helpers

### DIFF
--- a/kubernetes/kube_provider.go
+++ b/kubernetes/kube_provider.go
@@ -32,7 +32,12 @@ import (
 type KubeProvider struct {
 	MainClientset       *kubernetes.Clientset
 	RestConfig          restclient.Config
-	AggregatorClientset *aggregator.Clientset
+	// AggregatorClientset is the interface (not a concrete clientset) so
+	// tests can substitute the upstream fake from
+	// kube-aggregator/.../clientset/fake without faking out the REST
+	// transport. Production code constructs a real *aggregator.Clientset
+	// from provider_config.go; the interface widening is purely additive.
+	AggregatorClientset aggregator.Interface
 	// ApplyRetryCount is how many times an apply is retried with exponential
 	// backoff before surfacing the error. Sourced from the
 	// `apply_retry_count` provider arg (or KUBECTL_PROVIDER_APPLY_RETRY_COUNT).

--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -260,6 +260,9 @@ func WaitForDelete(ctx context.Context, restClient *RestClientResult, name strin
 					}
 					return fmt.Errorf("%s watch closed before resource was deleted", name)
 				}
+				if event.Type == watch.Error {
+					return watchErrorFromEvent(name, event)
+				}
 				if event.Type == watch.Deleted {
 					deleted = true
 				}
@@ -338,6 +341,9 @@ func WaitForDeploymentRollout(ctx context.Context, provider *KubeProvider, ns st
 					return nil
 				}
 				return fmt.Errorf("%s watch channel closed before Deployment rollout completed", name)
+			}
+			if event.Type == watch.Error {
+				return watchErrorFromEvent(name, event)
 			}
 			if event.Type != watch.Modified {
 				continue
@@ -433,6 +439,9 @@ func WaitForDaemonSetRollout(ctx context.Context, provider *KubeProvider, ns str
 				}
 				return fmt.Errorf("%s watch channel closed before DaemonSet rollout completed", name)
 			}
+			if event.Type == watch.Error {
+				return watchErrorFromEvent(name, event)
+			}
 			if event.Type != watch.Modified {
 				continue
 			}
@@ -509,6 +518,9 @@ func WaitForStatefulSetRollout(ctx context.Context, provider *KubeProvider, ns s
 				}
 				return fmt.Errorf("%s watch channel closed before StatefulSet rollout completed", name)
 			}
+			if event.Type == watch.Error {
+				return watchErrorFromEvent(name, event)
+			}
 			if event.Type != watch.Modified {
 				continue
 			}
@@ -526,9 +538,30 @@ func WaitForStatefulSetRollout(ctx context.Context, provider *KubeProvider, ns s
 }
 
 func WaitForApiService(ctx context.Context, provider *KubeProvider, name string, timeout time.Duration) error {
-	timeoutSeconds := int64(timeout.Seconds())
+	apiServiceClient := provider.AggregatorClientset.ApiregistrationV1().APIServices()
 
-	watcher, err := provider.AggregatorClientset.ApiregistrationV1().APIServices().Watch(ctx, meta_v1.ListOptions{Watch: true, TimeoutSeconds: &timeoutSeconds, FieldSelector: fields.OneTermEqualSelector("metadata.name", name).String()})
+	// Probe state before opening the watch. The aggregator may have
+	// already marked the APIService Available by the time we get here;
+	// a Watch opened with no ResourceVersion only delivers future
+	// events, so without the pre-probe the watcher would sit idle
+	// until the operation timeout. Capture the ResourceVersion to seed
+	// the Watch and avoid losing any reconcile event between the Get
+	// and the Watch open. Mirrors the rollout helpers (#226 / #228).
+	resourceVersion := ""
+	if current, err := apiServiceClient.Get(ctx, name, meta_v1.GetOptions{}); err == nil {
+		if apiServiceAvailable(current) {
+			return nil
+		}
+		resourceVersion = current.ResourceVersion
+	}
+
+	timeoutSeconds := int64(timeout.Seconds())
+	watcher, err := apiServiceClient.Watch(ctx, meta_v1.ListOptions{
+		Watch:           true,
+		TimeoutSeconds:  &timeoutSeconds,
+		FieldSelector:   fields.OneTermEqualSelector("metadata.name", name).String(),
+		ResourceVersion: resourceVersion,
+	})
 	if err != nil {
 		return err
 	}
@@ -546,20 +579,28 @@ func WaitForApiService(ctx context.Context, provider *KubeProvider, name string,
 				// just as the watch closed and the Modified event was
 				// dropped. Without this branch the receive would loop
 				// on the closed channel forever and burn a CPU (#266).
-				current, gerr := provider.AggregatorClientset.ApiregistrationV1().APIServices().Get(ctx, name, meta_v1.GetOptions{})
+				current, gerr := apiServiceClient.Get(ctx, name, meta_v1.GetOptions{})
 				if gerr == nil && apiServiceAvailable(current) {
 					return nil
 				}
 				return fmt.Errorf("%s watch closed before APIService reached Available", name)
 			}
-			if event.Type == watch.Modified {
-				apiService, ok := event.Object.(*apiregistration.APIService)
-				if !ok {
-					return fmt.Errorf("%s could not cast to APIService", name)
-				}
-				if apiServiceAvailable(apiService) {
-					done = true
-				}
+			if event.Type == watch.Error {
+				return watchErrorFromEvent(name, event)
+			}
+			// Accept Added in addition to Modified: a freshly-applied
+			// APIService whose backing service is already healthy may
+			// deliver the terminal state as Added with no follow-up
+			// Modified, which previously waited until timeout (#267).
+			if event.Type != watch.Modified && event.Type != watch.Added {
+				continue
+			}
+			apiService, ok := event.Object.(*apiregistration.APIService)
+			if !ok {
+				return fmt.Errorf("%s could not cast to APIService", name)
+			}
+			if apiServiceAvailable(apiService) {
+				done = true
 			}
 
 		case <-ctx.Done():
@@ -568,6 +609,21 @@ func WaitForApiService(ctx context.Context, provider *KubeProvider, name string,
 	}
 
 	return nil
+}
+
+// watchErrorFromEvent renders an apiserver-emitted watch.Error event
+// into a Go error. Per the watch contract the Object is normally
+// *metav1.Status carrying a human-readable Message (expired
+// ResourceVersion, RBAC change, server shutdown). Treating the event
+// as "no progress" leaves the loop spinning until the operation
+// timeout (#272); surface the message instead so the caller can act
+// or retry. Fall back to a generic error if the payload isn't a
+// Status, so a non-conforming apiserver does not slip past.
+func watchErrorFromEvent(name string, event watch.Event) error {
+	if status, ok := event.Object.(*meta_v1.Status); ok {
+		return fmt.Errorf("%s: watch error: %s", name, status.Message)
+	}
+	return fmt.Errorf("%s: watch error (unknown payload)", name)
 }
 
 // apiServiceAvailable reports whether the APIService has the Available
@@ -591,14 +647,34 @@ func apiServiceAvailable(svc *apiregistration.APIService) bool {
 }
 
 func WaitForConditions(ctx context.Context, restClient *RestClientResult, waitFields []types.WaitForField, waitConditions []types.WaitForStatusCondition, name string, timeout time.Duration) error {
-	timeoutSeconds := int64(timeout.Seconds())
+	// Probe the live state before opening the watch. The controller
+	// may have already satisfied the conditions by the time we get
+	// here; a Watch opened with no ResourceVersion only delivers
+	// future events, so without the pre-probe the watcher would sit
+	// idle until the operation timeout. Seed the Watch with the
+	// observed ResourceVersion so any reconcile event between the Get
+	// and the Watch open is still delivered. Mirrors the rollout
+	// helpers (#226 / #228).
+	resourceVersion := ""
+	if current, err := restClient.ResourceInterface.Get(ctx, name, meta_v1.GetOptions{}); err == nil {
+		matched, matchErr := matchesWaitConditions(current, waitFields, waitConditions, name)
+		if matchErr != nil {
+			return matchErr
+		}
+		if matched {
+			return nil
+		}
+		resourceVersion = current.GetResourceVersion()
+	}
 
+	timeoutSeconds := int64(timeout.Seconds())
 	watcher, err := restClient.ResourceInterface.Watch(
 		ctx,
 		meta_v1.ListOptions{
-			Watch:          true,
-			TimeoutSeconds: &timeoutSeconds,
-			FieldSelector:  fields.OneTermEqualSelector("metadata.name", name).String(),
+			Watch:           true,
+			TimeoutSeconds:  &timeoutSeconds,
+			FieldSelector:   fields.OneTermEqualSelector("metadata.name", name).String(),
+			ResourceVersion: resourceVersion,
 		},
 	)
 	if err != nil {
@@ -630,6 +706,9 @@ func WaitForConditions(ctx context.Context, restClient *RestClientResult, waitFi
 				return fmt.Errorf("%s watch closed before conditions met", name)
 			}
 			log.Printf("[TRACE] Received event type %s for %s", event.Type, name)
+			if event.Type == watch.Error {
+				return watchErrorFromEvent(name, event)
+			}
 			if event.Type == watch.Modified || event.Type == watch.Added {
 				rawResponse, ok := event.Object.(*meta_v1_unstruct.Unstructured)
 				if !ok {

--- a/kubernetes/wait_helpers_test.go
+++ b/kubernetes/wait_helpers_test.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,6 +12,9 @@ import (
 	apimachineryschema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
+	clienttesting "k8s.io/client-go/testing"
+	apiregistration "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	aggregatorfake "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
 
 	"github.com/alekc/terraform-provider-kubectl/internal/types"
 )
@@ -336,5 +340,221 @@ func TestMatchesWaitConditions_TableDriven(t *testing.T) {
 				t.Errorf("matchesWaitConditions = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// apiServiceWithAvailable builds an APIService whose Status carries an
+// Available condition with the given Status value. Centralised so the
+// tests don't repeat the struct layout.
+func apiServiceWithAvailable(name, resourceVersion string, status apiregistration.ConditionStatus) *apiregistration.APIService {
+	return &apiregistration.APIService{
+		ObjectMeta: meta_v1.ObjectMeta{Name: name, ResourceVersion: resourceVersion},
+		Status: apiregistration.APIServiceStatus{
+			Conditions: []apiregistration.APIServiceCondition{
+				{Type: apiregistration.Available, Status: status},
+			},
+		},
+	}
+}
+
+// TestWaitForApiService_EarlyReturnIfAlreadyAvailable pins the
+// Get-before-Watch race fix: if the aggregator has already marked the
+// APIService Available, the helper must return nil without opening a
+// Watch. Pairs with the parallel rollout helpers (#226, #228).
+func TestWaitForApiService_EarlyReturnIfAlreadyAvailable(t *testing.T) {
+	t.Parallel()
+	available := apiServiceWithAvailable("v1.example.com", "10", apiregistration.ConditionTrue)
+	fakeClient := aggregatorfake.NewClientset(available)
+
+	watchOpened := false
+	fakeClient.PrependWatchReactor("apiservices", func(a clienttesting.Action) (bool, watch.Interface, error) {
+		watchOpened = true
+		return true, watch.NewFake(), nil
+	})
+
+	provider := &KubeProvider{AggregatorClientset: fakeClient}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := WaitForApiService(ctx, provider, "v1.example.com", 60*time.Second); err != nil {
+		t.Fatalf("expected nil error when pre-watch probe finds Available=True, got: %v", err)
+	}
+	if watchOpened {
+		t.Errorf("WaitForApiService should not open the watch when the probe already sees Available")
+	}
+}
+
+// TestWaitForApiService_AcceptsAddedEvent pins the second half of #267:
+// when the first event delivered after the watch opens is `Added` for
+// an already-healthy APIService (no follow-up `Modified` arrives), the
+// helper must complete promptly rather than wait until the operation
+// timeout.
+func TestWaitForApiService_AcceptsAddedEvent(t *testing.T) {
+	t.Parallel()
+	pending := apiServiceWithAvailable("v1.example.com", "1", apiregistration.ConditionFalse)
+	fakeClient := aggregatorfake.NewClientset(pending)
+
+	fakeWatch := watch.NewFake()
+	fakeClient.PrependWatchReactor("apiservices", func(a clienttesting.Action) (bool, watch.Interface, error) {
+		return true, fakeWatch, nil
+	})
+
+	go func() {
+		fakeWatch.Add(apiServiceWithAvailable("v1.example.com", "2", apiregistration.ConditionTrue))
+	}()
+
+	provider := &KubeProvider{AggregatorClientset: fakeClient}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err := WaitForApiService(ctx, provider, "v1.example.com", 60*time.Second)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected nil error for Added event carrying Available=True, got: %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("WaitForApiService should accept Added events promptly; took %s", elapsed)
+	}
+}
+
+// TestWaitForApiService_SurfacesWatchError pins the #272 fix on the
+// APIService path: a watch.Error carrying a *metav1.Status must be
+// rendered into a Go error containing the Status message, not silently
+// ignored.
+func TestWaitForApiService_SurfacesWatchError(t *testing.T) {
+	t.Parallel()
+	pending := apiServiceWithAvailable("v1.example.com", "1", apiregistration.ConditionFalse)
+	fakeClient := aggregatorfake.NewClientset(pending)
+
+	fakeWatch := watch.NewFake()
+	fakeClient.PrependWatchReactor("apiservices", func(a clienttesting.Action) (bool, watch.Interface, error) {
+		return true, fakeWatch, nil
+	})
+
+	go func() {
+		fakeWatch.Error(&meta_v1.Status{Message: "the requested resource version is too old"})
+	}()
+
+	provider := &KubeProvider{AggregatorClientset: fakeClient}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := WaitForApiService(ctx, provider, "v1.example.com", 60*time.Second)
+	if err == nil {
+		t.Fatalf("expected an error when watch.Error is delivered, got nil")
+	}
+	if !strings.Contains(err.Error(), "the requested resource version is too old") {
+		t.Errorf("expected the Status.Message in the error, got: %v", err)
+	}
+}
+
+// TestWaitForConditions_EarlyReturnIfAlreadyMatched pins the
+// Get-before-Watch race fix on the conditions path. Mirrors
+// TestWaitForApiService_EarlyReturnIfAlreadyAvailable.
+func TestWaitForConditions_EarlyReturnIfAlreadyMatched(t *testing.T) {
+	t.Parallel()
+
+	watchOpened := false
+	mock := &mockResourceInterface{
+		watchFn: func(ctx context.Context, opts meta_v1.ListOptions) (watch.Interface, error) {
+			watchOpened = true
+			return watch.NewFake(), nil
+		},
+		getFn: func(ctx context.Context, name string, opts meta_v1.GetOptions, subresources ...string) (*meta_v1_unstruct.Unstructured, error) {
+			obj := &meta_v1_unstruct.Unstructured{}
+			obj.SetName(name)
+			obj.SetUnstructuredContent(map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata":   map[string]interface{}{"name": name, "resourceVersion": "42"},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						map[string]interface{}{"type": "Ready", "status": "True"},
+					},
+				},
+			})
+			return obj, nil
+		},
+	}
+
+	rc := RestClientResultSuccess(mock)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := WaitForConditions(
+		ctx,
+		rc,
+		nil,
+		[]types.WaitForStatusCondition{{Type: "Ready", Status: "True"}},
+		"x",
+		60*time.Second,
+	)
+	if err != nil {
+		t.Fatalf("expected nil error when pre-watch probe satisfies conditions, got: %v", err)
+	}
+	if watchOpened {
+		t.Errorf("WaitForConditions should not open the watch when the probe already matches")
+	}
+}
+
+// TestWaitForConditions_SurfacesWatchError pins the #272 fix on the
+// conditions path: a watch.Error carrying a *metav1.Status must be
+// rendered into a Go error containing the Status message.
+func TestWaitForConditions_SurfacesWatchError(t *testing.T) {
+	t.Parallel()
+
+	fakeWatch := watch.NewFake()
+	mock := &mockResourceInterface{
+		watchFn: func(ctx context.Context, opts meta_v1.ListOptions) (watch.Interface, error) {
+			return fakeWatch, nil
+		},
+		getFn: func(ctx context.Context, name string, opts meta_v1.GetOptions, subresources ...string) (*meta_v1_unstruct.Unstructured, error) {
+			obj := &meta_v1_unstruct.Unstructured{}
+			obj.SetName(name)
+			obj.SetUnstructuredContent(map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata":   map[string]interface{}{"name": name, "resourceVersion": "1"},
+			})
+			return obj, nil
+		},
+	}
+
+	go func() {
+		fakeWatch.Error(&meta_v1.Status{Message: "forbidden: user cannot watch configmaps"})
+	}()
+
+	rc := RestClientResultSuccess(mock)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := WaitForConditions(
+		ctx,
+		rc,
+		nil,
+		[]types.WaitForStatusCondition{{Type: "Ready", Status: "True"}},
+		"x",
+		60*time.Second,
+	)
+	if err == nil {
+		t.Fatalf("expected an error when watch.Error is delivered, got nil")
+	}
+	if !strings.Contains(err.Error(), "forbidden: user cannot watch configmaps") {
+		t.Errorf("expected the Status.Message in the error, got: %v", err)
+	}
+}
+
+// TestWatchErrorFromEvent_UnknownPayload pins the fallback branch when
+// the apiserver delivers a watch.Error whose Object is not a Status.
+func TestWatchErrorFromEvent_UnknownPayload(t *testing.T) {
+	t.Parallel()
+	err := watchErrorFromEvent("x", watch.Event{Type: watch.Error, Object: nil})
+	if err == nil {
+		t.Fatalf("expected an error for nil Object, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown payload") {
+		t.Errorf("expected the unknown-payload fallback, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Finishes the wait-helpers hardening campaign started with #321 (#266, busy-spin on closed channel). This PR completes the remaining halves of #267 and all of #272, and closes the read-then-watch race the independent reviewer flagged on PR #321.

## What's wrong today

Five watch loops in `kubernetes/resource_kubectl_manifest.go` silently drop `watch.Error` events. An expired `ResourceVersion`, an RBAC change, or an apiserver shutdown mid-watch turns into the operation timeout instead of a fast-actionable error. `WaitForApiService` additionally accepts only `watch.Modified`, so a freshly-applied APIService whose backing service is already healthy may deliver its terminal state as `Added` and never complete until timeout (this is the second half of #267; the `ConditionTrue` half shipped in #321). And `WaitForApiService` / `WaitForConditions` had the same Get-then-Watch race the rollout helpers closed in #226 / #228: if the controller settled the state between this code path's entry and the watch open, the watcher would sit idle until the operation timeout.

## What this PR changes

A new `watchErrorFromEvent` helper extracts `*metav1.Status` from a `watch.Error` event and renders it into a Go error containing the apiserver-supplied message. It's applied to `WaitForDelete`, the three rollout helpers (`WaitForDeploymentRollout`, `WaitForDaemonSetRollout`, `WaitForStatefulSetRollout`), `WaitForApiService`, and `WaitForConditions`. `WaitForApiService` now also accepts `watch.Added` in addition to `watch.Modified`. `WaitForApiService` and `WaitForConditions` now probe live state before opening the watch (early-return on terminal state, seed `ResourceVersion` otherwise), matching the pattern the rollout helpers have used since #226 / #228.

To make the new APIService-side behaviour unit-testable, `KubeProvider.AggregatorClientset` is widened from `*aggregator.Clientset` to `aggregator.Interface`. Production code in `provider_config.go` still constructs the concrete clientset; the widening is purely additive and lets tests substitute the upstream fake from `kube-aggregator/.../clientset/fake` without faking the REST transport.

## Tests

Six new regression tests in `kubernetes/wait_helpers_test.go`: `TestWaitForApiService_EarlyReturnIfAlreadyAvailable` (probe sees Available, watch never opened), `TestWaitForApiService_AcceptsAddedEvent` (fake watch delivers Available=True via Added), `TestWaitForApiService_SurfacesWatchError` (`*metav1.Status` message threaded through into the returned error), `TestWaitForConditions_EarlyReturnIfAlreadyMatched`, `TestWaitForConditions_SurfacesWatchError`, and `TestWatchErrorFromEvent_UnknownPayload` for the fallback branch. All previous wait-helper tests still pass unchanged. The acceptance suite exercises the live paths via CI.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -short` green
- [x] No em / en dashes in commit or diff (per repo style guard)
- [x] Sign-off present, no AI attribution trailers
- [ ] Acceptance suite green in CI
- [ ] Maintainer review

Refs: alekc/terraform-provider-kubectl#267
Refs: alekc/terraform-provider-kubectl#272


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and reporting when waiting for Kubernetes resources to become available
  * Improved detection and surfacing of server errors during resource monitoring operations
  * Added early completion checks to avoid unnecessary waits when resources are already in desired state

* **Refactor**
  * Refined internal provider architecture for improved extensibility

* **Tests**
  * Expanded test coverage for resource availability monitoring and error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->