### PR TITLE
docs(resource): document kubectl_server_version triggers v2 to v3 break

### DIFF
--- a/docs/resources/kubectl_server_version.md
+++ b/docs/resources/kubectl_server_version.md
@@ -11,8 +11,8 @@ resource "kubectl_server_version" "current" { }
 ```
 
 ## Argument Reference
-  
-* `triggers` - Optional. Any changes in triggers will force a re-read. Behaves the same as the `null_resource` triggers. 
+
+* `triggers` - Optional, `map(string)`. Any change to the map forces re-creation of the resource, which refreshes the version fields from the apiserver. Behaves the same as `null_resource.triggers`. **Values must be strings.** Wrap non-string inputs with `tostring()`; see [Upgrading from v2](#upgrading-from-v2) below.
 
 ## Attribute Reference
 
@@ -24,3 +24,27 @@ resource "kubectl_server_version" "current" { }
 * `git_commit` - Git sha commit, e.g. `aae39f4697508697bf16c0de4a5687d464f4da81`.
 * `build_date` - Date the server binaries were built, e.g. `2025-08-27T08:19:12Z`.
 * `platform` - Server platform name, e.g. `linux/amd64`.
+
+## Upgrading from v2
+
+v3 ports `kubectl_server_version` from the Terraform SDK v2 to the plugin framework. The user-visible behaviour is identical except for one contract tightening: the `triggers` attribute is now declared as `map(string)` instead of an untyped map. v2 accepted values of any type and stringified them implicitly at decode time; v3 rejects non-string values at `terraform validate` with `Inappropriate value for attribute "triggers": element [...] must be string`.
+
+Stringify any non-string input with `tostring()`:
+
+```hcl
+# v2 (number value, implicitly stringified)
+resource "kubectl_server_version" "current" {
+  triggers = {
+    count = var.cluster_count
+  }
+}
+
+# v3 (explicit string)
+resource "kubectl_server_version" "current" {
+  triggers = {
+    count = tostring(var.cluster_count)
+  }
+}
+```
+
+This applies to numbers, booleans, and any other non-string scalar that was previously accepted. String-valued triggers configurations are unaffected.


### PR DESCRIPTION
## Summary

Phase F (PR #318) tightened the `kubectl_server_version` `triggers` attribute from an untyped SDK v2 map (`schema.TypeMap` with no `Elem`, values decoded as `interface{}` and stringified at decode time) to a framework `map(string)`. Configurations that worked on v2 with non-string values (e.g. `triggers = { count = var.cluster_count }` where `count` is a number) now fail with `Inappropriate value for attribute "triggers": element [...] must be string` at `terraform validate` time. Per #329, v3.0.0 is the right place to ship this tightening: widening back to a dynamic-typed map preserves v2 ergonomics but adds plan/apply complexity for an attribute that only exists to gate `RequiresReplace`. This PR ships Option 1 from the issue (document the breaking change).

Fixes: #329.

## What changes

One file: `docs/resources/kubectl_server_version.md`.

- Updated the `triggers` Argument Reference line to declare the type explicitly as `map(string)`, call out that values must be strings, and link to the migration section.
- Added a new `## Upgrading from v2` section at the bottom of the page with a concrete before/after example showing the `tostring()` workaround for the common number-value case. Also names the exact diagnostic users will see, so they can search for it.

No code change, no schema change.

## Tests

Docs-only PR. The repo's `tests-docs-skip.yaml` ghost workflow emits success statuses for the matrix-named jobs on documentation paths, so branch protection is satisfied without burning the test matrix. `docstring-coverage` is Go-source-only and is correctly excluded from this PR's path filter.

## Reference

- Audit context: #329 was filed alongside #326-#330 from the post-#324 v2-to-v3 contract audit.
- SDK v2 schema: `git show d768eaa^:kubernetes/resource_kubectl_server_version.go` lines 15-19 (untyped map).
- Framework schema: `internal/framework/resource_kubectl_server_version.go:62-70` (`map(string)`).
- Phase F cutover: PR #318 (commit `13fb804`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `triggers` argument documentation to reflect stricter type validation requirements (map(string) values).
  * Non-string trigger values must now be wrapped with the `tostring()` function.
  * Added upgrade guide for users migrating from the previous version, including validation behavior changes and migration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->