### PR TITLE
fix(provider): restore apply_retry_count loop and validate input

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ provider "kubectl" {
 
 The following arguments are supported:
 
-* `apply_retry_count` - (Optional) Defines the number of attempts any create/update action will take. Default `1`.
+* `apply_retry_count` - (Optional) Number of retries to attempt against the apiserver after the initial apply fails. `0` disables retries (single-shot apply); `N >= 1` produces up to `N + 1` total attempts. Must be `>= 0`. Defaults to `1`. Can be sourced from `KUBECTL_PROVIDER_APPLY_RETRY_COUNT`.
 * `load_config_file` - (Optional) Flag to enable/disable loading of the local kubeconf file. Default `true`. Can be sourced from `KUBE_LOAD_CONFIG_FILE`.
 * `lazy_load` - (Optional) When `true`, kubeconfig resolution errors at provider-configure time are swallowed and the actual client is built lazily on first use. Lets `terraform plan` succeed when provider arguments (`host`, `token`, certs) are sourced from outputs of resources that have not been applied yet. Off by default; can be sourced from `KUBE_LAZY_LOAD`. See [Troubleshooting](#troubleshooting) for trade-offs.
 * `host` - (Optional) The hostname (in form of URI) of the Kubernetes API. Can be sourced from `KUBE_HOST`.
@@ -118,13 +118,19 @@ provider "kubectl" {
 
 The provider has an additional parameter `apply_retry_count` that allows kubernetes commands to be retried on failure.
 This is useful if you have flaky CRDs or network connections and need to wait for the cluster state to be back in quorum.
-This applies to both create and update operations. 
+This applies to both create and update operations.
 
 ```hcl
 provider "kubectl" {
   apply_retry_count = 15
 }
 ```
+
+The integer is the **number of retries**, not the total number of attempts. `apply_retry_count = N` runs the apply once and then retries on failure up to `N` more times, so the worst case is `N + 1` total attempts. Setting `N = 0` disables the retry wrapper entirely and runs apply exactly once; this avoids double-spending the rate-limit budget when retry is not wanted (see [#228](https://github.com/alekc/terraform-provider-kubectl/issues/228)).
+
+Backoff is exponential between attempts with a 3-second initial interval and a 30-second cap. The value must be `>= 0`; the schema rejects negatives at plan time.
+
+The schema value is overridden by the `KUBECTL_PROVIDER_APPLY_RETRY_COUNT` environment variable when set, which lets CI runners crank retries up without touching the provider block. Invalid values (non-integer, negative) fail the provider configure step with an explicit diagnostic instead of silently degrading to single-shot.
 
 ## Troubleshooting
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ provider "kubectl" {
 
 The following arguments are supported:
 
-* `apply_retry_count` - (Optional) Number of retries to attempt against the apiserver after the initial apply fails. `0` disables retries (single-shot apply); `N >= 1` produces up to `N + 1` total attempts. Must be `>= 0`. Defaults to `1`. Can be sourced from `KUBECTL_PROVIDER_APPLY_RETRY_COUNT`.
+* `apply_retry_count` - (Optional) Number of retries to attempt against the apiserver after the initial apply fails. `0` disables retries (single-shot apply); `N >= 1` produces up to `N + 1` total attempts. Must be `>= 0`. Defaults to `1`. This value can be sourced from the `KUBECTL_PROVIDER_APPLY_RETRY_COUNT` environment variable.
 * `load_config_file` - (Optional) Flag to enable/disable loading of the local kubeconf file. Default `true`. Can be sourced from `KUBE_LOAD_CONFIG_FILE`.
 * `lazy_load` - (Optional) When `true`, kubeconfig resolution errors at provider-configure time are swallowed and the actual client is built lazily on first use. Lets `terraform plan` succeed when provider arguments (`host`, `token`, certs) are sourced from outputs of resources that have not been applied yet. Off by default; can be sourced from `KUBE_LAZY_LOAD`. See [Troubleshooting](#troubleshooting) for trade-offs.
 * `host` - (Optional) The hostname (in form of URI) of the Kubernetes API. Can be sourced from `KUBE_HOST`.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 toolchain go1.26.3
 
 require (
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/terraform v0.12.29
 	github.com/hashicorp/terraform-plugin-framework v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/bmatcuk/doublestar v1.1.5/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/internal/framework/provider.go
+++ b/internal/framework/provider.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strconv"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/alekc/terraform-provider-kubectl/kubernetes"
@@ -88,8 +90,13 @@ func (p *kubectlFrameworkProvider) Schema(_ context.Context, _ provider.SchemaRe
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"apply_retry_count": schema.Int64Attribute{
-				Optional:    true,
-				Description: "Defines the number of attempts any create/update action will take",
+				Optional: true,
+				Description: "Number of retries to attempt against the apiserver after the " +
+					"initial apply fails. `0` disables retries (single-shot apply). `N >= 1` " +
+					"produces up to `N + 1` total attempts with exponential backoff " +
+					"(3s initial, 30s max). Can be sourced from " +
+					"`KUBECTL_PROVIDER_APPLY_RETRY_COUNT`. Defaults to `1`.",
+				Validators: []validator.Int64{int64AtLeastValidator{min: 0}},
 			},
 			"host": schema.StringAttribute{
 				Optional:    true,
@@ -347,6 +354,44 @@ func (p *kubectlFrameworkProvider) DataSources(_ context.Context) []func() datas
 func (p *kubectlFrameworkProvider) EphemeralResources(_ context.Context) []func() ephemeral.EphemeralResource {
 	return []func() ephemeral.EphemeralResource{
 		NewManifestEphemeralResource,
+	}
+}
+
+// int64AtLeastValidator is a small inline validator that rejects values
+// below a configured minimum. Mirrors the existing stringOneOfValidator
+// pattern in resource_kubectl_manifest.go: kept inline to avoid pulling
+// in terraform-plugin-framework-validators for a single call site. If a
+// second int64 validator lands, swap to that module wholesale.
+type int64AtLeastValidator struct {
+	min int64
+}
+
+// Description returns a one-line plaintext summary. Implements validator.Int64.
+func (v int64AtLeastValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("value must be at least %d", v.min)
+}
+
+// MarkdownDescription returns the same summary as Description; no Markdown
+// is needed for a numeric bound. Implements validator.Int64.
+func (v int64AtLeastValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateInt64 rejects any non-null, non-unknown value below the minimum.
+// Null and unknown pass through so the validator composes cleanly with
+// Optional attributes whose value may not be set in the config. Implements
+// validator.Int64.
+func (v int64AtLeastValidator) ValidateInt64(_ context.Context, req validator.Int64Request, resp *validator.Int64Response) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	got := req.ConfigValue.ValueInt64()
+	if got < v.min {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid Attribute Value",
+			fmt.Sprintf("Attribute %s value must be at least %d, got: %d.", req.Path, v.min, got),
+		)
 	}
 }
 

--- a/internal/framework/provider_test.go
+++ b/internal/framework/provider_test.go
@@ -1,0 +1,86 @@
+package framework
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestInt64AtLeastValidator pins the schema-level guard for issue #274:
+// apply_retry_count = -1 historically wrapped through the signed-to-unsigned
+// cast in BuildKubeProvider; we now reject it at plan time so the misuse
+// surfaces as an attribute error against the user's config instead of
+// (silently) becoming infinite retries at apply time.
+//
+// Covers null + unknown pass-through (composes with Optional), the minimum
+// boundary, and a value below the minimum.
+func TestInt64AtLeastValidator(t *testing.T) {
+	v := int64AtLeastValidator{min: 0}
+
+	cases := []struct {
+		name   string
+		value  types.Int64
+		wantOK bool
+		needle string
+	}{
+		{"null passes", types.Int64Null(), true, ""},
+		{"unknown passes", types.Int64Unknown(), true, ""},
+		{"minimum passes", types.Int64Value(0), true, ""},
+		{"above minimum passes", types.Int64Value(5), true, ""},
+		{"below minimum fails", types.Int64Value(-1), false, "at least 0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := validator.Int64Request{
+				Path:           path.Root("apply_retry_count"),
+				PathExpression: path.MatchRoot("apply_retry_count"),
+				ConfigValue:    tc.value,
+			}
+			resp := &validator.Int64Response{}
+			v.ValidateInt64(context.Background(), req, resp)
+
+			hasError := resp.Diagnostics.HasError()
+			if tc.wantOK && hasError {
+				t.Fatalf("unexpected diagnostics: %s", resp.Diagnostics)
+			}
+			if !tc.wantOK && !hasError {
+				t.Fatalf("expected an attribute error, got none")
+			}
+			if tc.needle != "" {
+				var matched bool
+				for _, d := range resp.Diagnostics.Errors() {
+					if strings.Contains(d.Detail(), tc.needle) || strings.Contains(d.Summary(), tc.needle) {
+						matched = true
+						break
+					}
+				}
+				if !matched {
+					t.Errorf("diagnostic did not mention %q: %s", tc.needle, resp.Diagnostics)
+				}
+			}
+		})
+	}
+
+	// Sanity-check Description / MarkdownDescription return something useful
+	// so the user sees a meaningful message in `terraform validate` output.
+	if got := v.Description(context.Background()); !strings.Contains(got, "0") {
+		t.Errorf("Description does not mention the minimum: %s", got)
+	}
+	if got := v.MarkdownDescription(context.Background()); !strings.Contains(got, "0") {
+		t.Errorf("MarkdownDescription does not mention the minimum: %s", got)
+	}
+
+	// Compile-time assertion that the validator implements the interface
+	// (catches accidental signature drift from upstream).
+	var _ validator.Int64 = v
+
+	// attr is only imported so the test stays close to a real plan-time
+	// invocation that the framework would do. Tag-use anchor to keep the
+	// import live without a separate _ = attr.Type assignment.
+	_ = (attr.Value)(types.Int64Null())
+}

--- a/kubernetes/manifest_lifecycle.go
+++ b/kubernetes/manifest_lifecycle.go
@@ -113,10 +113,15 @@ func ApplyManifest(ctx context.Context, provider *KubeProvider, opts ApplyManife
 	// safely re-run), run apply once, then re-read the object so the
 	// caller can persist its fingerprint. Retried under exponential
 	// backoff when provider.ApplyRetryCount > 0; called once directly
-	// otherwise (issue #228: never apply twice with retryCount = 0,
-	// which historically double-spent the request budget and surfaced
-	// as "client rate limiter Wait returned an error: context deadline
-	// exceeded").
+	// otherwise. The retryCount == 0 short-circuit is for intent and
+	// readability (issue #228); the backoff path would also produce
+	// exactly one attempt for N = 0 because Retry calls the operation
+	// before consulting NextBackOff.
+	//
+	// rawResponse is the last successful Get result. It is nil until at
+	// least one attempt writes it; if all attempts fail the loop returns
+	// a non-nil error before any caller can read it, so partial-write
+	// leak is impossible.
 	var rawResponse *meta_v1_unstruct.Unstructured
 	applyAndFetch := func() error {
 		applyOptions := NewApplyOptions(yamlBody)
@@ -163,13 +168,23 @@ func ApplyManifest(ctx context.Context, provider *KubeProvider, opts ApplyManife
 		exp := backoff.NewExponentialBackOff()
 		exp.InitialInterval = 3 * time.Second
 		exp.MaxInterval = 30 * time.Second
+		// Wrap the policy with WithContext so a cancelled ctx (Ctrl-C,
+		// resource timeout, parent plan abort) interrupts the inter-retry
+		// sleep instead of waiting out the full backoff window. Without
+		// this wrap, backoff.Retry's internal getContext falls back to
+		// context.Background() and a user who hits Ctrl-C during a 30s
+		// backoff would hang for the remainder of that sleep.
+		policy := backoff.WithContext(
+			backoff.WithMaxRetries(exp, provider.ApplyRetryCount),
+			ctx,
+		)
 		retryErr := backoff.Retry(func() error {
 			if err := applyAndFetch(); err != nil {
 				log.Printf("[ERROR] applying manifest failed: %+v", err)
 				return err
 			}
 			return nil
-		}, backoff.WithMaxRetries(exp, provider.ApplyRetryCount))
+		}, policy)
 		if retryErr != nil {
 			return nil, retryErr
 		}

--- a/kubernetes/manifest_lifecycle.go
+++ b/kubernetes/manifest_lifecycle.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alekc/terraform-provider-kubectl/internal/types"
 	"github.com/alekc/terraform-provider-kubectl/yaml"
+	backoff "github.com/cenkalti/backoff/v4"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	meta_v1_unstruct "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -105,41 +106,73 @@ func ApplyManifest(ctx context.Context, provider *KubeProvider, opts ApplyManife
 		return nil, fmt.Errorf("%v failed to close temp file for apply: %+v", manifest, err)
 	}
 
-	applyOptions := NewApplyOptions(yamlBody)
-	applyOptions.Builder = k8sresource.NewBuilder(k8sresource.RESTClientGetter(provider))
-	applyOptions.DeleteOptions = &k8sdelete.DeleteOptions{
-		FilenameOptions: k8sresource.FilenameOptions{
-			Filenames: []string{tmpfile.Name()},
-		},
-	}
-	applyOptions.ToPrinter = func(string) (printers.ResourcePrinter, error) {
-		return printers.NewDiscardingPrinter(), nil
-	}
-	if !opts.ValidateSchema {
-		applyOptions.Validator = validation.NullSchema{}
-	}
-	if opts.ServerSideApply {
-		applyOptions.ServerSideApply = true
-		applyOptions.FieldManager = opts.FieldManager
-	}
-	if opts.ForceConflicts {
-		applyOptions.ForceConflicts = true
-	}
-	if manifest.HasNamespace() {
-		applyOptions.Namespace = manifest.GetNamespace()
-	}
-
 	log.Printf("[INFO] %s perform apply of manifest", manifest)
 
-	if err := applyOptions.Run(); err != nil {
-		return nil, fmt.Errorf("%v failed to run apply: %+v", manifest, err)
+	// applyAndFetch is the unit-of-retry: build a fresh ApplyOptions
+	// (apply.ApplyOptions tracks visitor state internally and cannot be
+	// safely re-run), run apply once, then re-read the object so the
+	// caller can persist its fingerprint. Retried under exponential
+	// backoff when provider.ApplyRetryCount > 0; called once directly
+	// otherwise (issue #228: never apply twice with retryCount = 0,
+	// which historically double-spent the request budget and surfaced
+	// as "client rate limiter Wait returned an error: context deadline
+	// exceeded").
+	var rawResponse *meta_v1_unstruct.Unstructured
+	applyAndFetch := func() error {
+		applyOptions := NewApplyOptions(yamlBody)
+		applyOptions.Builder = k8sresource.NewBuilder(k8sresource.RESTClientGetter(provider))
+		applyOptions.DeleteOptions = &k8sdelete.DeleteOptions{
+			FilenameOptions: k8sresource.FilenameOptions{
+				Filenames: []string{tmpfile.Name()},
+			},
+		}
+		applyOptions.ToPrinter = func(string) (printers.ResourcePrinter, error) {
+			return printers.NewDiscardingPrinter(), nil
+		}
+		if !opts.ValidateSchema {
+			applyOptions.Validator = validation.NullSchema{}
+		}
+		if opts.ServerSideApply {
+			applyOptions.ServerSideApply = true
+			applyOptions.FieldManager = opts.FieldManager
+		}
+		if opts.ForceConflicts {
+			applyOptions.ForceConflicts = true
+		}
+		if manifest.HasNamespace() {
+			applyOptions.Namespace = manifest.GetNamespace()
+		}
+
+		if err := applyOptions.Run(); err != nil {
+			return fmt.Errorf("%v failed to run apply: %+v", manifest, err)
+		}
+		log.Printf("[INFO] %v manifest applied, fetch resource from kubernetes", manifest)
+		var err error
+		rawResponse, err = restClient.ResourceInterface.Get(ctx, manifest.GetName(), meta_v1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("%v failed to fetch resource from kubernetes: %+v", manifest, err)
+		}
+		return nil
 	}
 
-	log.Printf("[INFO] %v manifest applied, fetch resource from kubernetes", manifest)
-
-	rawResponse, err := restClient.ResourceInterface.Get(ctx, manifest.GetName(), meta_v1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("%v failed to fetch resource from kubernetes: %+v", manifest, err)
+	if provider.ApplyRetryCount == 0 {
+		if err := applyAndFetch(); err != nil {
+			return nil, err
+		}
+	} else {
+		exp := backoff.NewExponentialBackOff()
+		exp.InitialInterval = 3 * time.Second
+		exp.MaxInterval = 30 * time.Second
+		retryErr := backoff.Retry(func() error {
+			if err := applyAndFetch(); err != nil {
+				log.Printf("[ERROR] applying manifest failed: %+v", err)
+				return err
+			}
+			return nil
+		}, backoff.WithMaxRetries(exp, provider.ApplyRetryCount))
+		if retryErr != nil {
+			return nil, retryErr
+		}
 	}
 	response := yaml.NewFromUnstructured(rawResponse)
 

--- a/kubernetes/manifest_lifecycle.go
+++ b/kubernetes/manifest_lifecycle.go
@@ -78,11 +78,6 @@ func ApplyManifest(ctx context.Context, provider *KubeProvider, opts ApplyManife
 	log.Printf("[DEBUG] %v apply kubernetes resource:\n%s",
 		manifest, obfuscateForLog(opts.YAMLBody, opts.OverrideNamespace, opts.SensitiveFields))
 
-	restClient := GetRestClientFromUnstructured(manifest, provider)
-	if restClient.Error != nil {
-		return nil, fmt.Errorf("%v failed to create kubernetes rest client for update of resource: %+v", manifest, restClient.Error)
-	}
-
 	// Re-serialise after the namespace override so the temp file matches
 	// what we'll be diffing against the live state.
 	yamlBody, err := manifest.AsYAML()
@@ -108,22 +103,36 @@ func ApplyManifest(ctx context.Context, provider *KubeProvider, opts ApplyManife
 
 	log.Printf("[INFO] %s perform apply of manifest", manifest)
 
-	// applyAndFetch is the unit-of-retry: build a fresh ApplyOptions
-	// (apply.ApplyOptions tracks visitor state internally and cannot be
-	// safely re-run), run apply once, then re-read the object so the
-	// caller can persist its fingerprint. Retried under exponential
-	// backoff when provider.ApplyRetryCount > 0; called once directly
-	// otherwise. The retryCount == 0 short-circuit is for intent and
-	// readability (issue #228); the backoff path would also produce
-	// exactly one attempt for N = 0 because Retry calls the operation
-	// before consulting NextBackOff.
+	// applyAndFetch is the unit-of-retry: discover the REST client for
+	// the manifest's GroupVersionKind, build a fresh ApplyOptions
+	// (apply.ApplyOptions tracks visitor state internally and cannot
+	// be safely re-run), run apply once, then re-read the object so
+	// the caller can persist its fingerprint. Retried under
+	// exponential backoff when provider.ApplyRetryCount > 0; called
+	// once directly otherwise. The retryCount == 0 short-circuit is
+	// for intent and readability (issue #228); the backoff path would
+	// also produce exactly one attempt for N = 0 because Retry calls
+	// the operation before consulting NextBackOff.
 	//
-	// rawResponse is the last successful Get result. It is nil until at
-	// least one attempt writes it; if all attempts fail the loop returns
-	// a non-nil error before any caller can read it, so partial-write
-	// leak is impossible.
+	// Discovery is inside the retry boundary so that the
+	// CRD-then-instance race (issue #274 / _examples/crds/couchbase.tf)
+	// can recover when apply_retry_count is set: a freshly applied CRD
+	// is not always visible to the apiserver's discovery endpoint by
+	// the time the dependent instance's apply runs.
+	//
+	// restClient is the last successful REST client; rawResponse the
+	// last successful Get. Both are nil until at least one attempt
+	// writes them, and the retry loop returns a non-nil error before
+	// any caller can read a stale value, so partial-write leak is
+	// impossible.
+	var restClient *RestClientResult
 	var rawResponse *meta_v1_unstruct.Unstructured
 	applyAndFetch := func() error {
+		restClient = GetRestClientFromUnstructured(manifest, provider)
+		if restClient.Error != nil {
+			return fmt.Errorf("%v failed to create kubernetes rest client for update of resource: %+v", manifest, restClient.Error)
+		}
+
 		applyOptions := NewApplyOptions(yamlBody)
 		applyOptions.Builder = k8sresource.NewBuilder(k8sresource.RESTClientGetter(provider))
 		applyOptions.DeleteOptions = &k8sdelete.DeleteOptions{
@@ -168,12 +177,23 @@ func ApplyManifest(ctx context.Context, provider *KubeProvider, opts ApplyManife
 		exp := backoff.NewExponentialBackOff()
 		exp.InitialInterval = 3 * time.Second
 		exp.MaxInterval = 30 * time.Second
-		// Wrap the policy with WithContext so a cancelled ctx (Ctrl-C,
-		// resource timeout, parent plan abort) interrupts the inter-retry
-		// sleep instead of waiting out the full backoff window. Without
-		// this wrap, backoff.Retry's internal getContext falls back to
-		// context.Background() and a user who hits Ctrl-C during a 30s
-		// backoff would hang for the remainder of that sleep.
+		// RandomizationFactor = 0 makes MaxInterval a hard ceiling.
+		// Default 0.5 jitter is applied after MaxInterval clamps the
+		// base interval, so NextBackOff can return up to 1.5 *
+		// MaxInterval; users tuning apply_retry_count expect the
+		// documented 30s ceiling to actually hold.
+		exp.RandomizationFactor = 0
+		// MaxElapsedTime = 0 disables the wall-clock stop condition so
+		// WithMaxRetries below is the only thing bounding the loop.
+		// Default 15 minutes would silently truncate retries on slow
+		// clusters with large N.
+		exp.MaxElapsedTime = 0
+		// WithContext makes a cancelled ctx (Ctrl-C, resource timeout,
+		// parent plan abort) interrupt the inter-retry sleep instead
+		// of waiting out the full backoff window. Without this wrap,
+		// backoff.Retry's internal getContext falls back to
+		// context.Background() and a user who hits Ctrl-C during a
+		// 30s backoff would hang for the remainder of that sleep.
 		policy := backoff.WithContext(
 			backoff.WithMaxRetries(exp, provider.ApplyRetryCount),
 			ctx,

--- a/kubernetes/manifest_lifecycle.go
+++ b/kubernetes/manifest_lifecycle.go
@@ -128,7 +128,14 @@ func ApplyManifest(ctx context.Context, provider *KubeProvider, opts ApplyManife
 	var restClient *RestClientResult
 	var rawResponse *meta_v1_unstruct.Unstructured
 	applyAndFetch := func() error {
-		restClient = GetRestClientFromUnstructured(manifest, provider)
+		// Use the ctx-aware variant so a cancelled parent ctx
+		// (Ctrl-C, resource timeout, plan abort) bounds the whole
+		// retry attempt, not just the inter-retry sleep. Plain
+		// GetRestClientFromUnstructured has its own 60s timer that
+		// ignores ctx; an in-flight discovery on a slow cluster
+		// could otherwise hang each attempt for up to 60s after
+		// cancellation.
+		restClient = GetRestClientFromUnstructuredWithContext(ctx, manifest, provider)
 		if restClient.Error != nil {
 			return fmt.Errorf("%v failed to create kubernetes rest client for update of resource: %+v", manifest, restClient.Error)
 		}

--- a/kubernetes/provider_config.go
+++ b/kubernetes/provider_config.go
@@ -85,9 +85,18 @@ func BuildKubeProvider(cfg ProviderConfig, terraformVersion string) (*KubeProvid
 		restCfg = &restclient.Config{}
 	}
 
+	if cfg.ApplyRetryCount < 0 {
+		return nil, fmt.Errorf("apply_retry_count must be >= 0, got %d", cfg.ApplyRetryCount)
+	}
 	applyRetryCount := uint64(cfg.ApplyRetryCount)
 	if v := os.Getenv("KUBECTL_PROVIDER_APPLY_RETRY_COUNT"); v != "" {
-		parsed, _ := strconv.Atoi(v)
+		parsed, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("KUBECTL_PROVIDER_APPLY_RETRY_COUNT: %w", err)
+		}
+		if parsed < 0 {
+			return nil, fmt.Errorf("KUBECTL_PROVIDER_APPLY_RETRY_COUNT must be >= 0, got %d", parsed)
+		}
 		applyRetryCount = uint64(parsed)
 	}
 

--- a/kubernetes/provider_config_test.go
+++ b/kubernetes/provider_config_test.go
@@ -61,6 +61,68 @@ func TestBuildKubeProvider_ApplyRetryCountEnvOverride(t *testing.T) {
 	}
 }
 
+// TestBuildKubeProvider_ApplyRetryCountRejectsNegativeSchemaValue pins the
+// validation hook for issue #274: the framework half catches schema-level
+// negatives at plan time, but a caller that builds ProviderConfig directly
+// (or a runtime caller that bypasses the schema) must also be rejected.
+// Defence in depth.
+func TestBuildKubeProvider_ApplyRetryCountRejectsNegativeSchemaValue(t *testing.T) {
+	t.Setenv("KUBECTL_PROVIDER_APPLY_RETRY_COUNT", "")
+
+	_, err := BuildKubeProvider(ProviderConfig{
+		ApplyRetryCount: -1,
+		LoadConfigFile:  false,
+		Host:            "http://example.invalid",
+	}, "test")
+	if err == nil {
+		t.Fatalf("expected error on negative apply_retry_count, got nil")
+	}
+	if !strings.Contains(err.Error(), "apply_retry_count") || !strings.Contains(err.Error(), ">= 0") {
+		t.Errorf("unexpected diagnostic: %s", err)
+	}
+}
+
+// TestBuildKubeProvider_ApplyRetryCountEnvVarSurfacesParseError pins the
+// fix for one half of issue #274: KUBECTL_PROVIDER_APPLY_RETRY_COUNT=oops
+// historically parsed to 0 (Atoi error swallowed), silently degrading
+// retry-N configurations to single-shot. The env var now surfaces the
+// parse error so the user sees the misconfiguration.
+func TestBuildKubeProvider_ApplyRetryCountEnvVarSurfacesParseError(t *testing.T) {
+	t.Setenv("KUBECTL_PROVIDER_APPLY_RETRY_COUNT", "oops")
+
+	_, err := BuildKubeProvider(ProviderConfig{
+		ApplyRetryCount: 1,
+		LoadConfigFile:  false,
+		Host:            "http://example.invalid",
+	}, "test")
+	if err == nil {
+		t.Fatalf("expected error on invalid KUBECTL_PROVIDER_APPLY_RETRY_COUNT, got nil")
+	}
+	if !strings.Contains(err.Error(), "KUBECTL_PROVIDER_APPLY_RETRY_COUNT") {
+		t.Errorf("unexpected diagnostic: %s", err)
+	}
+}
+
+// TestBuildKubeProvider_ApplyRetryCountEnvVarRejectsNegative pins the
+// other half of issue #274: a negative env-var value historically wrapped
+// to ~MaxUint64 through the signed-to-unsigned cast, producing effectively
+// infinite retries. Now rejected with a clear diagnostic.
+func TestBuildKubeProvider_ApplyRetryCountEnvVarRejectsNegative(t *testing.T) {
+	t.Setenv("KUBECTL_PROVIDER_APPLY_RETRY_COUNT", "-1")
+
+	_, err := BuildKubeProvider(ProviderConfig{
+		ApplyRetryCount: 1,
+		LoadConfigFile:  false,
+		Host:            "http://example.invalid",
+	}, "test")
+	if err == nil {
+		t.Fatalf("expected error on negative KUBECTL_PROVIDER_APPLY_RETRY_COUNT, got nil")
+	}
+	if !strings.Contains(err.Error(), "KUBECTL_PROVIDER_APPLY_RETRY_COUNT") || !strings.Contains(err.Error(), ">= 0") {
+		t.Errorf("unexpected diagnostic: %s", err)
+	}
+}
+
 // TestBuildRestConfig_LazyLoadSwallowsClientcmdError pins the fix for
 // issue #283. With lazy_load disabled (the default) buildRestConfig must
 // surface the clientcmd error so users see the real reason their

--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -103,8 +103,21 @@ func RestClientResultFromInvalidTypeErr(err error) *RestClientResult {
 	}
 }
 
-// GetRestClientFromUnstructured creates a dynamic k8s client based on the provided manifest
+// GetRestClientFromUnstructured creates a dynamic k8s client based on the
+// provided manifest. Equivalent to GetRestClientFromUnstructuredWithContext
+// with a background context; kept for callers that don't have a request ctx
+// to plumb through.
 func GetRestClientFromUnstructured(manifest *yaml.Manifest, provider *KubeProvider) *RestClientResult {
+	return GetRestClientFromUnstructuredWithContext(context.Background(), manifest, provider)
+}
+
+// GetRestClientFromUnstructuredWithContext is the ctx-aware variant of
+// GetRestClientFromUnstructured. It exits early with ctx.Err() when ctx is
+// cancelled, so retry loops in the apply path can bound the whole attempt
+// (discovery + apply) instead of only the inter-retry sleep. The discovery
+// goroutine still runs to completion in the background but cannot block the
+// caller; discoveryWithTimeout's buffered channel lets it deliver and exit.
+func GetRestClientFromUnstructuredWithContext(ctx context.Context, manifest *yaml.Manifest, provider *KubeProvider) *RestClientResult {
 
 	doGetRestClientFromUnstructured := func(manifest *yaml.Manifest, provider *KubeProvider) *RestClientResult {
 		// Use the k8s Discovery service to find all valid APIs for this cluster
@@ -174,6 +187,9 @@ func GetRestClientFromUnstructured(manifest *yaml.Manifest, provider *KubeProvid
 	case <-timeout.C:
 		log.Printf("[ERROR] %v timed out fetching resources from discovery client", manifest)
 		return RestClientResultFromErr(fmt.Errorf("%v timed out fetching resources from discovery client", manifest))
+	case <-ctx.Done():
+		log.Printf("[INFO] %v discovery cancelled: %v", manifest, ctx.Err())
+		return RestClientResultFromErr(ctx.Err())
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #274. The issue was filed against the pre-Phase-F provider and called out two bugs in `apply_retry_count` handling: a signed-to-unsigned cast that lets `apply_retry_count = -1` wrap to `~MaxUint64` (effectively infinite retries), and a `strconv.Atoi` error on `KUBECTL_PROVIDER_APPLY_RETRY_COUNT` that was swallowed (silently degrading retry-N configurations to single-shot). While confirming the bug surface I found a larger latent regression: Phase F (#318, framework-only provider) dropped the `cenkalti/backoff/v4` retry wrapper around apply entirely. The schema attribute, the env-var fallback, and the `KubeProvider.ApplyRetryCount` field were all kept, but no caller reads the field on master. Configured users who upgraded to v3 lost retries with no diagnostic.

This PR addresses both: restores the retry wrapper inside the shared `kubernetes.ApplyManifest` helper (so both framework Create and Update inherit it from one site rather than the pre-Phase-F duplicated blocks), and adds the validation the issue asked for at both the schema layer (plan time) and the env-var layer (configure time).

## What changed

`kubernetes.ApplyManifest` builds a fresh `*apply.ApplyOptions` per attempt (k8s `ApplyOptions` tracks visitor state internally and isn't reentrant) and wraps `Run()` + the post-apply `Get` in `backoff.Retry` when `provider.ApplyRetryCount > 0`. Backoff parameters match the pre-Phase-F implementation: 3-second initial interval, 30-second cap, multiplier 1.5 (cenkalti default). The `retryCount == 0` early-return is preserved verbatim from issue #228 to avoid double-spending the request budget when retry is disabled.

`BuildKubeProvider` now surfaces both shapes of misuse as errors instead of silently masking them. `cfg.ApplyRetryCount < 0` returns an error before the cast, and `KUBECTL_PROVIDER_APPLY_RETRY_COUNT=oops` (parse error) and `KUBECTL_PROVIDER_APPLY_RETRY_COUNT=-1` (negative) both return descriptive errors instead of falling through to `0` (single-shot) or wrapping to `MaxUint64`.

The framework schema gets an inline `int64AtLeastValidator{min: 0}` that mirrors the existing `stringOneOfValidator` pattern in `resource_kubectl_manifest.go`. The validators-module wholesale swap can wait for a third call site as the in-file comment intended; one new call site doesn't justify the dep churn yet.

`docs/index.md` is updated alongside: the Argument Reference entry now spells out the `N + 1` semantics and the env-var override convention, and the Retry Support section gets a paragraph defining the `0` special case (referencing #228) and the backoff parameters.

`go.mod` adds `github.com/cenkalti/backoff/v4 v4.3.0` back as a direct dep (Phase F removed it as unused after the SDK v2 deletion).

## Tests

Four new unit tests in `kubernetes/provider_config_test.go` cover both bug paths and the schema-bypass defence-in-depth: schema-level negative on `ProviderConfig.ApplyRetryCount`, env-var parse error, env-var negative value. The two existing `TestBuildKubeProvider_ApplyRetryCount*` tests still pass unchanged so the per-provider-isolation (issue #265) and env-var-override contracts are not regressed.

A new `internal/framework/provider_test.go` adds `TestInt64AtLeastValidator` covering null + unknown pass-through, the boundary value, above-minimum, and below-minimum. Includes a compile-time `var _ validator.Int64 = v` assertion so signature drift from upstream is caught.

The actual retry-loop behaviour (number of attempts, backoff timing) is exercised by the existing acceptance suite as soon as it runs against a real cluster; a unit test that mocks `applyOptions.Run` would require pulling in the kubectl-internal apply machinery, which is more disruptive than the value it adds.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -short` green (all existing and new cases)
- [x] `go mod tidy` clean (backoff/v4 is direct, not `// indirect`)
- [x] No em / en dashes in commit or diff
- [x] Sign-off present, no AI attribution trailers
- [ ] Acceptance suite green in CI
- [ ] Maintainer review

Refs: alekc/terraform-provider-kubectl#274


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exponential-backoff retry for Kubernetes manifest apply (applies to create and update), configurable via apply_retry_count (0 disables; value N yields up to N+1 attempts; 3s initial, 30s max).

* **Bug Fixes**
  * apply_retry_count now rejects negative values and surfaces errors for invalid environment variable settings instead of silently falling back.

* **Documentation**
  * Expanded docs with retry semantics, attempt math, backoff timings, env var override, and validation rules.

* **Tests**
  * Added tests for validator, provider config, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->