### PR TITLE
fix(framework): yaml-body-aware UseStateForUnknown for kubectl_manifest

### DIFF
--- a/internal/framework/resource_kubectl_manifest.go
+++ b/internal/framework/resource_kubectl_manifest.go
@@ -155,7 +155,7 @@ func (r *manifestResource) Schema(ctx context.Context, _ resource.SchemaRequest,
 				Sensitive:   true,
 				Description: "Fingerprint of the canonical YAML at the time of the last apply. Drift detection compares this to live_manifest_incluster.",
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
+					yamlBodyAwareUseStateForUnknown{},
 				},
 			},
 			"live_manifest_incluster": schema.StringAttribute{
@@ -163,7 +163,7 @@ func (r *manifestResource) Schema(ctx context.Context, _ resource.SchemaRequest,
 				Sensitive:   true,
 				Description: "Fingerprint of the canonical YAML as observed during the most recent Read.",
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
+					yamlBodyAwareUseStateForUnknown{},
 				},
 			},
 			"api_version": schema.StringAttribute{
@@ -211,7 +211,7 @@ func (r *manifestResource) Schema(ctx context.Context, _ resource.SchemaRequest,
 				Computed:    true,
 				Description: "The YAML body as applied to the cluster, with any field listed in `sensitive_fields` replaced by `(sensitive value)`. Surfaced for plan-output review without leaking secret values.",
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
+					yamlBodyAwareUseStateForUnknown{},
 				},
 			},
 			"sensitive_fields": schema.ListAttribute{
@@ -1172,4 +1172,76 @@ func buildManifestImportYAMLStub(apiVersion, kind, name, namespace string) strin
 		"apiVersion: %s\nkind: %s\nmetadata:\n  name: %s\n",
 		apiVersion, kind, name,
 	)
+}
+
+// yamlBodyAwareUseStateForUnknown is a string planmodifier for the
+// fingerprint / parsed-body attributes whose values are deterministic
+// functions of yaml_body. It behaves identically to
+// stringplanmodifier.UseStateForUnknown EXCEPT when plan.yaml_body is
+// itself Unknown (an interpolation of an upstream Computed attribute
+// or timestamp()), in which case it leaves the plan value Unknown so
+// Apply can write the recomputed fingerprint without tripping
+// Terraform's plan-vs-apply consistency check.
+//
+// Regression target: issue #49. The SDK v2 half handled the same
+// pattern via CustomizeDiff SetNewComputed; the framework's plan
+// walker invokes attribute-level PlanModifiers before ModifyPlan can
+// intervene, so the carve-out has to live here instead.
+type yamlBodyAwareUseStateForUnknown struct{}
+
+// Description returns the planmodifier's plaintext summary. Implements
+// planmodifier.String.
+func (yamlBodyAwareUseStateForUnknown) Description(_ context.Context) string {
+	return "Once set, the value of this attribute in state will not change, unless yaml_body is Unknown at plan time."
+}
+
+// MarkdownDescription returns the same summary as Description; no
+// Markdown features are needed for the one-line text. Implements
+// planmodifier.String.
+func (m yamlBodyAwareUseStateForUnknown) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+// PlanModifyString implements the plan-walker hook. Exit paths:
+//
+//   - State is null (Create): no-op, the framework keeps PlanValue at
+//     Unknown so Apply can fill in the computed value.
+//   - PlanValue is already Known (e.g. RequiresReplace set it): no-op.
+//   - Plan's yaml_body is Unknown (interpolates an upstream Computed
+//     value): no-op so the downstream fingerprint stays Unknown
+//     alongside its source. Apply will produce the new fingerprint
+//     and Terraform accepts Unknown -> Known transitions.
+//   - Plan's yaml_body is Known but differs from state.yaml_body
+//     (e.g. embeds timestamp() or a value that changes between plans):
+//     no-op so the fingerprint stays Unknown and Apply recomputes it.
+//     Without this branch the plan-walker copies the old fingerprint
+//     into the plan, then Apply overwrites it, tripping Terraform's
+//     "Provider produced inconsistent result after apply" guard.
+//   - Otherwise (yaml_body unchanged): copy StateValue into PlanValue,
+//     the standard UseStateForUnknown behaviour, so the plan is empty
+//     in the no-op case.
+//
+// Implements planmodifier.String.
+func (yamlBodyAwareUseStateForUnknown) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.StateValue.IsNull() {
+		return
+	}
+	if !req.PlanValue.IsUnknown() {
+		return
+	}
+	var planYAMLBody, stateYAMLBody types.String
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("yaml_body"), &planYAMLBody)...)
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("yaml_body"), &stateYAMLBody)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	// Either Unknown plan or a plan-vs-state diff means the
+	// fingerprint will change at Apply time; leave PlanValue Unknown.
+	if planYAMLBody.IsUnknown() {
+		return
+	}
+	if planYAMLBody.ValueString() != stateYAMLBody.ValueString() {
+		return
+	}
+	resp.PlanValue = req.StateValue
 }

