### PR TITLE
fix(framework): restore empty-map default on kubectl_path_documents vars

### DIFF
--- a/internal/framework/data_source_kubectl_path_documents.go
+++ b/internal/framework/data_source_kubectl_path_documents.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -61,7 +62,13 @@ func (d *pathDocumentsDataSource) Schema(_ context.Context, _ datasource.SchemaR
 				Description: "Glob pattern, evaluated relative to the Terraform working directory.",
 			},
 			"vars": schema.MapAttribute{
-				Optional:    true,
+				Optional: true,
+				// Computed so Read can populate the empty-map default
+				// when the user didn't set the attribute; without
+				// Computed the framework rejects state-vs-config
+				// divergence as "Provider produced inconsistent result
+				// after apply".
+				Computed:    true,
 				ElementType: types.StringType,
 				Description: "Variables to substitute into each loaded document's HCL template. The map's " +
 					"element type is string, so the framework rejects lists or maps at config-validate time " +
@@ -69,13 +76,14 @@ func (d *pathDocumentsDataSource) Schema(_ context.Context, _ datasource.SchemaR
 			},
 			"sensitive_vars": schema.MapAttribute{
 				Optional:    true,
+				Computed:    true,
 				Sensitive:   true,
 				ElementType: types.StringType,
 				Description: "Same as `vars` but the values are marked sensitive so they don't leak into plan / " +
 					"apply output. Defaults to an empty map.",
 			},
 			"disable_template": schema.BoolAttribute{
-				Optional:    true,
+				Optional: true,
 				Description: "When true, files are loaded as-is without template rendering. Useful for raw YAML " +
 					"that contains `${...}` literals that would otherwise be interpreted by Terraform. Defaults " +
 					"to false.",
@@ -202,19 +210,28 @@ func (d *pathDocumentsDataSource) Read(ctx context.Context, req datasource.ReadR
 	data.ID = types.StringValue(fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join(allDocuments, "")))))
 	data.Documents = docsVal
 	data.Manifests = manifestsVal
-	// The framework requires Optional+!Computed attributes to be written
-	// back as null if the user didn't set them; preserve that behaviour
-	// explicitly so the state shape stays predictable across reads.
+	// `vars` and `sensitive_vars` are Optional+Computed so Read fills
+	// the empty-map default when the user did not set them. SDK v2
+	// declared both with `Default: make(map[string]interface{})` so
+	// downstream `keys(data.x.vars)` returned `[]`; the post-Phase-F
+	// `types.MapNull` regression (#328) broke that contract because
+	// `keys(null)` errors with "argument must not be null". Restoring
+	// the empty-map default realigns v3 with v2 and matches the
+	// schema description ("Defaults to an empty map.").
+	emptyStringMap := types.MapValueMust(types.StringType, map[string]attr.Value{})
 	if data.Vars.IsNull() || data.Vars.IsUnknown() {
-		data.Vars = types.MapNull(types.StringType)
+		data.Vars = emptyStringMap
 	}
 	if data.SensitiveVars.IsNull() || data.SensitiveVars.IsUnknown() {
-		data.SensitiveVars = types.MapNull(types.StringType)
+		data.SensitiveVars = emptyStringMap
 	}
+	// `disable_template` stays Optional-only and null-by-default. The
+	// audit (#328) limited the regression scope to maps because
+	// `length`/`keys` on null is the failure mode; a null bool has no
+	// equivalent footgun via terraform's standard library functions.
 	if data.DisableTemplate.IsNull() || data.DisableTemplate.IsUnknown() {
 		data.DisableTemplate = types.BoolNull()
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
-

--- a/internal/framework/data_source_kubectl_path_documents_test.go
+++ b/internal/framework/data_source_kubectl_path_documents_test.go
@@ -33,6 +33,35 @@ data "kubectl_path_documents" "test" {
 	})
 }
 
+// TestAccKubectlDataSourcePathDocuments_emptyMapsByDefault pins the v2
+// behaviour of `vars` and `sensitive_vars` defaulting to an empty map
+// when the user omits them. Regression test for #328: Phase F's
+// framework rewrite shipped `types.MapNull` here so downstream
+// `keys(data.x.vars)` started failing with "argument must not be null".
+// The state count attribute `.%` is `"0"` for an empty map and absent
+// for a null map, so checking for `"0"` doubles as a null-rejection
+// assertion.
+func TestAccKubectlDataSourcePathDocuments_emptyMapsByDefault(t *testing.T) {
+	t.Parallel()
+	cfg := fmt.Sprintf(`
+data "kubectl_path_documents" "test" {
+  pattern = "%s/single.yaml"
+}
+`, pathDocumentsExamplesDir)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{{
+			Config: cfg,
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("data.kubectl_path_documents.test", "vars.%", "0"),
+				resource.TestCheckResourceAttr("data.kubectl_path_documents.test", "sensitive_vars.%", "0"),
+			),
+		}},
+	})
+}
+
 func TestAccKubectlDataSourcePathDocuments_multiple(t *testing.T) {
 	t.Parallel()
 	cfg := fmt.Sprintf(`


### PR DESCRIPTION
## Summary

Restores the v2 contract on `data.kubectl_path_documents.vars` and `sensitive_vars`. Phase F (PR #318) shipped `types.MapNull(types.StringType)` for both attributes when the user omitted them. SDK v2 used `Default: make(map[string]interface{})`, so existing configurations doing `keys(data.kubectl_path_documents.x.vars)` (or any other function that rejects null input) started erroring with `Invalid function argument: argument must not be null` on v3. `length()` and `lookup()` happened to keep working against null, which made the regression silent for most users; the schema description still claimed "Defaults to an empty map" so the docs already promised v2 behaviour.

Fixes: #328.

## What changes

`internal/framework/data_source_kubectl_path_documents.go`:

- Add `Computed: true` to `vars` and `sensitive_vars`. Without Computed, populating an attribute the user did not supply trips the framework's "Provider produced inconsistent result after apply" guard.
- In `Read`, replace `types.MapNull(types.StringType)` with `types.MapValueMust(types.StringType, map[string]attr.Value{})` for both maps when the input is null or unknown.
- `disable_template` stays Optional-only / null-by-default; the audit scoped the regression to map attributes because `length` / `keys` on null is the user-visible footgun and bool-null has no equivalent standard-library issue.

`internal/framework/data_source_kubectl_path_documents_test.go`:

- Add `TestAccKubectlDataSourcePathDocuments_emptyMapsByDefault` pinning `vars.%` and `sensitive_vars.%` to `"0"` when omitted. Empty maps populate `.%`; null maps do not, so the `"0"` check rejects both the v3 null regression and any future null shape.

## Tests

`go build ./...`, `go vet ./...`, `go test ./internal/framework/ ./kubernetes/ -short -count=1` all green locally. The new acc test runs in the existing CI matrix alongside the four other `kubectl_path_documents` tests.

## Reference

- Audit context: #328 was filed alongside #326-#330 from the post-#324 v2-to-v3 contract audit.
- Pre-cutover code: `git show 13fb804^:kubernetes/data_source_kubectl_path_documents.go` lines 47-61.
- Post-cutover schema: `internal/framework/data_source_kubectl_path_documents.go:64-84`.
- Post-cutover Read (before this PR): `internal/framework/data_source_kubectl_path_documents.go:208-219`.
- Phase F cutover: PR #318 (commit `13fb804`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data source schema behavior where configuration variables now correctly default to empty maps when omitted, aligning with documented behavior.

* **Tests**
  * Added regression test to verify empty map defaults for omitted variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->