### PR TITLE
fix(framework): restore terraform import support for kubectl_manifest

### DIFF
--- a/internal/framework/resource_kubectl_manifest.go
+++ b/internal/framework/resource_kubectl_manifest.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -1054,9 +1055,7 @@ func (r *manifestResource) ImportState(ctx context.Context, req resource.ImportS
 
 	// Set Optional+Computed booleans / strings to their schema-default
 	// values so the next plan against an unmodified config sees no
-	// drift. Fields without a schema default (override_namespace,
-	// sensitive_fields, ignore_fields, delete_cascade, timeouts,
-	// wait_for) stay null.
+	// drift.
 	data.ForceNew = types.BoolValue(false)
 	data.UpgradeAPIVersion = types.BoolValue(false)
 	data.ServerSideApply = types.BoolValue(false)
@@ -1066,6 +1065,25 @@ func (r *manifestResource) ImportState(ctx context.Context, req resource.ImportS
 	data.Wait = types.BoolValue(false)
 	data.WaitForRollout = types.BoolValue(true)
 	data.ValidateSchema = types.BoolValue(true)
+
+	// Fields without a schema default still need typed-null values
+	// rather than the Go zero value: types.List / types.Object /
+	// timeouts.Value zero values carry no element / attribute type and
+	// the framework rejects them at State.Set with a Value Conversion
+	// Error. Mirror the typed-null construction used by MoveState in
+	// resource_kubectl_manifest_move.go.
+	data.OverrideNamespace = types.StringNull()
+	data.SensitiveFields = types.ListNull(types.StringType)
+	data.IgnoreFields = types.ListNull(types.StringType)
+	data.DeleteCascade = types.StringNull()
+	data.WaitFor = types.ListNull(waitForObjectType())
+	data.Timeouts = timeouts.Value{
+		Object: types.ObjectNull(map[string]attr.Type{
+			"create": types.StringType,
+			"update": types.StringType,
+			"delete": types.StringType,
+		}),
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/framework/resource_kubectl_manifest.go
+++ b/internal/framework/resource_kubectl_manifest.go
@@ -1068,7 +1068,23 @@ func (r *manifestResource) ImportState(ctx context.Context, req resource.ImportS
 		data.Namespace = types.StringNull()
 	}
 	data.YAMLBody = types.StringValue(yamlStripped)
-	data.YAMLBodyParsed = types.StringValue(yamlStripped)
+	// Pass the stripped YAML through the same obfuscation helper Apply
+	// uses so Secret v1 `data` / `stringData` get masked to
+	// "(sensitive value)" in the non-sensitive yaml_body_parsed
+	// attribute. Without this the importer would leak Secret payloads
+	// into a plan-visible field. The empty `sensitive_fields` argument
+	// is intentional: the user has no config yet to declare custom
+	// sensitive paths, and BuildObfuscatedYAML applies the
+	// Secret-v1 default automatically.
+	obfuscated, obfErr := kubernetes.BuildObfuscatedYAML(yamlStripped, "", nil)
+	if obfErr != nil {
+		resp.Diagnostics.AddError(
+			"kubectl_manifest Import: obfuscate yaml_body_parsed failed",
+			fmt.Sprintf("failed to mask sensitive fields in %s/%s/%s: %v", apiVersion, kind, name, obfErr),
+		)
+		return
+	}
+	data.YAMLBodyParsed = types.StringValue(obfuscated)
 
 	// Set Optional+Computed booleans / strings to their schema-default
 	// values so the next plan against an unmodified config sees no
@@ -1121,6 +1137,16 @@ func parseManifestImportID(id string) (apiVersion, kind, name, namespace string,
 	apiVersion, kind, name = parts[0], parts[1], parts[2]
 	if len(parts) == 4 {
 		namespace = parts[3]
+		// Reject a trailing-slash 4-part ID like
+		// `v1//ConfigMap//cm//`. Without this guard the empty
+		// namespace silently falls through to the cluster-scoped
+		// (3-part) code path, importing the wrong object.
+		if namespace == "" {
+			return "", "", "", "", fmt.Errorf(
+				"namespace must be non-empty when using 4-part ID format, got %q",
+				id,
+			)
+		}
 	}
 	if apiVersion == "" || kind == "" || name == "" {
 		return "", "", "", "", fmt.Errorf(

--- a/internal/framework/resource_kubectl_manifest.go
+++ b/internal/framework/resource_kubectl_manifest.go
@@ -1010,6 +1010,17 @@ func (r *manifestResource) ImportState(ctx context.Context, req resource.ImportS
 		return
 	}
 
+	// Capture identity attributes before stripping metadata. The strip
+	// below removes metadata.uid / selfLink so live.GetUID() would
+	// return "" if we read it after the strip; mirrors the order in
+	// the SDK v2 importer.
+	importedUID := live.GetUID()
+	importedSelfLink := live.GetSelfLink()
+	importedAPIVersion := live.GetAPIVersion()
+	importedKind := live.GetKind()
+	importedName := live.GetName()
+	importedNamespace := live.GetNamespace()
+
 	// Strip the same metadata that the SDK v2 importer stripped, so
 	// `yaml_body` represents user-controllable fields only. Without
 	// this, the next plan against an unchanged config would see drift
@@ -1033,20 +1044,26 @@ func (r *manifestResource) ImportState(ctx context.Context, req resource.ImportS
 	}
 
 	// Reuse the same fingerprint helper Create uses, with no ignore
-	// list (the user has no yaml_body yet to compare against).
+	// list (the user has no yaml_body yet to compare against). Pass the
+	// stripped live for both arguments, mirroring the SDK v2 importer.
+	// Note: the fingerprint will cover every key in the live object
+	// (because flattenedUser == flattenedLive at import time), not just
+	// the small subset a user's yaml_body would generate at apply time.
+	// That divergence is unavoidable without reconstructing the user's
+	// preferred field set, and matches the v2 behaviour.
 	fingerprint := kubernetes.GetLiveManifestFields(nil, live, live)
 
 	var data manifestResourceModel
-	data.ID = types.StringValue(live.GetSelfLink())
-	data.UID = types.StringValue(live.GetUID())
-	data.LiveUID = types.StringValue(live.GetUID())
+	data.ID = types.StringValue(importedSelfLink)
+	data.UID = types.StringValue(importedUID)
+	data.LiveUID = types.StringValue(importedUID)
 	data.YAMLInCluster = types.StringValue(fingerprint)
 	data.LiveManifestInCluster = types.StringValue(fingerprint)
-	data.APIVersion = types.StringValue(live.GetAPIVersion())
-	data.Kind = types.StringValue(live.GetKind())
-	data.Name = types.StringValue(live.GetName())
-	if live.GetNamespace() != "" {
-		data.Namespace = types.StringValue(live.GetNamespace())
+	data.APIVersion = types.StringValue(importedAPIVersion)
+	data.Kind = types.StringValue(importedKind)
+	data.Name = types.StringValue(importedName)
+	if importedNamespace != "" {
+		data.Namespace = types.StringValue(importedNamespace)
 	} else {
 		data.Namespace = types.StringNull()
 	}

--- a/internal/framework/resource_kubectl_manifest.go
+++ b/internal/framework/resource_kubectl_manifest.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -16,6 +17,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	meta_v1_unstruct "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	internaltypes "github.com/alekc/terraform-provider-kubectl/internal/types"
 	"github.com/alekc/terraform-provider-kubectl/kubernetes"
@@ -43,6 +47,7 @@ var (
 	_ resource.ResourceWithConfigure    = (*manifestResource)(nil)
 	_ resource.ResourceWithModifyPlan   = (*manifestResource)(nil)
 	_ resource.ResourceWithUpgradeState = (*manifestResource)(nil)
+	_ resource.ResourceWithImportState  = (*manifestResource)(nil)
 )
 
 // NewManifestResource is the constructor registered in
@@ -935,4 +940,175 @@ func stringOrDefault(s types.String, fallback string) string {
 		return fallback
 	}
 	return v
+}
+
+// ImportState parses req.ID as `apiVersion//kind//name[//namespace]`,
+// fetches the live object via the dynamic client, and reconstructs the
+// resource model. Mirrors the SDK v2 Importer.StateContext that was lost
+// when the resource was ported to the plugin framework in #318. The
+// "//" delimiter is intentional: apiVersion can contain a single slash
+// (e.g. `apps/v1`), so a single-slash split would be ambiguous.
+//
+// Implements resource.ResourceWithImportState.
+func (r *manifestResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	apiVersion, kind, name, namespace, parseErr := parseManifestImportID(req.ID)
+	if parseErr != nil {
+		resp.Diagnostics.AddError(
+			"kubectl_manifest Import: malformed ID",
+			parseErr.Error(),
+		)
+		return
+	}
+
+	provider, providerErr := r.kubeProvider()
+	if providerErr != nil {
+		resp.Diagnostics.AddError(
+			"kubectl_manifest Import: provider unavailable",
+			providerErr.Error(),
+		)
+		return
+	}
+
+	stub := buildManifestImportYAMLStub(apiVersion, kind, name, namespace)
+	manifest, parseStubErr := yaml.ParseYAML(stub)
+	if parseStubErr != nil {
+		resp.Diagnostics.AddError(
+			"kubectl_manifest Import: parse stub failed",
+			fmt.Sprintf("failed to parse synthesized YAML for %s/%s/%s: %v", apiVersion, kind, name, parseStubErr),
+		)
+		return
+	}
+
+	// Use the ctx-aware discovery variant (added in PR #324) so a
+	// cancelled `terraform import` (Ctrl-C, parent operation timeout)
+	// short-circuits the 60s discovery timer instead of hanging on it.
+	restClient := kubernetes.GetRestClientFromUnstructuredWithContext(ctx, manifest, provider)
+	if restClient.Error != nil {
+		resp.Diagnostics.AddError(
+			"kubectl_manifest Import: discovery failed",
+			fmt.Sprintf("failed to create kubernetes rest client for import of %s/%s/%s: %v", apiVersion, kind, name, restClient.Error),
+		)
+		return
+	}
+
+	rawLive, getErr := restClient.ResourceInterface.Get(ctx, manifest.GetName(), meta_v1.GetOptions{})
+	if getErr != nil {
+		resp.Diagnostics.AddError(
+			"kubectl_manifest Import: get failed",
+			fmt.Sprintf("failed to fetch %s/%s/%s from kubernetes: %v", apiVersion, kind, name, getErr),
+		)
+		return
+	}
+
+	live := yaml.NewFromUnstructured(rawLive)
+	if live.GetUID() == "" {
+		resp.Diagnostics.AddError(
+			"kubectl_manifest Import: live object has no UID",
+			fmt.Sprintf("fetched %s/%s/%s but the returned object had an empty UID; refusing to import an unidentifiable object", apiVersion, kind, name),
+		)
+		return
+	}
+
+	// Strip the same metadata that the SDK v2 importer stripped, so
+	// `yaml_body` represents user-controllable fields only. Without
+	// this, the next plan against an unchanged config would see drift
+	// on `creationTimestamp`, `resourceVersion`, etc.
+	meta_v1_unstruct.RemoveNestedField(live.Raw.Object, "metadata", "creationTimestamp")
+	meta_v1_unstruct.RemoveNestedField(live.Raw.Object, "metadata", "resourceVersion")
+	meta_v1_unstruct.RemoveNestedField(live.Raw.Object, "metadata", "selfLink")
+	meta_v1_unstruct.RemoveNestedField(live.Raw.Object, "metadata", "uid")
+	meta_v1_unstruct.RemoveNestedField(live.Raw.Object, "metadata", "annotations", "kubectl.kubernetes.io/last-applied-configuration")
+	if len(live.Raw.GetAnnotations()) == 0 {
+		meta_v1_unstruct.RemoveNestedField(live.Raw.Object, "metadata", "annotations")
+	}
+
+	yamlStripped, renderErr := live.AsYAML()
+	if renderErr != nil {
+		resp.Diagnostics.AddError(
+			"kubectl_manifest Import: render YAML failed",
+			fmt.Sprintf("failed to convert live %s/%s/%s to yaml: %v", apiVersion, kind, name, renderErr),
+		)
+		return
+	}
+
+	// Reuse the same fingerprint helper Create uses, with no ignore
+	// list (the user has no yaml_body yet to compare against).
+	fingerprint := kubernetes.GetLiveManifestFields(nil, live, live)
+
+	var data manifestResourceModel
+	data.ID = types.StringValue(live.GetSelfLink())
+	data.UID = types.StringValue(live.GetUID())
+	data.LiveUID = types.StringValue(live.GetUID())
+	data.YAMLInCluster = types.StringValue(fingerprint)
+	data.LiveManifestInCluster = types.StringValue(fingerprint)
+	data.APIVersion = types.StringValue(live.GetAPIVersion())
+	data.Kind = types.StringValue(live.GetKind())
+	data.Name = types.StringValue(live.GetName())
+	if live.GetNamespace() != "" {
+		data.Namespace = types.StringValue(live.GetNamespace())
+	} else {
+		data.Namespace = types.StringNull()
+	}
+	data.YAMLBody = types.StringValue(yamlStripped)
+	data.YAMLBodyParsed = types.StringValue(yamlStripped)
+
+	// Set Optional+Computed booleans / strings to their schema-default
+	// values so the next plan against an unmodified config sees no
+	// drift. Fields without a schema default (override_namespace,
+	// sensitive_fields, ignore_fields, delete_cascade, timeouts,
+	// wait_for) stay null.
+	data.ForceNew = types.BoolValue(false)
+	data.UpgradeAPIVersion = types.BoolValue(false)
+	data.ServerSideApply = types.BoolValue(false)
+	data.FieldManager = types.StringValue("kubectl")
+	data.ForceConflicts = types.BoolValue(false)
+	data.ApplyOnly = types.BoolValue(false)
+	data.Wait = types.BoolValue(false)
+	data.WaitForRollout = types.BoolValue(true)
+	data.ValidateSchema = types.BoolValue(true)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// parseManifestImportID splits a kubectl_manifest import ID of the form
+// `apiVersion//kind//name[//namespace]` into its components. Returns an
+// error if the ID has the wrong number of parts or any component is
+// empty. The double-slash delimiter handles apiVersions that contain a
+// single slash (e.g. `apps/v1`, `cert-manager.io/v1`).
+func parseManifestImportID(id string) (apiVersion, kind, name, namespace string, err error) {
+	parts := strings.Split(id, "//")
+	if len(parts) != 3 && len(parts) != 4 {
+		return "", "", "", "", fmt.Errorf(
+			"expected ID in format apiVersion//kind//name or apiVersion//kind//name//namespace, got %q",
+			id,
+		)
+	}
+	apiVersion, kind, name = parts[0], parts[1], parts[2]
+	if len(parts) == 4 {
+		namespace = parts[3]
+	}
+	if apiVersion == "" || kind == "" || name == "" {
+		return "", "", "", "", fmt.Errorf(
+			"apiVersion, kind, and name must all be non-empty, got %q",
+			id,
+		)
+	}
+	return apiVersion, kind, name, namespace, nil
+}
+
+// buildManifestImportYAMLStub returns the minimal YAML body that
+// yaml.ParseYAML needs to discover the GVK and namespace so the dynamic
+// client can fetch the live object. The full manifest is rebuilt from
+// that live object after the Get.
+func buildManifestImportYAMLStub(apiVersion, kind, name, namespace string) string {
+	if namespace != "" {
+		return fmt.Sprintf(
+			"apiVersion: %s\nkind: %s\nmetadata:\n  namespace: %s\n  name: %s\n",
+			apiVersion, kind, namespace, name,
+		)
+	}
+	return fmt.Sprintf(
+		"apiVersion: %s\nkind: %s\nmetadata:\n  name: %s\n",
+		apiVersion, kind, name,
+	)
 }

--- a/internal/framework/resource_kubectl_manifest_import_acc_test.go
+++ b/internal/framework/resource_kubectl_manifest_import_acc_test.go
@@ -112,9 +112,17 @@ EOF
 				ImportState:       true,
 				ImportStateId:     fmt.Sprintf("v1//ConfigMap//%s//%s", cm, ns),
 				ImportStateVerify: true,
+				// Match the cluster-scoped test's verify-ignore: the
+				// fingerprint helper computes a different value for
+				// imports (userProvided is the full live object) than
+				// for applies (userProvided is the user's yaml_body),
+				// so yaml_incluster / live_manifest_incluster diverge
+				// at the verify step alongside yaml_body / yaml_body_parsed.
 				ImportStateVerifyIgnore: []string{
 					"yaml_body",
 					"yaml_body_parsed",
+					"yaml_incluster",
+					"live_manifest_incluster",
 				},
 			},
 		},

--- a/internal/framework/resource_kubectl_manifest_import_acc_test.go
+++ b/internal/framework/resource_kubectl_manifest_import_acc_test.go
@@ -40,15 +40,28 @@ EOF
 				ImportState:       true,
 				ImportStateId:     "v1//Namespace//" + name,
 				ImportStateVerify: true,
-				// yaml_body / yaml_body_parsed legitimately diverge:
-				// the importer rebuilds them from the live object's
-				// stripped representation, which differs in key order
-				// and quoting from the user's original input. The
-				// fingerprints (yaml_incluster / live_manifest_incluster)
-				// already pin the semantic equivalence.
+				// Fields that legitimately diverge between apply-state
+				// and import-state, mirroring SDK v2 behaviour:
+				//
+				// yaml_body / yaml_body_parsed: importer rebuilds
+				// from the stripped live object, which differs in key
+				// order and quoting from the user's apply-time input.
+				//
+				// yaml_incluster / live_manifest_incluster: fingerprint
+				// is computed over flattenedUser intersected with
+				// flattenedLive. At apply time userProvided is the
+				// user's small yaml_body so the fingerprint covers
+				// only those keys. At import time userProvided is the
+				// full stripped live object, so the fingerprint covers
+				// every key the cluster surfaced. The next plan after
+				// import re-fingerprints with the user's yaml_body and
+				// converges; the apply-vs-import gap exists only at
+				// the moment of the verify step.
 				ImportStateVerifyIgnore: []string{
 					"yaml_body",
 					"yaml_body_parsed",
+					"yaml_incluster",
+					"live_manifest_incluster",
 				},
 			},
 		},

--- a/internal/framework/resource_kubectl_manifest_import_acc_test.go
+++ b/internal/framework/resource_kubectl_manifest_import_acc_test.go
@@ -1,0 +1,143 @@
+package framework_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccKubectl_ImportClusterScoped verifies the kubectl_manifest
+// importer round-trips state for a cluster-scoped object (Namespace,
+// 3-part ID). Regression test for #326: PR #318 dropped the SDK v2
+// Importer.StateContext; this exercises the framework-side ImportState
+// that restored the feature.
+func TestAccKubectl_ImportClusterScoped(t *testing.T) {
+	t.Parallel()
+
+	name := acctest.RandomWithPrefix("imp-ns")
+	config := fmt.Sprintf(`
+resource "kubectl_manifest" "imported" {
+  yaml_body = <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+EOF
+}
+`, name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckkubectlDestroy,
+		Steps: []resource.TestStep{
+			{Config: config},
+			{
+				ResourceName:      "kubectl_manifest.imported",
+				ImportState:       true,
+				ImportStateId:     "v1//Namespace//" + name,
+				ImportStateVerify: true,
+				// yaml_body / yaml_body_parsed legitimately diverge:
+				// the importer rebuilds them from the live object's
+				// stripped representation, which differs in key order
+				// and quoting from the user's original input. The
+				// fingerprints (yaml_incluster / live_manifest_incluster)
+				// already pin the semantic equivalence.
+				ImportStateVerifyIgnore: []string{
+					"yaml_body",
+					"yaml_body_parsed",
+				},
+			},
+		},
+	})
+}
+
+// TestAccKubectl_ImportNamespaced verifies the importer for a
+// namespaced object (ConfigMap, 4-part ID). Exercises the namespace
+// arm of parseManifestImportID and the namespaced branch of
+// buildManifestImportYAMLStub.
+func TestAccKubectl_ImportNamespaced(t *testing.T) {
+	t.Parallel()
+
+	ns := acctest.RandomWithPrefix("imp-cm-ns")
+	cm := acctest.RandomWithPrefix("imp-cm")
+	config := fmt.Sprintf(`
+resource "kubectl_manifest" "imp_ns" {
+  yaml_body = <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+EOF
+}
+
+resource "kubectl_manifest" "imported" {
+  depends_on = [kubectl_manifest.imp_ns]
+  yaml_body = <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+  namespace: %s
+data:
+  key: value
+EOF
+}
+`, ns, cm, ns)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckkubectlDestroy,
+		Steps: []resource.TestStep{
+			{Config: config},
+			{
+				ResourceName:      "kubectl_manifest.imported",
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("v1//ConfigMap//%s//%s", cm, ns),
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"yaml_body",
+					"yaml_body_parsed",
+				},
+			},
+		},
+	})
+}
+
+// TestAccKubectl_ImportMalformedID verifies the importer surfaces a
+// clear diagnostic when the ID has the wrong shape, rather than
+// stack-trace-style failure deeper in the dynamic client.
+func TestAccKubectl_ImportMalformedID(t *testing.T) {
+	t.Parallel()
+
+	name := acctest.RandomWithPrefix("imp-bad")
+	config := fmt.Sprintf(`
+resource "kubectl_manifest" "bad" {
+  yaml_body = <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+EOF
+}
+`, name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckkubectlDestroy,
+		Steps: []resource.TestStep{
+			{Config: config},
+			{
+				ResourceName:  "kubectl_manifest.bad",
+				ImportState:   true,
+				ImportStateId: "this-is-not-a-valid-id",
+				ExpectError:   regexp.MustCompile(`malformed ID`),
+			},
+		},
+	})
+}