--- a/internal/framework/resource_kubectl_manifest_acc_test.go
+++ b/internal/framework/resource_kubectl_manifest_acc_test.go
@@ -569,19 +569,17 @@ func TestAccKubectl_WaitForFieldUpdate(t *testing.T) {
 
 func TestAccInconsistentPlanning(t *testing.T) {
 	t.Parallel()
-	// TODO(#295 follow-up): port this regression test to the framework
-	// half. The SDK v2 dispatch handled the timestamp()-driven
+	// Regression test for issue #49 and the partial fix in PR #46.
+	// The SDK v2 dispatch handled the timestamp()-driven
 	// "yaml_body always interpolated" pattern via the CustomizeDiff
-	// SetNewComputed escape hatch; the framework's plan-walker sets
-	// yaml_incluster / live_manifest_incluster to the state value via
-	// UseStateForUnknown before ModifyPlan can intervene, and any
-	// later Unknown override trips Terraform's "known to Unknown"
-	// final-plan consistency check. The fix is a custom string
-	// PlanModifier that returns Unknown when plan.yaml_body is Unknown
-	// (instead of UseStateForUnknown) but copies state otherwise.
-	// Tracked separately so the v3 cutover is not blocked on a
-	// regression test that originally documented a different bug.
-	t.Skip("framework UseStateForUnknown vs Unknown-on-interpolated-yaml_body conflict; see TODO above")
+	// SetNewComputed escape hatch; the framework's plan-walker invokes
+	// attribute-level PlanModifiers before ModifyPlan can intervene,
+	// so the carve-out lives in yamlBodyAwareUseStateForUnknown.
+	// That modifier leaves yaml_incluster / live_manifest_incluster /
+	// yaml_body_parsed Unknown in the plan whenever yaml_body is
+	// Unknown OR yaml_body differs from state, so Apply can recompute
+	// the fingerprint without tripping Terraform's
+	// "inconsistent result after apply" guard.
 
 	// See https://github.com/alekc/terraform-provider-kubectl/pull/46
 	name := acctest.RandomWithPrefix("inconsistent-secret")

--- a/internal/framework/resource_kubectl_manifest_planmodifier_test.go
+++ b/internal/framework/resource_kubectl_manifest_planmodifier_test.go
@@ -1,0 +1,157 @@
+package framework
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// TestYAMLBodyAwareUseStateForUnknown_PlanModifyString covers the five
+// branches of yamlBodyAwareUseStateForUnknown: null state (Create),
+// already-known plan, plan.yaml_body Unknown, plan.yaml_body Known and
+// differs from state, plan.yaml_body Known and matches state. The
+// matching branch is the only one that returns state into the plan;
+// every other branch must leave the framework's default Unknown alone.
+//
+// Regression target: issue #49 (cross-resource Unknown interpolation)
+// and TestAccInconsistentPlanning's timestamp() pattern.
+func TestYAMLBodyAwareUseStateForUnknown_PlanModifyString(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	m := yamlBodyAwareUseStateForUnknown{}
+
+	// Build the resource schema once; every case reuses it for the
+	// tfsdk.Plan and tfsdk.State terraform-types.
+	r := &manifestResource{}
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("building schema: %+v", schemaResp.Diagnostics)
+	}
+	s := schemaResp.Schema
+	tfType := s.Type().TerraformType(ctx)
+
+	mkObj := func(yamlBody types.String) tftypes.Value {
+		model := baseModel()
+		model.YAMLBody = yamlBody
+		raw := tftypes.NewValue(tfType, nil)
+		plan := tfsdk.Plan{Schema: s, Raw: raw}
+		if diags := plan.Set(ctx, &model); diags.HasError() {
+			t.Fatalf("seeding tfsdk.Plan: %+v", diags)
+		}
+		return plan.Raw
+	}
+
+	cases := []struct {
+		name          string
+		stateValue    types.String
+		planValue     types.String
+		planYAMLBody  types.String
+		stateYAMLBody types.String
+		wantPlanValue types.String
+		wantUnchanged bool
+	}{
+		{
+			name:          "state null (Create) leaves plan unknown",
+			stateValue:    types.StringNull(),
+			planValue:     types.StringUnknown(),
+			planYAMLBody:  types.StringValue("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n"),
+			stateYAMLBody: types.StringNull(),
+			wantUnchanged: true,
+		},
+		{
+			name:          "plan already known is left alone",
+			stateValue:    types.StringValue("sha-OLD"),
+			planValue:     types.StringValue("sha-FORCED"),
+			planYAMLBody:  types.StringValue("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n"),
+			stateYAMLBody: types.StringValue("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n"),
+			wantUnchanged: true,
+		},
+		{
+			name:          "plan.yaml_body Unknown leaves plan unknown",
+			stateValue:    types.StringValue("sha-OLD"),
+			planValue:     types.StringUnknown(),
+			planYAMLBody:  types.StringUnknown(),
+			stateYAMLBody: types.StringValue("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n"),
+			wantUnchanged: true,
+		},
+		{
+			name:          "plan.yaml_body differs from state leaves plan unknown",
+			stateValue:    types.StringValue("sha-OLD"),
+			planValue:     types.StringUnknown(),
+			planYAMLBody:  types.StringValue("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\ndata:\n  k: NEW\n"),
+			stateYAMLBody: types.StringValue("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n"),
+			wantUnchanged: true,
+		},
+		{
+			name:          "plan.yaml_body matches state copies state into plan",
+			stateValue:    types.StringValue("sha-OLD"),
+			planValue:     types.StringUnknown(),
+			planYAMLBody:  types.StringValue("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n"),
+			stateYAMLBody: types.StringValue("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n"),
+			wantPlanValue: types.StringValue("sha-OLD"),
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			planRaw := mkObj(tc.planYAMLBody)
+			stateRaw := mkObj(tc.stateYAMLBody)
+
+			// State null overrides: if the case wants null state,
+			// stub the State raw to a null Value so the modifier's
+			// req.StateValue null check fires before any GetAttribute.
+			if tc.stateValue.IsNull() {
+				stateRaw = tftypes.NewValue(tfType, nil)
+			}
+
+			req := planmodifier.StringRequest{
+				Path:       path.Root("yaml_incluster"),
+				StateValue: tc.stateValue,
+				PlanValue:  tc.planValue,
+				Plan:       tfsdk.Plan{Schema: s, Raw: planRaw},
+				State:      tfsdk.State{Schema: s, Raw: stateRaw},
+			}
+			resp := &planmodifier.StringResponse{PlanValue: tc.planValue}
+			m.PlanModifyString(ctx, req, resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
+			}
+			if tc.wantUnchanged {
+				if !resp.PlanValue.Equal(tc.planValue) {
+					t.Errorf("expected PlanValue unchanged, got %v (was %v)", resp.PlanValue, tc.planValue)
+				}
+				return
+			}
+			if !resp.PlanValue.Equal(tc.wantPlanValue) {
+				t.Errorf("PlanValue: got %v, want %v", resp.PlanValue, tc.wantPlanValue)
+			}
+		})
+	}
+}
+
+// TestYAMLBodyAwareUseStateForUnknown_DescriptionsAreNonEmpty pins the
+// trivial getters so the planmodifier.String interface remains
+// satisfied even after future field renames. The interface check
+// itself is a compile-time assertion.
+func TestYAMLBodyAwareUseStateForUnknown_DescriptionsAreNonEmpty(t *testing.T) {
+	t.Parallel()
+	var _ planmodifier.String = yamlBodyAwareUseStateForUnknown{}
+	m := yamlBodyAwareUseStateForUnknown{}
+	if m.Description(context.Background()) == "" {
+		t.Error("Description must be non-empty")
+	}
+	if m.MarkdownDescription(context.Background()) == "" {
+		t.Error("MarkdownDescription must be non-empty")
+	}
+}


