### PR TITLE
docs(data-source): add kubectl_kustomize_documents page

### DIFF
--- a/docs/data-sources/kubectl_kustomize_documents.md
+++ b/docs/data-sources/kubectl_kustomize_documents.md
@@ -30,7 +30,7 @@ data "kubectl_kustomize_documents" "manifests" {
 ## Argument Reference
 
 * `target` - Required. Path to the kustomization directory, evaluated relative to the Terraform working directory. Same semantics as `kustomize build <target>` on the command line.
-* `load_restrictor` - Optional. Kustomize loader restriction. `rootOnly` (default) prevents bases from loading files outside the target directory; `none` removes the restriction. Anything else is rejected at config-validate time.
+* `load_restrictor` - Optional. Kustomize loader restriction. `rootOnly` (default) prevents bases from loading files outside the target directory; `none` removes the restriction. An empty string falls back to the default. Any other non-empty value is rejected at config-validate time.
 * `add_managed_by_label` - Optional. When true, kustomize stamps an `app.kubernetes.io/managed-by` label on every rendered resource. Default false.
 
 ## Attribute Reference

--- a/docs/data-sources/kubectl_kustomize_documents.md
+++ b/docs/data-sources/kubectl_kustomize_documents.md
@@ -1,0 +1,39 @@
+# Data Source: kubectl_kustomize_documents
+
+This provider provides a `data` resource `kubectl_kustomize_documents` to run `kustomize build` against a target directory and surface the rendered YAML documents to Terraform. Wraps the `sigs.k8s.io/kustomize/api` library, so no external `kustomize` binary is required at apply time.
+
+## Example Usage
+
+### Apply rendered manifests via for_each (recommended)
+
+```hcl
+data "kubectl_kustomize_documents" "manifests" {
+  target = "${path.module}/kustomize/overlays/prod"
+}
+
+resource "kubectl_manifest" "this" {
+  for_each  = { for i, doc in data.kubectl_kustomize_documents.manifests.documents : i => doc }
+  yaml_body = each.value
+}
+```
+
+### Pin the kustomize loader and add the managed-by label
+
+```hcl
+data "kubectl_kustomize_documents" "manifests" {
+  target               = "${path.module}/kustomize/overlays/prod"
+  load_restrictor      = "rootOnly"
+  add_managed_by_label = true
+}
+```
+
+## Argument Reference
+
+* `target` - Required. Path to the kustomization directory, evaluated relative to the Terraform working directory. Same semantics as `kustomize build <target>` on the command line.
+* `load_restrictor` - Optional. Kustomize loader restriction. `rootOnly` (default) prevents bases from loading files outside the target directory; `none` removes the restriction. Anything else is rejected at config-validate time.
+* `add_managed_by_label` - Optional. When true, kustomize stamps an `app.kubernetes.io/managed-by` label on every rendered resource. Default false.
+
+## Attribute Reference
+
+* `documents` - List of YAML documents (list[string]) in kustomize build order. Best used with `count` or a `for_each` expression as shown above.
+* `id` - sha256 fingerprint of the rendered document list. Stable across plans when the rendered output is unchanged.


### PR DESCRIPTION
## Summary

Adds the missing `docs/data-sources/kubectl_kustomize_documents.md` page. The data source has been registered and shipped since PR #303 (Phase F-1, framework-native from day one) but had no user-facing documentation. Users were discovering it only via the CHANGELOG or `docs/adr/0001-framework-migration-and-moved-blocks.md`. The four other data sources plus `kubectl_server_version` all have dedicated docs pages; this closes the gap.

Fixes: #327.

## What changes

One new file: `docs/data-sources/kubectl_kustomize_documents.md`.

The page mirrors the structure of the sister `kubectl_path_documents` page: a one-paragraph purpose, two `## Example Usage` blocks (one for the `for_each` recommended pattern, one showing the `load_restrictor` and `add_managed_by_label` configuration), an Argument Reference section with the three input attributes, and an Attribute Reference section with the two computed outputs.

The attribute wording is taken from the live schema in `internal/framework/data_source_kubectl_kustomize_documents.go` so the documented behaviour matches the implementation byte-for-byte:

- `target` (required): path to the kustomization directory, evaluated relative to the Terraform working directory.
- `load_restrictor` (optional, default `rootOnly`): `rootOnly` or `none`. Anything else is rejected at config-validate time by the inline `loadRestrictorValidator`.
- `add_managed_by_label` (optional, default false): stamps `app.kubernetes.io/managed-by` on every rendered resource.
- `documents` (computed): list of rendered YAML documents in kustomize build order.
- `id` (computed): sha256 fingerprint of the rendered document list.

## Tests

Docs-only change. The repo's `tests-docs-skip.yaml` workflow already emits success statuses for documentation paths (the companion to `paths-ignore` in `tests.yaml`), so branch protection is satisfied without burning the test matrix. `docstring-coverage` is Go-source-only and is correctly excluded from this PR's path filter.

## Reference

- Audit context: #327 was filed alongside #326-#330 from the post-#324 audit of v2 to v3 contract changes.
- Sister docs pages used as structural reference: `docs/data-sources/kubectl_path_documents.md` and `docs/data-sources/kubectl_file_documents.md`.
- Implementation: `internal/framework/data_source_kubectl_kustomize_documents.go` (registered at `internal/framework/provider.go:347`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the kubectl_kustomize_documents Terraform data source, detailing how to render Kubernetes YAML, with two HCL usage examples (including iteration and optional settings) and a complete reference for input arguments and output attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->