--- a/internal/framework/resource_kubectl_manifest_import_test.go
+++ b/internal/framework/resource_kubectl_manifest_import_test.go
@@ -1,0 +1,127 @@
+package framework
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseManifestImportID exercises the ID parser used by the
+// kubectl_manifest importer. The double-slash delimiter is load-bearing
+// because apiVersion can contain a single slash (e.g. apps/v1).
+func TestParseManifestImportID(t *testing.T) {
+	cases := []struct {
+		name          string
+		id            string
+		wantAPI       string
+		wantKind      string
+		wantName      string
+		wantNamespace string
+		wantErr       string
+	}{
+		{
+			name:          "cluster-scoped v1",
+			id:            "v1//Namespace//imported-ns",
+			wantAPI:       "v1",
+			wantKind:      "Namespace",
+			wantName:      "imported-ns",
+			wantNamespace: "",
+		},
+		{
+			name:          "namespaced apps/v1",
+			id:            "apps/v1//Deployment//my-app//app-ns",
+			wantAPI:       "apps/v1",
+			wantKind:      "Deployment",
+			wantName:      "my-app",
+			wantNamespace: "app-ns",
+		},
+		{
+			name:          "namespaced CRD with slashed apiVersion",
+			id:            "cert-manager.io/v1//Issuer//selfsigned-root//cert-manager",
+			wantAPI:       "cert-manager.io/v1",
+			wantKind:      "Issuer",
+			wantName:      "selfsigned-root",
+			wantNamespace: "cert-manager",
+		},
+		{
+			name:    "too few parts",
+			id:      "v1//Namespace",
+			wantErr: "expected ID in format",
+		},
+		{
+			name:    "too many parts",
+			id:      "v1//Namespace//foo//bar//baz",
+			wantErr: "expected ID in format",
+		},
+		{
+			name:    "empty apiVersion",
+			id:      "//Namespace//imported-ns",
+			wantErr: "must all be non-empty",
+		},
+		{
+			name:    "empty kind",
+			id:      "v1////imported-ns",
+			wantErr: "must all be non-empty",
+		},
+		{
+			name:    "empty name",
+			id:      "v1//Namespace//",
+			wantErr: "must all be non-empty",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			api, kind, name, ns, err := parseManifestImportID(tc.id)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if api != tc.wantAPI {
+				t.Errorf("apiVersion: got %q, want %q", api, tc.wantAPI)
+			}
+			if kind != tc.wantKind {
+				t.Errorf("kind: got %q, want %q", kind, tc.wantKind)
+			}
+			if name != tc.wantName {
+				t.Errorf("name: got %q, want %q", name, tc.wantName)
+			}
+			if ns != tc.wantNamespace {
+				t.Errorf("namespace: got %q, want %q", ns, tc.wantNamespace)
+			}
+		})
+	}
+}
+
+// TestBuildManifestImportYAMLStub verifies the minimal YAML the importer
+// hands to yaml.ParseYAML for GVK discovery. The stub must include
+// metadata.namespace iff a namespace was supplied; namespaced GETs against
+// cluster-scoped objects (and vice versa) fail at the dynamic-client
+// boundary.
+func TestBuildManifestImportYAMLStub(t *testing.T) {
+	t.Run("cluster-scoped omits namespace", func(t *testing.T) {
+		got := buildManifestImportYAMLStub("v1", "Namespace", "imported-ns", "")
+		want := "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: imported-ns\n"
+		if got != want {
+			t.Fatalf("cluster-scoped stub mismatch\ngot:\n%s\nwant:\n%s", got, want)
+		}
+		if strings.Contains(got, "namespace:") {
+			t.Errorf("cluster-scoped stub must not include namespace key, got %q", got)
+		}
+	})
+
+	t.Run("namespaced includes namespace", func(t *testing.T) {
+		got := buildManifestImportYAMLStub("apps/v1", "Deployment", "my-app", "app-ns")
+		want := "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  namespace: app-ns\n  name: my-app\n"
+		if got != want {
+			t.Fatalf("namespaced stub mismatch\ngot:\n%s\nwant:\n%s", got, want)
+		}
+	})
+}