### PR DESCRIPTION
## Summary

Restores the SDK v2 behaviour for two `kubectl_manifest` plan patterns that became inconsistent on v3 after the plugin-framework cutover (PR #318):

1. `yaml_body` interpolates an upstream Computed attribute (e.g. `${kubernetes_namespace.test.metadata.0.resource_version}`, the original issue #49 reproducer). At plan time `yaml_body` is Unknown; the downstream fingerprints (`yaml_incluster`, `live_manifest_incluster`) must also stay Unknown so Apply can write the new value.

2. `yaml_body` embeds a value that changes on every plan (e.g. `${formatdate(..., timestamp())}`, the `TestAccInconsistentPlanning` reproducer). `yaml_body` is Known but its value differs from `state.yaml_body`; the recomputed fingerprint will likewise differ.

SDK v2 handled both via the `CustomizeDiff` `SetNewComputed` escape hatch. The framework's plan-walker invokes attribute-level PlanModifiers before `ModifyPlan` can intervene, so the carve-out has to live as an attribute PlanModifier.

Fixes: #49.

## What changes

`internal/framework/resource_kubectl_manifest.go`:

- New `yamlBodyAwareUseStateForUnknown` planmodifier.String. Five exit paths: state is null (Create), PlanValue already Known (forced), `plan.yaml_body` Unknown, `plan.yaml_body` Known and differs from state, `plan.yaml_body` Known and matches state. Only the matching branch copies state into the plan (the standard `UseStateForUnknown` behaviour); every other branch leaves the framework's default Unknown alone.
- Wired onto `yaml_incluster`, `live_manifest_incluster`, and `yaml_body_parsed` in the schema in place of `stringplanmodifier.UseStateForUnknown()`. Plain `UseStateForUnknown` stays on `id`, `uid`, `live_uid`, `api_version`, `kind`, `name`, and `namespace` because those are not direct derivatives of `yaml_body` content.

`internal/framework/resource_kubectl_manifest_acc_test.go`:

- Un-skipped `TestAccInconsistentPlanning`. The test runs the same config twice with `ExpectNonEmptyPlan: true` (the `timestamp()` makes the plan permanently dirty by design); the second run used to crash on v3 with "Provider produced inconsistent result after apply" before this fix.

`internal/framework/resource_kubectl_manifest_planmodifier_test.go` (new):

- Table-driven `TestYAMLBodyAwareUseStateForUnknown_PlanModifyString` pinning all five branches. Builds a real `tfsdk.Plan` / `tfsdk.State` via the resource's own schema so the GetAttribute paths exercise the real wire format. All five sub-tests pass on `go test -short`.
- `TestYAMLBodyAwareUseStateForUnknown_DescriptionsAreNonEmpty` plus the compile-time `var _ planmodifier.String = yamlBodyAwareUseStateForUnknown{}` assertion to pin the interface.

## Tests

`go build ./...`, `go vet ./...`, `go test ./... -short -count=1` all green locally. The unit-level planmodifier tests are non-acc and run on every CI matrix cell. `TestAccInconsistentPlanning` runs in the acc matrix.

## Reference

- Issue #49 (2023-09-19): the original cross-resource Unknown interpolation reproducer.
- PR #46: the SDK-v2-era partial fix.
- Phase F cutover: PR #318 (commit `13fb804`) dropped the SDK v2 CustomizeDiff dispatch that handled this pattern.
- TODO that tracked the fix: `internal/framework/resource_kubectl_manifest_acc_test.go:572-583` (pre-commit).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved plan/apply inconsistency when handling YAML body changes in kubectl manifest resources, ensuring accurate fingerprint preservation during apply operations.

* **Tests**
  * Re-enabled regression test for inconsistent planning scenarios.
  * Added comprehensive unit tests for YAML body-aware state handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->