### PR TITLE
docs(data-source): document kubectl_filename_list v3 id hash rotation

### DIFF
--- a/docs/data-sources/kubectl_filename_list.md
+++ b/docs/data-sources/kubectl_filename_list.md
@@ -18,3 +18,20 @@ resource "kubectl_manifest" "test" {
 ## Attribute Reference
 
 * `matches` - List of matching file names.
+* `id` - sha256 fingerprint of the matched filenames, used as the Terraform resource id. Stable across plans when the matched list is unchanged. See [Upgrading from v2](#upgrading-from-v2) for the v2-to-v3 hash format change.
+
+## Upgrading from v2
+
+v3 changes the input passed to the `id` hash. v2 concatenated each entry with its bare index (`strconv.Itoa(i) + s`) and hashed the result, which left a small ambiguity window between lists like `["1foo"]` and `["", "1foo"]`. v3 length-prefixes each entry (`fmt.Sprintf("%d:%d:%s\n", i, len(s), s)`) so distinct lists always produce distinct hashes and the hash matches the sister `kubectl_kustomize_documents` data source.
+
+The new hash shares no pre-images with the old one, so every existing state-stored `id` rotates on the first `terraform plan` after upgrading. Data sources re-read on every plan anyway, so for almost all users this is invisible churn that resolves itself on the same plan. The only case that needs action is configurations that wired `id` into a downstream `triggers` map:
+
+```hcl
+resource "null_resource" "render" {
+  triggers = {
+    manifests = data.kubectl_filename_list.docs.id
+  }
+}
+```
+
+Such resources will force-recreate once on the first post-upgrade apply. If that is undesirable, either replace the trigger with a content-derived hash you compute in HCL, or use `terraform state` surgery to align the trigger value to the new id before the apply.


### PR DESCRIPTION
## Summary

Phase F (PR #318) ported `kubectl_filename_list` to the plugin framework and changed the input shape passed to the `id` sha256. v2 concatenated each match with its bare index (`strconv.Itoa(i) + s`), leaving a small collision window between lists like `["1foo"]` and `["", "1foo"]`. v3 length-prefixes each entry (`fmt.Sprintf("%d:%d:%s\n", i, len(s), s)`), which both removes the ambiguity and matches the sister `kubectl_kustomize_documents` data source. The new hash shares no pre-images with the old one, so every existing state-stored `id` rotates on the first post-upgrade plan. Per #330, v3.0.0 is the right place to accept this and document it: reverting to the v2 hash would diverge from the v3-native sibling and reintroduce the collision window.

Fixes: #330.

## What changes

`docs/data-sources/kubectl_filename_list.md`:

- Add `id` to the Attribute Reference. It was absent from the page even though it's a real, plan-visible attribute that users do reference via `triggers`.
- Add an "Upgrading from v2" section that names the diagnostic users will see (none, in most cases), explains why the hash changed, and documents the one footgun (configurations that wired `id` into a downstream `triggers` map will force-recreate once on the first apply, with a workaround).

No code change, no schema change. The framed-hash shape stays as it landed in Phase F.

## Tests

Docs-only PR. The repo's `tests-docs-skip.yaml` ghost workflow emits success statuses for the matrix-named jobs on documentation paths, so branch protection is satisfied without burning the test matrix. `docstring-coverage` is Go-source-only and is correctly excluded from this PR's path filter.

## Reference

- Audit context: #330 was filed alongside #326-#329 from the post-#324 v2-to-v3 contract audit.
- Pre-cutover code: `git show 13fb804^:kubernetes/data_source_kubectl_filename_list.go` lines 44-50.
- Post-cutover code: `internal/framework/data_source_kubectl_filename_list.go:85-92`.
- Sister hash shape: `internal/framework/data_source_kubectl_kustomize_documents.go`.
- Phase F cutover: PR #318 (commit `13fb804`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
  * Updated documentation for the `kubectl_filename_list` data source to clarify the `id` attribute behavior, which is a SHA256 fingerprint of matched filenames. Includes upgrade guidance from v2 to v3, explaining the hash computation change and how to handle state rotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->