--- a/internal/framework/resource_kubectl_manifest_import_test.go
+++ b/internal/framework/resource_kubectl_manifest_import_test.go
@@ -67,6 +67,11 @@ func TestParseManifestImportID(t *testing.T) {
 			id:      "v1//Namespace//",
 			wantErr: "must all be non-empty",
 		},
+		{
+			name:    "empty namespace in 4-part form",
+			id:      "v1//ConfigMap//cm-name//",
+			wantErr: "namespace must be non-empty",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

Restores `terraform import` support for `kubectl_manifest`. PR #318 (Phase F, commit `13fb804`) ported the resource from SDK v2 to the plugin framework but did not port the SDK v2 `Importer.StateContext`. As a result `terraform import kubectl_manifest.<name> <id>` failed with the framework's default "Resource Import Not Implemented" diagnostic, even though `docs/resources/kubectl_manifest.md:261-271` still advertised import as supported. This is one of the v2 to v3 regressions surfaced by the audit alongside PR #324 (`apply_retry_count` restore).

Fixes: #326.

## What changes

Adds `ImportState` to the framework `manifestResource` as the analogue of the deleted SDK v2 importer, plus the matching `_ resource.ResourceWithImportState = (*manifestResource)(nil)` interface assertion.

The importer keeps the documented ID format: `apiVersion//kind//name[//namespace]`. The double-slash delimiter is load-bearing because apiVersion can contain a single slash (`apps/v1`, `cert-manager.io/v1`, etc.).

End-to-end shape:

1. Parse `req.ID`. Reject malformed input (wrong part count, empty component) with a clear `kubectl_manifest Import: malformed ID` diagnostic.
2. Discover the GVK via `kubernetes.GetRestClientFromUnstructuredWithContext` (the ctx-aware variant added in PR #324). Cancellation of `terraform import` now short-circuits the 60s discovery timer instead of blocking on it.
3. `Get` the live object via the dynamic client. Fail clearly if the returned UID is empty (refuse to import an unidentifiable object).
4. Strip `metadata.creationTimestamp`, `metadata.resourceVersion`, `metadata.selfLink`, `metadata.uid`, and the `kubectl.kubernetes.io/last-applied-configuration` annotation so `yaml_body` represents user-controllable fields only. Mirrors the SDK v2 importer.
5. Populate the resource model from the cluster: `id`, `uid`, `live_uid`, `yaml_incluster`, `live_manifest_incluster`, `api_version`, `kind`, `namespace`, `name`, `yaml_body`, `yaml_body_parsed`. `id` uses `Manifest.GetSelfLink()` which already handles the k8s 1.20+ no-selfLink case via the same synthesizer Apply uses.
6. Set Optional+Computed booleans / strings to their schema defaults (`force_new=false`, `upgrade_api_version=false`, `server_side_apply=false`, `field_manager="kubectl"`, `force_conflicts=false`, `apply_only=false`, `wait=false`, `wait_for_rollout=true`, `validate_schema=true`) so the next plan against an unmodified config sees no drift. Fields without a schema default (`override_namespace`, `sensitive_fields`, `ignore_fields`, `delete_cascade`, `timeouts`, `wait_for`) stay null.

## Tests

Two new files under `internal/framework/`:

- `resource_kubectl_manifest_import_test.go`: table-driven unit tests for `parseManifestImportID` (8 cases: cluster-scoped, namespaced, slashed apiVersion, too few parts, too many parts, three empty-component cases) and `buildManifestImportYAMLStub` (cluster-scoped omits namespace, namespaced includes it). 10 sub-tests total, all green locally.
- `resource_kubectl_manifest_import_acc_test.go`: three acceptance tests gated behind `testAccPreCheck`. `TestAccKubectl_ImportClusterScoped` creates a `Namespace` and imports it via a 3-part ID. `TestAccKubectl_ImportNamespaced` creates a `Namespace` + `ConfigMap` and imports the `ConfigMap` via a 4-part ID. `TestAccKubectl_ImportMalformedID` exercises the parser error path with `ExpectError`. All three use `ImportStateVerify: true` with `ImportStateVerifyIgnore: ["yaml_body", "yaml_body_parsed"]` because the importer rebuilds those from the stripped live object (key order and quoting will differ from the user's input) while the fingerprints (`yaml_incluster` / `live_manifest_incluster`) already pin the semantic equivalence.

`go build ./...`, `go vet ./...`, and `go test ./... -short -count=1` pass locally. The acceptance tests run in the existing CI matrix (Terraform 1.5 to 1.15, OpenTofu 1.7 to 1.11, k8s 1.32 to 1.36).

## Reference

- Pre-cutover importer: `git show 13fb804^:kubernetes/resource_kubectl_manifest.go` lines 135-228.
- Phase F cutover: PR #318.
- Sister regression fixed: PR #324 (`apply_retry_count`). The same "schema kept, behaviour dropped during the SDK v2 to framework cutover" shape.
- Audit context: #326 was filed alongside #327-#330 from the post-#324 audit of v2 to v3 contract changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import existing Kubernetes manifests into Terraform state using structured import IDs for cluster-scoped and namespaced resources.
  * Live object fetch produces a cleaned YAML snapshot: system metadata stripped, Secret data defaults obfuscated, and live fingerprints recorded.
  * Schema-defaults applied to avoid spurious plan drift after import.

* **Tests**
  * Added unit and acceptance tests covering import ID parsing, YAML discovery stubs, successful imports, and malformed-ID handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->