### PR TITLE
feat(framework)!: replace yaml_incluster with drift YAML attribute

### DIFF
--- a/docs/resources/kubectl_manifest.md
+++ b/docs/resources/kubectl_manifest.md
@@ -94,6 +94,9 @@ YAML
 * `force_conflicts` - Optional. Allow using force_conflicts. Default `false`.
 * `apply_only` - Optional. When `true`, the resource is never deleted on `terraform destroy`. Default `false`.
 * `ignore_fields` - Optional. List of map fields to ignore when applying the manifest. See below for more details.
+* `show_drift_values` - Optional. Controls how leaf values appear in the computed `drift` attribute. One of `none` (default; renders `<drift>` markers, paths only), `hash` (renders `<was:HASH now:HASH>` short-hash markers), or `full` (renders literal before/after values, parity with `kubectl diff`). Secret `data` / `stringData` paths and `mask_paths` globs always mask their leaves regardless of mode. See [Drift Visualisation](#drift-visualisation) below.
+* `mask_paths` - Optional. Glob paths whose leaves are masked in the `drift` attribute regardless of `show_drift_values`. Supports `*` (one path segment) and `**` (zero or more segments). E.g. `spec.template.spec.containers.*.env.*.value` or `**.password`. Layers on top of the built-in Secret masking.
+* `drift_engine` - Optional. Algorithm used to detect drift. `client` (default) compares the user's manifest to the live object client-side; fast (no extra API calls) but susceptible to false drift on arrays, server-side defaulting, and admission-webhook mutations. `server` runs an SSA dry-run patch against the apiserver and uses the response as the desired side of the comparison; same semantics as `kubectl diff`. Costs one extra API call per Read and requires PATCH on the resource's kind in RBAC. Falls back to `client` on patch failure with a `[WARN]` log.
 * `override_namespace` - Optional. Override the namespace to apply the kubernetes resource to, ignoring any declared namespace in the `yaml_body`.
 * `validate_schema` - Optional. Setting to `false` will mimic `kubectl apply --validate=false` mode. Default `true`.
 * `wait` - Optional. When `true`, wait for finalizers to complete on deleted objects before returning. Default `false`.
@@ -135,8 +138,156 @@ Required:
 * `namespace` - Extracted object namespace from `yaml_body`.
 * `uid` - Kubernetes unique identifier from last run.
 * `live_uid` - Current uuid from Kubernetes.
-* `yaml_incluster` - A fingerprint of the current yaml within Kubernetes.
-* `live_manifest_incluster` - A fingerprint of the current manifest within Kubernetes.
+* `drift` - Human-readable YAML subtree showing the paths where the desired manifest differs from the live object. Empty string when in sync. Leaf rendering is controlled by `show_drift_values`; Secret kinds and `mask_paths` always mask regardless of mode. See [Drift Visualisation](#drift-visualisation).
+
+## Drift Visualisation
+
+In v2.x, drift between the desired manifest and the live object was tracked through the `yaml_incluster` and `live_manifest_incluster` attributes, both opaque sha256 fingerprints. When they diverged, Terraform plan output looked like:
+
+```
+~ yaml_incluster = (sensitive value) -> (sensitive value)
+```
+
+That told you *something* drifted but not *what*. Resolving it meant re-running with `TF_LOG=trace` and grepping for `yaml drift detected` lines. See [issue #54](https://github.com/alekc/terraform-provider-kubectl/issues/54).
+
+The v3 `drift` attribute replaces that workflow. It is a YAML subtree of the paths where the desired manifest differs from the live object. Empty string means in sync; populated content renders as a multi-line diff in plan output. Three rendering modes via `show_drift_values`:
+
+### `show_drift_values = "none"` (default)
+
+Safe: only paths render, values appear as `<drift>` markers.
+
+```yaml
+metadata:
+  annotations:
+    foo: <drift>
+spec:
+  replicas: <drift>
+```
+
+### `show_drift_values = "hash"`
+
+Confirms a value really changed without revealing it. Useful for sensitive workloads where the fact of the change is informative but the value is not.
+
+```yaml
+metadata:
+  annotations:
+    foo: <was:37b51d1 now:9d0c4ac>
+spec:
+  replicas: <was:d4735e3 now:4e07408>
+```
+
+### `show_drift_values = "full"`
+
+Parity with `kubectl diff`: literal before/after values. Use for non-sensitive workloads where you want maximum visibility.
+
+```yaml
+metadata:
+  annotations:
+    foo: <was: "bar", now: "BAR">
+spec:
+  replicas: <was: 2, now: 3>
+```
+
+Even with `show_drift_values = "full"`, `data.*` and `stringData.*` on `kind: Secret` are always masked to `<drift sensitive>`, as are any paths matched by `mask_paths`. Example with a paranoid masking policy:
+
+```hcl
+resource "kubectl_manifest" "example" {
+  yaml_body         = local.manifest_yaml
+  show_drift_values = "full"
+  mask_paths = [
+    "**.password",
+    "**.token",
+    "spec.template.spec.containers.*.env.*.value",
+  ]
+}
+```
+
+### Detection engine: `drift_engine`
+
+The provider supports two drift-detection algorithms with the same output shape:
+
+| Mode | What it does | When to use |
+|---|---|---|
+| `client` (default) | Flattens the user's manifest and the live object into dotted paths and compares per-key. No extra API calls. Same algorithm v2 used. | Default. Stick with this unless you have a specific reason to switch. Existing `ignore_fields` lists are tuned against it. |
+| `server` (opt-in) | Calls the apiserver with `Patch(ApplyPatchType, body, DryRun: All)` and uses the response as the desired side of the comparison. Same semantics `kubectl diff` uses. | Resources where the client engine reports false drift on every refresh — typically operator-managed objects, CRDs with server-side defaulting, manifests mutated by admission webhooks, or arrays whose order the apiserver reorganises. |
+
+The `drift` attribute shape is identical between engines, so switching is purely a behaviour swap, not a schema change.
+
+#### `client` engine
+
+```hcl
+resource "kubectl_manifest" "example" {
+  yaml_body = local.manifest_yaml
+  # drift_engine = "client"  # default; omit to use
+}
+```
+
+The comparison walks every key the user wrote in `yaml_body`. Extra fields the apiserver / controllers add (status, server-side defaults, webhook injections, managed-fields metadata) are ignored — same as v2. Drift surfaces when:
+
+- A value the user wrote differs from the live value (string equality, with whitespace trimmed)
+- A field the user wrote is absent from the live object
+
+Tends to over-report on objects that go through normalisation (memory units, durations) or admission-webhook mutation. The fix in v2 was to add the noisy path to `ignore_fields`; the same fix works here.
+
+#### `server` engine
+
+```hcl
+resource "kubectl_manifest" "example" {
+  yaml_body    = local.manifest_yaml
+  drift_engine = "server"
+}
+```
+
+Each Read issues an SSA dry-run patch against the apiserver. The patch response is the apiserver's view of what the post-apply object would look like (with all defaulting, normalisation, and mutating-webhook edits applied). That response becomes the desired side; the current live object is the live side; the renderer produces drift only for paths where they actually differ.
+
+**Trade-offs versus `client`:**
+
+- ✅ Strategic-merge comparison on arrays (no false drift from element reordering)
+- ✅ Server-side defaulting absorbed (no false drift from CRD-injected defaults)
+- ✅ Type coercion handled by the apiserver (`"2048Mi"` and `"2Gi"` agree)
+- ✅ Mutating-webhook edits visible in `drift` — you see what apply will actually change
+- ✅ `metadata.namespace` injected by `override_namespace` onto cluster-scoped resources gets stripped server-side, suppressing the long-standing false drift on `ClusterRole`/`CRD`
+- ⚠ One extra API call per Read. With 500 manifests at default `parallelism=10`, that's roughly 5-15s added to plan time depending on apiserver latency.
+- ⚠ Needs the `PATCH` verb on the resource's kind in the ServiceAccount's RBAC. Workloads with tightly-scoped RBAC (CREATE+UPDATE via apply, no PATCH) need a role broadening.
+- ⚠ Admission webhooks may fire side effects despite `?dryRun=All`. **Read the warning below before enabling.**
+- ⚠ A small set of CRDs (older ones without proper SSA schemas) reject `ApplyPatchType`. The engine falls back to `client` with a `[WARN]` log per resource.
+
+`fieldManager` and `force_conflicts` from the same resource configuration are passed through to the dry-run patch, so the dry-run result represents what *this* resource's apply would do, not what some other writer's apply would do.
+
+> **Warning — admission webhook side effects:**
+>
+> Mutating and validating admission webhooks SHOULD honour `?dryRun=All` by skipping any external side effects (no Slack messages, no audit-log writes to external systems, no CI triggers). The Kubernetes spec is clear on this, and most upstream webhooks (Gatekeeper, Kyverno, cert-manager, Istio sidecar injector) implement it correctly.
+>
+> Custom or third-party webhooks may not. Before enabling `drift_engine = "server"` cluster-wide, audit:
+>
+> 1. List your webhooks: `kubectl get validatingwebhookconfigurations,mutatingwebhookconfigurations`
+> 2. For each non-upstream one, verify it checks `request.dryRun` before any external write
+>
+> If you're not sure, enable `drift_engine = "server"` on a single resource first and observe (`kubectl plan`, then check downstream systems for spurious activity) before rolling it out broadly. Switching back is one config line.
+
+### Migration from v2 (`yaml_incluster`)
+
+v3 dropped the legacy `yaml_incluster` and `live_manifest_incluster` attributes (both opaque sha256 fingerprints) in favour of `drift`. State migrates automatically via the resource state upgrader: existing state is decoded, the two fingerprint values are dropped, and `drift` is computed fresh on the next Read against the live cluster. No manual `terraform state` surgery required.
+
+HCL that referenced the legacy attributes (rare — both values were opaque sensitive strings) breaks loudly at plan time with a clear missing-attribute message. The migration is one line:
+
+```hcl
+# Before (v2): detect drift by comparing the two opaque fingerprints
+output "drifted" {
+  value = kubectl_manifest.example.yaml_incluster != kubectl_manifest.example.live_manifest_incluster
+}
+
+# After (v3): drift is a string that's empty when in sync
+output "drifted" {
+  value = kubectl_manifest.example.drift != ""
+}
+```
+
+`ignore_fields` lists carry over unchanged — the rules and the path syntax are identical to v2.
+
+### Future default
+
+The `client` engine is the default in v3 to preserve v2's drift-detection semantics for upgrading users (zero behaviour change beyond the attribute shape). A later v3.x minor may flip the default to `server` once the community feedback on dry-run reliability across cluster shapes (webhook coverage, CRD compatibility, RBAC scoping) is in. The opt-out (`drift_engine = "client"`) will remain supported in that case.
 
 ## Sensitive Fields
 

--- a/docs/resources/kubectl_manifest.md
+++ b/docs/resources/kubectl_manifest.md
@@ -144,7 +144,7 @@ Required:
 
 In v2.x, drift between the desired manifest and the live object was tracked through the `yaml_incluster` and `live_manifest_incluster` attributes, both opaque sha256 fingerprints. When they diverged, Terraform plan output looked like:
 
-```
+```diff
 ~ yaml_incluster = (sensitive value) -> (sensitive value)
 ```
 

--- a/internal/framework/resource_kubectl_manifest.go
+++ b/internal/framework/resource_kubectl_manifest.go
@@ -949,29 +949,103 @@ func (r *manifestResource) ModifyPlan(ctx context.Context, req resource.ModifyPl
 //   - v1 -> v2: safety net for anyone who installed an interim v3
 //     pre-release that shipped the sha256-fingerprint shape. Same
 //     promotion as v0 -> v2, just decoding from the same shape.
-func (r *manifestResource) UpgradeState(_ context.Context) map[int64]resource.StateUpgrader {
+func (r *manifestResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	priorSchema := priorManifestSchemaV1(ctx)
+	upgrade := func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+		var v1 manifestResourceModelV1
+		resp.Diagnostics.Append(req.State.Get(ctx, &v1)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data := promoteV1ToV2(v1)
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	}
 	return map[int64]resource.StateUpgrader{
 		0: {
-			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				var v1 manifestResourceModelV1
-				resp.Diagnostics.Append(req.State.Get(ctx, &v1)...)
-				if resp.Diagnostics.HasError() {
-					return
-				}
-				data := promoteV1ToV2(v1)
-				resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-			},
+			PriorSchema:   &priorSchema,
+			StateUpgrader: upgrade,
 		},
 		1: {
-			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				var v1 manifestResourceModelV1
-				resp.Diagnostics.Append(req.State.Get(ctx, &v1)...)
-				if resp.Diagnostics.HasError() {
-					return
-				}
-				data := promoteV1ToV2(v1)
-				resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+			PriorSchema:   &priorSchema,
+			StateUpgrader: upgrade,
+		},
+	}
+}
+
+// priorManifestSchemaV1 returns the v0/v1 schema definition: the
+// pre-drift attribute set, including yaml_incluster and
+// live_manifest_incluster. The framework needs this declared as
+// PriorSchema on each state upgrader so req.State.Get can decode the
+// raw state into a typed model. Without it, req.State has no Schema
+// and any Get against it panics (issue: nil pointer in
+// UpgradeResourceState observed on the upgrade_path_smoke jobs).
+//
+// Only attribute *shapes* need to match the v1 schema for decoding;
+// validators, plan modifiers, descriptions, and defaults can be
+// omitted because they never run during state upgrade.
+func priorManifestSchemaV1(ctx context.Context) schema.Schema {
+	str := schema.StringAttribute{Optional: true, Computed: true}
+	strSensitive := schema.StringAttribute{Optional: true, Computed: true, Sensitive: true}
+	strReq := schema.StringAttribute{Required: true, Sensitive: true}
+	boolAttr := schema.BoolAttribute{Optional: true, Computed: true}
+	strList := schema.ListAttribute{Optional: true, ElementType: types.StringType}
+	return schema.Schema{
+		Version: 1,
+		Attributes: map[string]schema.Attribute{
+			"id":                      schema.StringAttribute{Computed: true},
+			"uid":                     schema.StringAttribute{Computed: true},
+			"live_uid":                schema.StringAttribute{Computed: true},
+			"yaml_incluster":          strSensitive,
+			"live_manifest_incluster": strSensitive,
+			"api_version":             schema.StringAttribute{Computed: true},
+			"kind":                    schema.StringAttribute{Computed: true},
+			"name":                    schema.StringAttribute{Computed: true},
+			"namespace":               schema.StringAttribute{Computed: true},
+			"override_namespace":      schema.StringAttribute{Optional: true},
+			"yaml_body":               strReq,
+			"yaml_body_parsed":        schema.StringAttribute{Computed: true},
+			"sensitive_fields":        strList,
+			"force_new":               boolAttr,
+			"upgrade_api_version":     boolAttr,
+			"server_side_apply":       boolAttr,
+			"field_manager":           str,
+			"force_conflicts":         boolAttr,
+			"apply_only":              boolAttr,
+			"ignore_fields":           strList,
+			"wait":                    boolAttr,
+			"wait_for_rollout":        boolAttr,
+			"validate_schema":         boolAttr,
+			"delete_cascade":          schema.StringAttribute{Optional: true},
+		},
+		Blocks: map[string]schema.Block{
+			"wait_for": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"condition": schema.ListNestedBlock{
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"type":   schema.StringAttribute{Required: true},
+									"status": schema.StringAttribute{Required: true},
+								},
+							},
+						},
+						"field": schema.ListNestedBlock{
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"key":        schema.StringAttribute{Required: true},
+									"value":      schema.StringAttribute{Required: true},
+									"value_type": schema.StringAttribute{Optional: true, Computed: true},
+								},
+							},
+						},
+					},
+				},
 			},
+			"timeouts": timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Update: true,
+				Delete: true,
+			}),
 		},
 	}
 }

--- a/internal/framework/resource_kubectl_manifest.go
+++ b/internal/framework/resource_kubectl_manifest.go
@@ -61,32 +61,34 @@ func NewManifestResource() resource.Resource {
 // the SDK v2 file for diff review. The tfsdk tags are the source of truth
 // for attribute names.
 type manifestResourceModel struct {
-	ID                    types.String   `tfsdk:"id"`
-	UID                   types.String   `tfsdk:"uid"`
-	LiveUID               types.String   `tfsdk:"live_uid"`
-	YAMLInCluster         types.String   `tfsdk:"yaml_incluster"`
-	LiveManifestInCluster types.String   `tfsdk:"live_manifest_incluster"`
-	APIVersion            types.String   `tfsdk:"api_version"`
-	Kind                  types.String   `tfsdk:"kind"`
-	Name                  types.String   `tfsdk:"name"`
-	Namespace             types.String   `tfsdk:"namespace"`
-	OverrideNamespace     types.String   `tfsdk:"override_namespace"`
-	YAMLBody              types.String   `tfsdk:"yaml_body"`
-	YAMLBodyParsed        types.String   `tfsdk:"yaml_body_parsed"`
-	SensitiveFields       types.List     `tfsdk:"sensitive_fields"`
-	ForceNew              types.Bool     `tfsdk:"force_new"`
-	UpgradeAPIVersion     types.Bool     `tfsdk:"upgrade_api_version"`
-	ServerSideApply       types.Bool     `tfsdk:"server_side_apply"`
-	FieldManager          types.String   `tfsdk:"field_manager"`
-	ForceConflicts        types.Bool     `tfsdk:"force_conflicts"`
-	ApplyOnly             types.Bool     `tfsdk:"apply_only"`
-	IgnoreFields          types.List     `tfsdk:"ignore_fields"`
-	Wait                  types.Bool     `tfsdk:"wait"`
-	WaitForRollout        types.Bool     `tfsdk:"wait_for_rollout"`
-	ValidateSchema        types.Bool     `tfsdk:"validate_schema"`
-	DeleteCascade         types.String   `tfsdk:"delete_cascade"`
-	WaitFor               types.List     `tfsdk:"wait_for"`
-	Timeouts              timeouts.Value `tfsdk:"timeouts"`
+	ID                types.String   `tfsdk:"id"`
+	UID               types.String   `tfsdk:"uid"`
+	LiveUID           types.String   `tfsdk:"live_uid"`
+	Drift             types.String   `tfsdk:"drift"`
+	ShowDriftValues   types.String   `tfsdk:"show_drift_values"`
+	MaskPaths         types.List     `tfsdk:"mask_paths"`
+	DriftEngine       types.String   `tfsdk:"drift_engine"`
+	APIVersion        types.String   `tfsdk:"api_version"`
+	Kind              types.String   `tfsdk:"kind"`
+	Name              types.String   `tfsdk:"name"`
+	Namespace         types.String   `tfsdk:"namespace"`
+	OverrideNamespace types.String   `tfsdk:"override_namespace"`
+	YAMLBody          types.String   `tfsdk:"yaml_body"`
+	YAMLBodyParsed    types.String   `tfsdk:"yaml_body_parsed"`
+	SensitiveFields   types.List     `tfsdk:"sensitive_fields"`
+	ForceNew          types.Bool     `tfsdk:"force_new"`
+	UpgradeAPIVersion types.Bool     `tfsdk:"upgrade_api_version"`
+	ServerSideApply   types.Bool     `tfsdk:"server_side_apply"`
+	FieldManager      types.String   `tfsdk:"field_manager"`
+	ForceConflicts    types.Bool     `tfsdk:"force_conflicts"`
+	ApplyOnly         types.Bool     `tfsdk:"apply_only"`
+	IgnoreFields      types.List     `tfsdk:"ignore_fields"`
+	Wait              types.Bool     `tfsdk:"wait"`
+	WaitForRollout    types.Bool     `tfsdk:"wait_for_rollout"`
+	ValidateSchema    types.Bool     `tfsdk:"validate_schema"`
+	DeleteCascade     types.String   `tfsdk:"delete_cascade"`
+	WaitFor           types.List     `tfsdk:"wait_for"`
+	Timeouts          timeouts.Value `tfsdk:"timeouts"`
 }
 
 // waitForBlockModel is the inline shape of a single wait_for block.
@@ -123,7 +125,7 @@ func (r *manifestResource) Metadata(_ context.Context, req resource.MetadataRequ
 // after the cutover. Implements resource.Resource.
 func (r *manifestResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Version: 1,
+		Version: 2,
 		Description: "Apply a Kubernetes manifest from raw YAML. Tracks the live resource by UID; reapplies " +
 			"on drift; surfaces full apply semantics (server-side apply, field manager, force conflicts, " +
 			"wait-for-rollout, wait_for conditions). Cross-provider state move from `gavinbunney/kubectl` " +
@@ -150,20 +152,57 @@ func (r *manifestResource) Schema(ctx context.Context, _ resource.SchemaRequest,
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"yaml_incluster": schema.StringAttribute{
-				Computed:    true,
-				Sensitive:   true,
-				Description: "Fingerprint of the canonical YAML at the time of the last apply. Drift detection compares this to live_manifest_incluster.",
+			"drift": schema.StringAttribute{
+				Computed: true,
+				Description: "Human-readable YAML subtree showing the paths where the desired manifest " +
+					"differs from the live object. Empty string when in sync. Leaf rendering is " +
+					"controlled by `show_drift_values`; Secret kinds and `mask_paths` always mask " +
+					"regardless of mode. Replaces the opaque sha256 in `yaml_incluster` / " +
+					"`live_manifest_incluster`. See issue #54.",
 				PlanModifiers: []planmodifier.String{
 					yamlBodyAwareUseStateForUnknown{},
 				},
 			},
-			"live_manifest_incluster": schema.StringAttribute{
-				Computed:    true,
-				Sensitive:   true,
-				Description: "Fingerprint of the canonical YAML as observed during the most recent Read.",
-				PlanModifiers: []planmodifier.String{
-					yamlBodyAwareUseStateForUnknown{},
+			"show_drift_values": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(string(kubernetes.ShowNone)),
+				Description: "How `drift` renders the leaf values at drifted paths. `none` (default, safe) " +
+					"shows `<drift>` markers only. `hash` shows `<was:HASH now:HASH>` short-hash " +
+					"markers. `full` shows literal before/after values (kubectl-diff parity). " +
+					"Secret `data` / `stringData` paths and `mask_paths` globs always mask regardless of mode.",
+				Validators: []validator.String{
+					stringOneOfValidator{allowed: []string{
+						string(kubernetes.ShowNone),
+						string(kubernetes.ShowHash),
+						string(kubernetes.ShowFull),
+					}},
+				},
+			},
+			"mask_paths": schema.ListAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
+				Description: "Glob paths whose leaves are masked in `drift` regardless of `show_drift_values`. " +
+					"Supports `*` (one path segment) and `**` (zero or more segments). For example, " +
+					"`spec.template.spec.containers.*.env.*.value` or `**.password`.",
+			},
+			"drift_engine": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(string(kubernetes.ClientDriftEngine)),
+				Description: "Algorithm used to detect drift. `client` (default) compares the user's manifest " +
+					"to the live object client-side using a flattened-path equality check; fast (no extra " +
+					"API calls) but susceptible to false drift on arrays, server-side defaulting, and " +
+					"admission-webhook mutations. `server` runs an SSA dry-run patch against the apiserver " +
+					"and uses the response (the apiserver's view of the post-apply object) as the desired " +
+					"side of the comparison; same semantics as `kubectl diff`. Costs one extra API call per " +
+					"Read and requires PATCH on the resource's kind in RBAC. Falls back to `client` on " +
+					"patch failure with a `[WARN]` log.",
+				Validators: []validator.String{
+					stringOneOfValidator{allowed: []string{
+						string(kubernetes.ClientDriftEngine),
+						string(kubernetes.ServerDriftEngine),
+					}},
 				},
 			},
 			"api_version": schema.StringAttribute{
@@ -427,6 +466,8 @@ func (r *manifestResource) buildApplyOptions(ctx context.Context, data manifestR
 	allDiags.Append(d...)
 	sensitiveFields, d := extractStringList(ctx, data.SensitiveFields)
 	allDiags.Append(d...)
+	maskPaths, d := extractStringList(ctx, data.MaskPaths)
+	allDiags.Append(d...)
 	// Drop empty / whitespace-only entries so a misconfigured
 	// sensitive_fields = [""] does not suppress the Secret v1 default
 	// masking inside BuildObfuscatedYAML.
@@ -443,7 +484,42 @@ func (r *manifestResource) buildApplyOptions(ctx context.Context, data manifestR
 		Timeout:           timeout,
 		IgnoreFields:      ignoreFields,
 		SensitiveFields:   sensitiveFields,
+		ShowDriftValues:   driftModeFromString(data.ShowDriftValues),
+		MaskPaths:         maskPaths,
+		DriftEngine:       driftEngineFromString(data.DriftEngine),
 	}, allDiags
+}
+
+// driftEngineFromString maps the `drift_engine` schema attribute to the
+// kubernetes.DriftEngine used by the lifecycle. Unknown / null / empty
+// falls through to ClientDriftEngine (the default).
+func driftEngineFromString(v types.String) kubernetes.DriftEngine {
+	if v.IsNull() || v.IsUnknown() {
+		return kubernetes.ClientDriftEngine
+	}
+	switch v.ValueString() {
+	case string(kubernetes.ServerDriftEngine):
+		return kubernetes.ServerDriftEngine
+	default:
+		return kubernetes.ClientDriftEngine
+	}
+}
+
+// driftModeFromString maps the `show_drift_values` schema attribute to the
+// kubernetes.ShowMode used by the renderer. Unknown / null / empty falls
+// through to ShowNone (the safe default).
+func driftModeFromString(v types.String) kubernetes.ShowMode {
+	if v.IsNull() || v.IsUnknown() {
+		return kubernetes.ShowNone
+	}
+	switch v.ValueString() {
+	case string(kubernetes.ShowHash):
+		return kubernetes.ShowHash
+	case string(kubernetes.ShowFull):
+		return kubernetes.ShowFull
+	default:
+		return kubernetes.ShowNone
+	}
 }
 
 // applyResultToModel writes the ApplyManifest output values onto the
@@ -452,14 +528,12 @@ func applyResultToModel(result *kubernetes.ApplyManifestResult, data *manifestRe
 	data.ID = types.StringValue(result.SelfLink)
 	data.UID = types.StringValue(result.UID)
 	data.LiveUID = types.StringValue(result.LiveUID)
-	data.YAMLInCluster = types.StringValue(result.YAMLInClusterFingerprint)
-	data.LiveManifestInCluster = types.StringValue(result.LiveManifestInClusterFingerprint)
+	data.Drift = types.StringValue(result.Drift)
 }
 
 // Create applies the manifest to the cluster and persists the resulting
-// fingerprints (uid, live_uid, yaml_incluster, live_manifest_incluster)
-// to state. Delegates to kubernetes.ApplyManifest, so behaviour matches
-// the SDK v2 half line-for-line. Implements resource.Resource.
+// identity (uid, live_uid) and drift state. Delegates to
+// kubernetes.ApplyManifest. Implements resource.Resource.
 func (r *manifestResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data manifestResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -503,10 +577,10 @@ func (r *manifestResource) Create(ctx context.Context, req resource.CreateReques
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-// Read refreshes live_uid and live_manifest_incluster from the cluster.
-// If the resource has disappeared (ReadManifest reports !Found, or the
-// REST mapper rejects the kind), the resource is removed from state so
-// the next plan recreates it. Implements resource.Resource.
+// Read refreshes live_uid and drift from the cluster. If the resource
+// has disappeared (ReadManifest reports !Found, or the REST mapper
+// rejects the kind), the resource is removed from state so the next
+// plan recreates it. Implements resource.Resource.
 func (r *manifestResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var data manifestResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
@@ -525,10 +599,20 @@ func (r *manifestResource) Read(ctx context.Context, req resource.ReadRequest, r
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	maskPaths, d := extractStringList(ctx, data.MaskPaths)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	opts := kubernetes.ReadManifestOptions{
 		YAMLBody:          data.YAMLBody.ValueString(),
 		OverrideNamespace: data.OverrideNamespace.ValueString(),
 		IgnoreFields:      ignoreFields,
+		ShowDriftValues:   driftModeFromString(data.ShowDriftValues),
+		MaskPaths:         maskPaths,
+		DriftEngine:       driftEngineFromString(data.DriftEngine),
+		FieldManager:      stringOrDefault(data.FieldManager, "kubectl"),
+		ForceConflicts:    data.ForceConflicts.ValueBool(),
 	}
 
 	result, readErr := kubernetes.ReadManifest(ctx, provider, opts)
@@ -544,7 +628,7 @@ func (r *manifestResource) Read(ctx context.Context, req resource.ReadRequest, r
 	}
 
 	data.LiveUID = types.StringValue(result.LiveUID)
-	data.LiveManifestInCluster = types.StringValue(result.LiveManifestInClusterFingerprint)
+	data.Drift = types.StringValue(result.Drift)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -675,9 +759,10 @@ func (r *manifestResource) Delete(ctx context.Context, req resource.DeleteReques
 //  5. UID divergence between state.uid and state.live_uid means the
 //     cluster-side object was recreated; mark uid as Unknown so it is
 //     refreshed during Apply.
-//  6. Drift detection: yaml_incluster vs live_manifest_incluster
-//     mismatch means an external change occurred; mark yaml_incluster
-//     Unknown.
+//  6. Drift detection: a non-empty `drift` in state means an external
+//     change occurred between the last apply and the last refresh;
+//     mark `drift` Unknown so Apply's recomputed value (which converges
+//     to "") doesn't trip the post-apply consistency check.
 //  7. Build yaml_body_parsed by obfuscating sensitive_fields (or the
 //     default Secret v1 fields) and write it into the plan.
 func (r *manifestResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
@@ -782,32 +867,29 @@ func (r *manifestResource) ModifyPlan(ctx context.Context, req resource.ModifyPl
 			resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("uid"), types.StringUnknown())...)
 		}
 
-		if state.YAMLInCluster.ValueString() != state.LiveManifestInCluster.ValueString() {
-			resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("yaml_incluster"), types.StringUnknown())...)
-			// Drift-driven applies recompute both fingerprints; pinning
-			// live_manifest_incluster to the stale state value triggers
-			// the post-apply consistency check when Apply returns the
-			// new value.
-			resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("live_manifest_incluster"), types.StringUnknown())...)
+		// If state recorded non-empty drift on the most recent Read,
+		// pin the planned `drift` to Unknown so Apply's recomputed
+		// value (which converges to "") doesn't trip the framework's
+		// post-apply consistency check. Same role the legacy v2
+		// fingerprint-mismatch gate played for yaml_incluster /
+		// live_manifest_incluster.
+		if state.Drift.ValueString() != "" {
+			resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("drift"), types.StringUnknown())...)
 		}
 
 		// When inputs that feed Apply differ between state and plan,
-		// the computed fingerprints Apply returns cannot be predicted
-		// at plan time: yaml_incluster / live_manifest_incluster are
-		// GetLiveManifestFields hashes over the new manifest against
-		// the post-apply cluster state. The SDK v2 diff engine marked
-		// these "(known after apply)" automatically when relevant
-		// inputs changed; the framework requires it to be explicit.
-		// Without this, the framework's post-apply consistency check
-		// raises "Provider produced inconsistent result after apply"
-		// whenever Apply's recomputed values differ from what state
-		// preserved via UseStateForUnknown.
+		// drift cannot be predicted at plan time: it is computed in
+		// Read against the post-apply live object. Mark it Unknown so
+		// the framework's post-apply consistency check accepts
+		// whatever Apply produces.
 		inputsChanged := plan.YAMLBody.ValueString() != state.YAMLBody.ValueString() ||
 			plan.OverrideNamespace.ValueString() != state.OverrideNamespace.ValueString() ||
-			!plan.IgnoreFields.Equal(state.IgnoreFields)
+			!plan.IgnoreFields.Equal(state.IgnoreFields) ||
+			!plan.MaskPaths.Equal(state.MaskPaths) ||
+			plan.ShowDriftValues.ValueString() != state.ShowDriftValues.ValueString() ||
+			plan.DriftEngine.ValueString() != state.DriftEngine.ValueString()
 		if inputsChanged {
-			resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("yaml_incluster"), types.StringUnknown())...)
-			resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("live_manifest_incluster"), types.StringUnknown())...)
+			resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("drift"), types.StringUnknown())...)
 		}
 
 		// id is the self-link (apiVersion + kind + namespace + name) of
@@ -851,32 +933,117 @@ func (r *manifestResource) ModifyPlan(ctx context.Context, req resource.ModifyPl
 	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("yaml_body_parsed"), obfuscated)...)
 }
 
-// UpgradeState ports the SDK v2 v0 -> v1 state upgrader. v0 stored the
-// raw canonicalised YAML strings in yaml_incluster and
-// live_manifest_incluster; v1 stores their sha256 fingerprints. The
-// upgrader simply hashes both fields if they look unhashed. The v0
-// schema was structurally identical to v1 so we reuse the v1 model for
-// decoding; only the value transform changes.
+// UpgradeState chains state migrations forward to the current schema
+// version. Two migrations are registered, both terminating at v2:
+//
+//   - v0 -> v2: the SDK v2 line (v2.4.x and earlier, the only released
+//     line as of v3.0). v0 stored the raw canonicalised YAML strings in
+//     yaml_incluster and live_manifest_incluster. v2 drops both
+//     attributes entirely and replaces them with `drift` (computed
+//     fresh on the next Read), `show_drift_values` ("none" default),
+//     `mask_paths` (null), and `drift_engine` ("client" default). HCL
+//     referencing the legacy attributes breaks at plan time with a
+//     clear missing-attribute message; migration is
+//     `drift != ""`.
+//
+//   - v1 -> v2: safety net for anyone who installed an interim v3
+//     pre-release that shipped the sha256-fingerprint shape. Same
+//     promotion as v0 -> v2, just decoding from the same shape.
 func (r *manifestResource) UpgradeState(_ context.Context) map[int64]resource.StateUpgrader {
 	return map[int64]resource.StateUpgrader{
 		0: {
 			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				var data manifestResourceModel
-				resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+				var v1 manifestResourceModelV1
+				resp.Diagnostics.Append(req.State.Get(ctx, &v1)...)
 				if resp.Diagnostics.HasError() {
 					return
 				}
-				if !data.YAMLInCluster.IsNull() && !data.YAMLInCluster.IsUnknown() {
-					data.YAMLInCluster = types.StringValue(
-						kubernetes.GetFingerprint(data.YAMLInCluster.ValueString()))
-				}
-				if !data.LiveManifestInCluster.IsNull() && !data.LiveManifestInCluster.IsUnknown() {
-					data.LiveManifestInCluster = types.StringValue(
-						kubernetes.GetFingerprint(data.LiveManifestInCluster.ValueString()))
-				}
+				data := promoteV1ToV2(v1)
 				resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 			},
 		},
+		1: {
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var v1 manifestResourceModelV1
+				resp.Diagnostics.Append(req.State.Get(ctx, &v1)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+				data := promoteV1ToV2(v1)
+				resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+			},
+		},
+	}
+}
+
+// manifestResourceModelV1 is the v0 / v1 schema shape (SDK v2 line +
+// any interim v3 pre-release). The two fingerprint attributes are
+// decoded so the upgrader can read state cleanly; the values are then
+// discarded when promoting to v2 because `drift` is computed fresh on
+// the next Read against live cluster state.
+type manifestResourceModelV1 struct {
+	ID                    types.String   `tfsdk:"id"`
+	UID                   types.String   `tfsdk:"uid"`
+	LiveUID               types.String   `tfsdk:"live_uid"`
+	YAMLInCluster         types.String   `tfsdk:"yaml_incluster"`
+	LiveManifestInCluster types.String   `tfsdk:"live_manifest_incluster"`
+	APIVersion            types.String   `tfsdk:"api_version"`
+	Kind                  types.String   `tfsdk:"kind"`
+	Name                  types.String   `tfsdk:"name"`
+	Namespace             types.String   `tfsdk:"namespace"`
+	OverrideNamespace     types.String   `tfsdk:"override_namespace"`
+	YAMLBody              types.String   `tfsdk:"yaml_body"`
+	YAMLBodyParsed        types.String   `tfsdk:"yaml_body_parsed"`
+	SensitiveFields       types.List     `tfsdk:"sensitive_fields"`
+	ForceNew              types.Bool     `tfsdk:"force_new"`
+	UpgradeAPIVersion     types.Bool     `tfsdk:"upgrade_api_version"`
+	ServerSideApply       types.Bool     `tfsdk:"server_side_apply"`
+	FieldManager          types.String   `tfsdk:"field_manager"`
+	ForceConflicts        types.Bool     `tfsdk:"force_conflicts"`
+	ApplyOnly             types.Bool     `tfsdk:"apply_only"`
+	IgnoreFields          types.List     `tfsdk:"ignore_fields"`
+	Wait                  types.Bool     `tfsdk:"wait"`
+	WaitForRollout        types.Bool     `tfsdk:"wait_for_rollout"`
+	ValidateSchema        types.Bool     `tfsdk:"validate_schema"`
+	DeleteCascade         types.String   `tfsdk:"delete_cascade"`
+	WaitFor               types.List     `tfsdk:"wait_for"`
+	Timeouts              timeouts.Value `tfsdk:"timeouts"`
+}
+
+// promoteV1ToV2 copies a v0 / v1 model into a v2 model, dropping the
+// two legacy fingerprint attributes and populating the four new ones
+// with safe defaults. drift = "" means "no drift recorded yet"; the
+// next Read recomputes it from cluster state.
+func promoteV1ToV2(v1 manifestResourceModelV1) manifestResourceModel {
+	return manifestResourceModel{
+		ID:                v1.ID,
+		UID:               v1.UID,
+		LiveUID:           v1.LiveUID,
+		Drift:             types.StringValue(""),
+		ShowDriftValues:   types.StringValue(string(kubernetes.ShowNone)),
+		MaskPaths:         types.ListNull(types.StringType),
+		DriftEngine:       types.StringValue(string(kubernetes.ClientDriftEngine)),
+		APIVersion:        v1.APIVersion,
+		Kind:              v1.Kind,
+		Name:              v1.Name,
+		Namespace:         v1.Namespace,
+		OverrideNamespace: v1.OverrideNamespace,
+		YAMLBody:          v1.YAMLBody,
+		YAMLBodyParsed:    v1.YAMLBodyParsed,
+		SensitiveFields:   v1.SensitiveFields,
+		ForceNew:          v1.ForceNew,
+		UpgradeAPIVersion: v1.UpgradeAPIVersion,
+		ServerSideApply:   v1.ServerSideApply,
+		FieldManager:      v1.FieldManager,
+		ForceConflicts:    v1.ForceConflicts,
+		ApplyOnly:         v1.ApplyOnly,
+		IgnoreFields:      v1.IgnoreFields,
+		Wait:              v1.Wait,
+		WaitForRollout:    v1.WaitForRollout,
+		ValidateSchema:    v1.ValidateSchema,
+		DeleteCascade:     v1.DeleteCascade,
+		WaitFor:           v1.WaitFor,
+		Timeouts:          v1.Timeouts,
 	}
 }
 
@@ -1043,22 +1210,19 @@ func (r *manifestResource) ImportState(ctx context.Context, req resource.ImportS
 		return
 	}
 
-	// Reuse the same fingerprint helper Create uses, with no ignore
-	// list (the user has no yaml_body yet to compare against). Pass the
-	// stripped live for both arguments, mirroring the SDK v2 importer.
-	// Note: the fingerprint will cover every key in the live object
-	// (because flattenedUser == flattenedLive at import time), not just
-	// the small subset a user's yaml_body would generate at apply time.
-	// That divergence is unavoidable without reconstructing the user's
-	// preferred field set, and matches the v2 behaviour.
-	fingerprint := kubernetes.GetLiveManifestFields(nil, live, live)
-
+	// Import starts in-sync: the stripped live IS the desired side, so
+	// drift is "" by definition. The next plan after import runs Read,
+	// which recomputes drift against the user's yaml_body (which is
+	// the stripped live at this point, byte-for-byte modulo
+	// rendering). Any first-plan diff lands in `drift` itself.
 	var data manifestResourceModel
 	data.ID = types.StringValue(importedSelfLink)
 	data.UID = types.StringValue(importedUID)
 	data.LiveUID = types.StringValue(importedUID)
-	data.YAMLInCluster = types.StringValue(fingerprint)
-	data.LiveManifestInCluster = types.StringValue(fingerprint)
+	data.Drift = types.StringValue("")
+	data.ShowDriftValues = types.StringValue(string(kubernetes.ShowNone))
+	data.MaskPaths = types.ListNull(types.StringType)
+	data.DriftEngine = types.StringValue(string(kubernetes.ClientDriftEngine))
 	data.APIVersion = types.StringValue(importedAPIVersion)
 	data.Kind = types.StringValue(importedKind)
 	data.Name = types.StringValue(importedName)

--- a/internal/framework/resource_kubectl_manifest_acc_test.go
+++ b/internal/framework/resource_kubectl_manifest_acc_test.go
@@ -1273,8 +1273,14 @@ func TestAcckubectlYaml(t *testing.T) {
 						Config: testkubectlYamlLoadTfExample(path, name),
 						Check: resource.ComposeAggregateTestCheckFunc(
 							testAccCheckkubectlExists,
-							resource.TestCheckResourceAttrSet("kubectl_manifest.test", "yaml_incluster"),
-							resource.TestCheckResourceAttrSet("kubectl_manifest.test", "live_manifest_incluster"),
+							// Post-apply, drift must be empty (in-sync sentinel).
+							// Replaces the v2 TestCheckResourceAttrSet on
+							// yaml_incluster / live_manifest_incluster, which
+							// both confirmed "the lifecycle ran"; the v3
+							// equivalent is "the lifecycle ran AND the result
+							// has no drift". testAccCheckkubectlExists already
+							// covers the existence half.
+							resource.TestCheckResourceAttr("kubectl_manifest.test", "drift", ""),
 						),
 					},
 				},

--- a/internal/framework/resource_kubectl_manifest_import_acc_test.go
+++ b/internal/framework/resource_kubectl_manifest_import_acc_test.go
@@ -40,23 +40,9 @@ EOF
 				ImportState:       true,
 				ImportStateId:     "v1//Namespace//" + name,
 				ImportStateVerify: true,
-				// Fields that legitimately diverge between apply-state
-				// and import-state, mirroring SDK v2 behaviour:
-				//
-				// yaml_body / yaml_body_parsed: importer rebuilds
-				// from the stripped live object, which differs in key
-				// order and quoting from the user's apply-time input.
-				//
-				// yaml_incluster / live_manifest_incluster: fingerprint
-				// is computed over flattenedUser intersected with
-				// flattenedLive. At apply time userProvided is the
-				// user's small yaml_body so the fingerprint covers
-				// only those keys. At import time userProvided is the
-				// full stripped live object, so the fingerprint covers
-				// every key the cluster surfaced. The next plan after
-				// import re-fingerprints with the user's yaml_body and
-				// converges; the apply-vs-import gap exists only at
-				// the moment of the verify step.
+				// Fields that legitimately diverge between
+				// apply-state and import-state. Detail in the
+				// ImportStateVerifyIgnore block below.
 				ImportStateVerifyIgnore: []string{
 					// yaml_body / yaml_body_parsed: importer rebuilds
 					// from the stripped live object, which differs in
@@ -119,12 +105,8 @@ EOF
 				ImportState:       true,
 				ImportStateId:     fmt.Sprintf("v1//ConfigMap//%s//%s", cm, ns),
 				ImportStateVerify: true,
-				// Match the cluster-scoped test's verify-ignore: the
-				// fingerprint helper computes a different value for
-				// imports (userProvided is the full live object) than
-				// for applies (userProvided is the user's yaml_body),
-				// so yaml_incluster / live_manifest_incluster diverge
-				// at the verify step alongside yaml_body / yaml_body_parsed.
+				// Same verify-ignore set as the cluster-scoped test;
+				// see that one for the rationale.
 				ImportStateVerifyIgnore: []string{
 					// yaml_body / yaml_body_parsed: importer rebuilds
 					// from the stripped live object, which differs in

--- a/internal/framework/resource_kubectl_manifest_import_acc_test.go
+++ b/internal/framework/resource_kubectl_manifest_import_acc_test.go
@@ -58,10 +58,17 @@ EOF
 				// converges; the apply-vs-import gap exists only at
 				// the moment of the verify step.
 				ImportStateVerifyIgnore: []string{
+					// yaml_body / yaml_body_parsed: importer rebuilds
+					// from the stripped live object, which differs in
+					// key order and quoting from the user's apply-time
+					// input. drift: computed during Read using the
+					// stub manifest the importer rebuilt from the
+					// live object, so it diverges at the verify step.
+					// The next plan after import converges using the
+					// user's yaml_body.
 					"yaml_body",
 					"yaml_body_parsed",
-					"yaml_incluster",
-					"live_manifest_incluster",
+					"drift",
 				},
 			},
 		},
@@ -119,10 +126,17 @@ EOF
 				// so yaml_incluster / live_manifest_incluster diverge
 				// at the verify step alongside yaml_body / yaml_body_parsed.
 				ImportStateVerifyIgnore: []string{
+					// yaml_body / yaml_body_parsed: importer rebuilds
+					// from the stripped live object, which differs in
+					// key order and quoting from the user's apply-time
+					// input. drift: computed during Read using the
+					// stub manifest the importer rebuilt from the
+					// live object, so it diverges at the verify step.
+					// The next plan after import converges using the
+					// user's yaml_body.
 					"yaml_body",
 					"yaml_body_parsed",
-					"yaml_incluster",
-					"live_manifest_incluster",
+					"drift",
 				},
 			},
 		},

--- a/internal/framework/resource_kubectl_manifest_modifyplan_test.go
+++ b/internal/framework/resource_kubectl_manifest_modifyplan_test.go
@@ -73,6 +73,7 @@ func baseModel() manifestResourceModel {
 		YAMLBody:        types.StringValue("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n"),
 		SensitiveFields: types.ListNull(types.StringType),
 		IgnoreFields:    types.ListNull(types.StringType),
+		MaskPaths:       types.ListNull(types.StringType),
 		WaitFor:         types.ListNull(waitForObjectType()),
 		Timeouts:        nullTimeouts(),
 	}

--- a/internal/framework/resource_kubectl_manifest_move.go
+++ b/internal/framework/resource_kubectl_manifest_move.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/alekc/terraform-provider-kubectl/kubernetes"
-	"github.com/alekc/terraform-provider-kubectl/yaml"
 )
 
 // Cross-provider state move support: lets practitioners migrate existing
@@ -192,77 +191,56 @@ func moveFromGavinbunneyManifest(ctx context.Context, req resource.MoveStateRequ
 		return
 	}
 
-	// Recompute the yaml_incluster fingerprint using alekc's
-	// GetLiveManifestFields algorithm against the source yaml_body.
-	// gavinbunney's stored fingerprint was computed by gavinbunney's
-	// algorithm against the apply response; alekc's Read post-move
-	// recomputes live_manifest_incluster against the live cluster using
-	// alekc's algorithm. If we passed gavinbunney's fingerprint through
-	// unchanged, alekc's drift detection in ModifyPlan (compares
-	// yaml_incluster to live_manifest_incluster) would fire on the first
-	// plan after the move, producing a non-empty plan that the
-	// cross-provider smoke job rejects. Computing the baseline here as
-	// GetLiveManifestFields(ignored, parsed, parsed) approximates what
-	// Read produces for a no-drift resource: identical for any kind that
-	// the server does not mutate beyond control fields (Namespace,
-	// ConfigMap, Secret, simple CRDs), which is the typical migration
-	// shape. Resources that get heavy server-side defaulting (admission
-	// webhooks rewriting spec fields) may still see a one-time refresh
-	// diff on the first plan after move; that's a documented caveat in
-	// the migration recipe.
-	yamlFingerprint := src.YAMLInCluster
-	if !src.YAMLBody.IsNull() && !src.YAMLBody.IsUnknown() {
-		parsed, parseErr := yaml.ParseYAML(src.YAMLBody.ValueString())
-		if parseErr == nil {
-			if !src.OverrideNamespace.IsNull() && src.OverrideNamespace.ValueString() != "" {
-				parsed.SetNamespace(src.OverrideNamespace.ValueString())
-			}
-			var ignored []string
-			if !src.IgnoreFields.IsNull() && !src.IgnoreFields.IsUnknown() {
-				for _, elem := range src.IgnoreFields.Elements() {
-					if s, ok := elem.(types.String); ok && !s.IsNull() && !s.IsUnknown() {
-						ignored = append(ignored, s.ValueString())
-					}
-				}
-			}
-			yamlFingerprint = types.StringValue(
-				kubernetes.GetLiveManifestFields(ignored, parsed, parsed),
-			)
-		}
-	}
+	// gavinbunney's stored yaml_incluster / live_manifest_incluster
+	// values were opaque sha256 fingerprints under gavinbunney's
+	// algorithm. This provider's v3 schema dropped both attributes;
+	// drift is recomputed against the live cluster on the next Read.
+	// So the move discards gavinbunney's fingerprints entirely and the
+	// target starts with drift = "". The next plan after the move runs
+	// Read, which computes drift fresh; any first-plan refresh diff
+	// surfaces in the `drift` attribute itself (documented caveat in
+	// the migration recipe).
 
-	// Passthrough of the 20 shared attributes plus id. The 4 alekc-only
-	// attributes take their schema defaults: upgrade_api_version=false
-	// (matches gavinbunney's always-recreate-on-api_version behaviour being
-	// the conservative default), field_manager="kubectl", and wait_for /
-	// delete_cascade null (unset, no-op).
+	// Passthrough of the 19 shared attributes plus id (yaml_incluster
+	// and live_manifest_incluster are NOT carried across; the source's
+	// values are obsolete in v3). The alekc-only attributes take their
+	// schema defaults: upgrade_api_version=false (matches gavinbunney's
+	// always-recreate-on-api_version behaviour being the conservative
+	// default), field_manager="kubectl", and wait_for / delete_cascade
+	// null (unset, no-op).
 	target := manifestResourceModel{
-		ID:                    src.ID,
-		UID:                   src.UID,
-		LiveUID:               src.LiveUID,
-		YAMLInCluster:         yamlFingerprint,
-		LiveManifestInCluster: yamlFingerprint,
-		APIVersion:            src.APIVersion,
-		Kind:                  src.Kind,
-		Name:                  src.Name,
-		Namespace:             src.Namespace,
-		OverrideNamespace:     src.OverrideNamespace,
-		YAMLBody:              src.YAMLBody,
-		YAMLBodyParsed:        src.YAMLBodyParsed,
-		SensitiveFields:       src.SensitiveFields,
-		ForceNew:              src.ForceNew,
-		ServerSideApply:       src.ServerSideApply,
-		ForceConflicts:        src.ForceConflicts,
-		ApplyOnly:             src.ApplyOnly,
-		IgnoreFields:          src.IgnoreFields,
-		Wait:                  src.Wait,
-		WaitForRollout:        src.WaitForRollout,
-		ValidateSchema:        src.ValidateSchema,
+		ID:                src.ID,
+		UID:               src.UID,
+		LiveUID:           src.LiveUID,
+		APIVersion:        src.APIVersion,
+		Kind:              src.Kind,
+		Name:              src.Name,
+		Namespace:         src.Namespace,
+		OverrideNamespace: src.OverrideNamespace,
+		YAMLBody:          src.YAMLBody,
+		YAMLBodyParsed:    src.YAMLBodyParsed,
+		SensitiveFields:   src.SensitiveFields,
+		ForceNew:          src.ForceNew,
+		ServerSideApply:   src.ServerSideApply,
+		ForceConflicts:    src.ForceConflicts,
+		ApplyOnly:         src.ApplyOnly,
+		IgnoreFields:      src.IgnoreFields,
+		Wait:              src.Wait,
+		WaitForRollout:    src.WaitForRollout,
+		ValidateSchema:    src.ValidateSchema,
 
 		UpgradeAPIVersion: types.BoolValue(false),
 		FieldManager:      types.StringValue(defaultFieldManager),
 		DeleteCascade:     types.StringNull(),
 		WaitFor:           types.ListNull(waitForObjectType()),
+		// v3 drift attributes: moved resources start in-sync. drift
+		// recomputes on the next Read. show_drift_values default
+		// "none" (safe); mask_paths null; drift_engine default
+		// "client".
+		Drift:           types.StringValue(""),
+		ShowDriftValues: types.StringValue(string(kubernetes.ShowNone)),
+		MaskPaths:       types.ListNull(types.StringType),
+		DriftEngine:     types.StringValue(string(kubernetes.ClientDriftEngine)),
 		Timeouts: timeouts.Value{
 			Object: types.ObjectNull(map[string]attr.Type{
 				"create": types.StringType,

--- a/internal/framework/resource_kubectl_manifest_move_test.go
+++ b/internal/framework/resource_kubectl_manifest_move_test.go
@@ -125,22 +125,34 @@ func TestMoveFromGavinbunney_HappyPath(t *testing.T) {
 	if !got.WaitFor.IsNull() {
 		t.Errorf("wait_for should be null, got %+v", got.WaitFor)
 	}
+
+	// v2 drift attributes: a moved resource starts in-sync, so drift
+	// must be "" and show_drift_values must be the safe "none"
+	// default. mask_paths is null.
+	if got.Drift.ValueString() != "" {
+		t.Errorf("drift should be empty on move, got %q", got.Drift.ValueString())
+	}
+	if got.ShowDriftValues.ValueString() != "none" {
+		t.Errorf("show_drift_values default: got %q, want %q", got.ShowDriftValues.ValueString(), "none")
+	}
+	if !got.MaskPaths.IsNull() {
+		t.Errorf("mask_paths should be null, got %+v", got.MaskPaths)
+	}
 }
 
-// TestMoveFromGavinbunney_RecomputesYAMLFingerprint asserts the mover
-// replaces the gavinbunney-stored yaml_incluster (and live_manifest_incluster)
-// with an alekc-canonical baseline computed from src.YAMLBody via
-// kubernetes.GetLiveManifestFields. The cross-provider smoke job depends on
-// this: if we passed gavinbunney's fingerprint through unchanged, alekc's
-// drift check in ModifyPlan would fire post-Read against alekc's freshly
-// computed live fingerprint, producing a non-empty plan on the first
-// terraform plan after the move.
-func TestMoveFromGavinbunney_RecomputesYAMLFingerprint(t *testing.T) {
+// TestMoveFromGavinbunney_DiscardsLegacyFingerprints asserts the mover
+// drops gavinbunney's yaml_incluster / live_manifest_incluster (now
+// removed from this provider's schema in v3) and starts the moved
+// resource in-sync. The next Read after move recomputes `drift`
+// against the live cluster object using the user's yaml_body. Any
+// first-plan refresh diff lands in `drift` itself; documented caveat
+// in the migration recipe.
+func TestMoveFromGavinbunney_DiscardsLegacyFingerprints(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
 	src := sampleGavinbunneySource()
-	// Sentinel value the recomputation must overwrite.
+	// Sentinel values the mover must NOT carry across.
 	src.YAMLInCluster = types.StringValue("gavinbunney-style-fp")
 	src.LiveManifestInCluster = types.StringValue("gavinbunney-style-fp")
 
@@ -163,18 +175,17 @@ func TestMoveFromGavinbunney_RecomputesYAMLFingerprint(t *testing.T) {
 		t.Fatalf("reading target state: %+v", diags)
 	}
 
-	if got.YAMLInCluster.ValueString() == "gavinbunney-style-fp" {
-		t.Errorf("yaml_incluster should be recomputed, still equals sentinel")
+	if got.Drift.ValueString() != "" {
+		t.Errorf("drift should be empty post-move (in-sync sentinel), got %q",
+			got.Drift.ValueString())
 	}
-	if got.LiveManifestInCluster.ValueString() == "gavinbunney-style-fp" {
-		t.Errorf("live_manifest_incluster should be recomputed, still equals sentinel")
+	if got.ShowDriftValues.ValueString() != "none" {
+		t.Errorf("show_drift_values default: got %q, want %q",
+			got.ShowDriftValues.ValueString(), "none")
 	}
-	if got.YAMLInCluster.ValueString() != got.LiveManifestInCluster.ValueString() {
-		t.Errorf("post-move yaml_incluster and live_manifest_incluster must match: %q vs %q",
-			got.YAMLInCluster.ValueString(), got.LiveManifestInCluster.ValueString())
-	}
-	if got.YAMLInCluster.ValueString() == "" {
-		t.Errorf("expected a non-empty alekc-canonical fingerprint, got empty")
+	if got.DriftEngine.ValueString() != "client" {
+		t.Errorf("drift_engine default: got %q, want %q",
+			got.DriftEngine.ValueString(), "client")
 	}
 }
 

--- a/internal/framework/resource_kubectl_manifest_test.go
+++ b/internal/framework/resource_kubectl_manifest_test.go
@@ -30,15 +30,18 @@ func TestManifestResource_SchemaShape(t *testing.T) {
 	}
 
 	s := schemaResp.Schema
-	if s.Version != 1 {
-		t.Fatalf("Schema Version: got %d, want 1", s.Version)
+	if s.Version != 2 {
+		t.Fatalf("Schema Version: got %d, want 2", s.Version)
 	}
 
-	// 24 attributes total (id + the 23 mirrored from SDK v2). wait_for is
-	// modelled as a Block, not an Attribute (matches SDK v2's TypeList +
-	// nested Resource shape), so it appears in s.Blocks instead.
+	// 26 attributes total. v3 dropped yaml_incluster and
+	// live_manifest_incluster (replaced by drift; see issue #54) and
+	// added four new ones: drift, show_drift_values, mask_paths,
+	// drift_engine. wait_for is modelled as a Block, not an
+	// Attribute, so it appears in s.Blocks instead.
 	wantAttrs := []string{
-		"id", "uid", "live_uid", "yaml_incluster", "live_manifest_incluster",
+		"id", "uid", "live_uid",
+		"drift", "show_drift_values", "mask_paths", "drift_engine",
 		"api_version", "kind", "name", "namespace", "override_namespace",
 		"yaml_body", "yaml_body_parsed", "sensitive_fields", "force_new",
 		"upgrade_api_version", "server_side_apply", "field_manager",

--- a/internal/framework/resource_kubectl_manifest_update_test.go
+++ b/internal/framework/resource_kubectl_manifest_update_test.go
@@ -31,11 +31,13 @@ func TestUpdate_PreservesStateOnApplyError(t *testing.T) {
 	priorYAML := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\ndata:\n  k: old\n"
 	plannedYAML := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\ndata:\n  k: new\n"
 
+	const priorDrift = "metadata:\n  annotations:\n    prior: <drift>\n"
+
 	priorState := baseModel()
 	priorState.YAMLBody = types.StringValue(priorYAML)
 	priorState.UID = types.StringValue("uid-existing")
 	priorState.LiveUID = types.StringValue("uid-existing")
-	priorState.Drift = types.StringValue("metadata:\n  annotations:\n    prior: <drift>\n")
+	priorState.Drift = types.StringValue(priorDrift)
 	priorState.APIVersion = types.StringValue("v1")
 	priorState.Kind = types.StringValue("ConfigMap")
 	priorState.Name = types.StringValue("x")
@@ -82,9 +84,9 @@ func TestUpdate_PreservesStateOnApplyError(t *testing.T) {
 	if got.YAMLBody.ValueString() == plannedYAML {
 		t.Errorf("yaml_body must NOT be the planned value after a failed Update; #60 regression")
 	}
-	if got.Drift.ValueString() != "metadata:\n  annotations:\n    prior: <drift>\n" {
-		t.Errorf("drift should be the prior value after a failed Update; got %q",
-			got.Drift.ValueString())
+	if got.Drift.ValueString() != priorDrift {
+		t.Errorf("drift after failed Update: expected %q, got %q",
+			priorDrift, got.Drift.ValueString())
 	}
 	if got.UID.ValueString() != "uid-existing" {
 		t.Errorf("uid should be the prior value after a failed Update; got %q",

--- a/internal/framework/resource_kubectl_manifest_update_test.go
+++ b/internal/framework/resource_kubectl_manifest_update_test.go
@@ -35,8 +35,7 @@ func TestUpdate_PreservesStateOnApplyError(t *testing.T) {
 	priorState.YAMLBody = types.StringValue(priorYAML)
 	priorState.UID = types.StringValue("uid-existing")
 	priorState.LiveUID = types.StringValue("uid-existing")
-	priorState.YAMLInCluster = types.StringValue("prior-fingerprint")
-	priorState.LiveManifestInCluster = types.StringValue("prior-fingerprint")
+	priorState.Drift = types.StringValue("metadata:\n  annotations:\n    prior: <drift>\n")
 	priorState.APIVersion = types.StringValue("v1")
 	priorState.Kind = types.StringValue("ConfigMap")
 	priorState.Name = types.StringValue("x")
@@ -83,9 +82,9 @@ func TestUpdate_PreservesStateOnApplyError(t *testing.T) {
 	if got.YAMLBody.ValueString() == plannedYAML {
 		t.Errorf("yaml_body must NOT be the planned value after a failed Update; #60 regression")
 	}
-	if got.YAMLInCluster.ValueString() != "prior-fingerprint" {
-		t.Errorf("yaml_incluster should be the prior fingerprint after a failed Update; got %q",
-			got.YAMLInCluster.ValueString())
+	if got.Drift.ValueString() != "metadata:\n  annotations:\n    prior: <drift>\n" {
+		t.Errorf("drift should be the prior value after a failed Update; got %q",
+			got.Drift.ValueString())
 	}
 	if got.UID.ValueString() != "uid-existing" {
 		t.Errorf("uid should be the prior value after a failed Update; got %q",

--- a/internal/framework/resource_kubectl_manifest_upgrader_test.go
+++ b/internal/framework/resource_kubectl_manifest_upgrader_test.go
@@ -1,0 +1,286 @@
+package framework
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/alekc/terraform-provider-kubectl/kubernetes"
+)
+
+// TestDriftEngineFromString covers the framework-side string -> enum
+// mapping that buildApplyOptions and Read call. Empty / null / unknown
+// must fall through to ClientDriftEngine so users on existing state
+// (where the attribute may not be populated yet) see v2 semantics.
+func TestDriftEngineFromString(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   types.String
+		want kubernetes.DriftEngine
+	}{
+		{"client", types.StringValue("client"), kubernetes.ClientDriftEngine},
+		{"server", types.StringValue("server"), kubernetes.ServerDriftEngine},
+		{"empty-string-falls-back-to-client", types.StringValue(""), kubernetes.ClientDriftEngine},
+		{"null-falls-back-to-client", types.StringNull(), kubernetes.ClientDriftEngine},
+		{"unknown-falls-back-to-client", types.StringUnknown(), kubernetes.ClientDriftEngine},
+		{"unrecognised-string-falls-back-to-client", types.StringValue("magic"), kubernetes.ClientDriftEngine},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got := driftEngineFromString(c.in)
+			if got != c.want {
+				t.Errorf("driftEngineFromString(%v): got %q want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestDriftModeFromString covers the show_drift_values enum mapping.
+// Same fallback contract: anything weird collapses to ShowNone.
+func TestDriftModeFromString(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   types.String
+		want kubernetes.ShowMode
+	}{
+		{"none", types.StringValue("none"), kubernetes.ShowNone},
+		{"hash", types.StringValue("hash"), kubernetes.ShowHash},
+		{"full", types.StringValue("full"), kubernetes.ShowFull},
+		{"empty", types.StringValue(""), kubernetes.ShowNone},
+		{"null", types.StringNull(), kubernetes.ShowNone},
+		{"unknown", types.StringUnknown(), kubernetes.ShowNone},
+		{"unrecognised", types.StringValue("verbose"), kubernetes.ShowNone},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got := driftModeFromString(c.in)
+			if got != c.want {
+				t.Errorf("driftModeFromString(%v): got %q want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestPromoteV1ToV2 verifies the state-shape promotion is faithful:
+// every v1 field round-trips to the v2 model verbatim, the four new
+// drift attributes get their safe defaults, and the two legacy
+// fingerprint attributes are dropped (not present on the v2 model).
+func TestPromoteV1ToV2(t *testing.T) {
+	t.Parallel()
+	v1 := manifestResourceModelV1{
+		ID:                    types.StringValue("/api/v1/configmaps/x"),
+		UID:                   types.StringValue("u-1"),
+		LiveUID:               types.StringValue("u-1"),
+		YAMLInCluster:         types.StringValue("legacy-fp-1"),
+		LiveManifestInCluster: types.StringValue("legacy-fp-2"),
+		APIVersion:            types.StringValue("v1"),
+		Kind:                  types.StringValue("ConfigMap"),
+		Name:                  types.StringValue("x"),
+		Namespace:             types.StringValue("default"),
+		OverrideNamespace:     types.StringValue("override"),
+		YAMLBody:              types.StringValue("apiVersion: v1\nkind: ConfigMap\n"),
+		YAMLBodyParsed:        types.StringValue("apiVersion: v1\nkind: ConfigMap\n"),
+		SensitiveFields:       types.ListNull(types.StringType),
+		ForceNew:              types.BoolValue(true),
+		UpgradeAPIVersion:     types.BoolValue(true),
+		ServerSideApply:       types.BoolValue(true),
+		FieldManager:          types.StringValue("alekc"),
+		ForceConflicts:        types.BoolValue(true),
+		ApplyOnly:             types.BoolValue(true),
+		IgnoreFields:          types.ListNull(types.StringType),
+		Wait:                  types.BoolValue(true),
+		WaitForRollout:        types.BoolValue(false),
+		ValidateSchema:        types.BoolValue(false),
+		DeleteCascade:         types.StringValue("Foreground"),
+		WaitFor:               types.ListNull(waitForObjectType()),
+	}
+	got := promoteV1ToV2(v1)
+
+	// Verbatim passthrough.
+	if got.ID.ValueString() != v1.ID.ValueString() {
+		t.Errorf("ID: got %q want %q", got.ID.ValueString(), v1.ID.ValueString())
+	}
+	if got.UID.ValueString() != v1.UID.ValueString() {
+		t.Errorf("UID: got %q want %q", got.UID.ValueString(), v1.UID.ValueString())
+	}
+	if got.YAMLBody.ValueString() != v1.YAMLBody.ValueString() {
+		t.Errorf("YAMLBody not preserved")
+	}
+	if !got.ForceNew.ValueBool() || !got.UpgradeAPIVersion.ValueBool() ||
+		!got.ServerSideApply.ValueBool() || !got.ForceConflicts.ValueBool() ||
+		!got.ApplyOnly.ValueBool() || !got.Wait.ValueBool() {
+		t.Errorf("bool passthrough lost: %+v", got)
+	}
+	if got.WaitForRollout.ValueBool() {
+		t.Errorf("WaitForRollout false should pass through as false")
+	}
+	if got.FieldManager.ValueString() != "alekc" {
+		t.Errorf("FieldManager passthrough lost: %q", got.FieldManager.ValueString())
+	}
+	if got.DeleteCascade.ValueString() != "Foreground" {
+		t.Errorf("DeleteCascade passthrough lost: %q", got.DeleteCascade.ValueString())
+	}
+
+	// v3 defaults populated.
+	if got.Drift.ValueString() != "" {
+		t.Errorf("Drift default after promotion: got %q want empty", got.Drift.ValueString())
+	}
+	if got.ShowDriftValues.ValueString() != string(kubernetes.ShowNone) {
+		t.Errorf("ShowDriftValues default: got %q want %q",
+			got.ShowDriftValues.ValueString(), kubernetes.ShowNone)
+	}
+	if got.DriftEngine.ValueString() != string(kubernetes.ClientDriftEngine) {
+		t.Errorf("DriftEngine default: got %q want %q",
+			got.DriftEngine.ValueString(), kubernetes.ClientDriftEngine)
+	}
+	if !got.MaskPaths.IsNull() {
+		t.Errorf("MaskPaths default: should be null, got %+v", got.MaskPaths)
+	}
+}
+
+// TestUpgradeState_V1ToV2_ExercisesUpgrader is the regression test
+// for the production crash this PR's first iteration hit: the
+// upgrader called req.State.Get without a PriorSchema declared, so
+// the framework's State had no Schema and Get panicked with a nil
+// pointer. The fix added priorManifestSchemaV1 as PriorSchema; this
+// test exercises the upgrader end-to-end with a constructed v1 raw
+// state so the same crash will reappear here before it reaches CI.
+//
+// The test is structured to:
+//  1. Build a v1-shaped raw state via the prior schema's Terraform
+//     type.
+//  2. Construct UpgradeStateRequest with that raw state wrapped in
+//     a tfsdk.State carrying the prior schema (mirroring how the
+//     framework's UpgradeResourceState handler does it under
+//     production conditions).
+//  3. Call the upgrader callback the resource registers for v1.
+//  4. Decode the response state into the current model and assert
+//     legacy fingerprints are dropped and v3 defaults populated.
+func TestUpgradeState_V1ToV2_ExercisesUpgrader(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := &manifestResource{}
+
+	// Build the current (v2) schema for the response side.
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("building v2 schema: %+v", schemaResp.Diagnostics)
+	}
+	currentSchema := schemaResp.Schema
+
+	// Build the prior (v1) schema from the same source the
+	// upgrader uses.
+	priorSchema := priorManifestSchemaV1(ctx)
+
+	// Seed a tfsdk.State at the prior schema with a representative
+	// v1 model: the legacy fingerprints are populated; the four
+	// new drift attributes are absent (the prior schema has no
+	// such attributes, so they're not encoded into the raw value).
+	priorState := tfsdk.State{
+		Schema: priorSchema,
+		Raw:    tftypes.NewValue(priorSchema.Type().TerraformType(ctx), nil),
+	}
+	v1 := manifestResourceModelV1{
+		ID:                    types.StringValue("/api/v1/configmaps/x"),
+		UID:                   types.StringValue("u-1"),
+		LiveUID:               types.StringValue("u-1"),
+		YAMLInCluster:         types.StringValue("legacy-fp-A"),
+		LiveManifestInCluster: types.StringValue("legacy-fp-B"),
+		APIVersion:            types.StringValue("v1"),
+		Kind:                  types.StringValue("ConfigMap"),
+		Name:                  types.StringValue("x"),
+		Namespace:             types.StringValue("default"),
+		YAMLBody:              types.StringValue("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n"),
+		YAMLBodyParsed:        types.StringValue("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n"),
+		SensitiveFields:       types.ListNull(types.StringType),
+		IgnoreFields:          types.ListNull(types.StringType),
+		WaitFor:               types.ListNull(waitForObjectType()),
+		Timeouts:              nullTimeouts(),
+	}
+	if diags := priorState.Set(ctx, &v1); diags.HasError() {
+		t.Fatalf("seeding prior state: %+v", diags)
+	}
+
+	// Call the registered v1 upgrader. UpgradeState builds the
+	// upgrader map fresh on each call.
+	upgraders := r.UpgradeState(ctx)
+	entry, ok := upgraders[1]
+	if !ok {
+		t.Fatalf("UpgradeState missing entry for prior schema version 1")
+	}
+	if entry.PriorSchema == nil {
+		t.Fatalf("PriorSchema must be declared on the v1 -> v2 upgrader; nil PriorSchema crashed UpgradeResourceState in production")
+	}
+
+	req := resource.UpgradeStateRequest{State: &priorState}
+	resp := &resource.UpgradeStateResponse{
+		State: tfsdk.State{
+			Schema: currentSchema,
+			Raw:    tftypes.NewValue(currentSchema.Type().TerraformType(ctx), nil),
+		},
+	}
+	entry.StateUpgrader(ctx, req, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("upgrader emitted diagnostics: %+v", resp.Diagnostics)
+	}
+
+	// Verify the response state matches the v2 shape: legacy
+	// fingerprints gone, drift attrs populated with safe defaults,
+	// passthrough fields preserved.
+	var got manifestResourceModel
+	if diags := resp.State.Get(ctx, &got); diags.HasError() {
+		t.Fatalf("reading upgraded state: %+v", diags)
+	}
+
+	if got.ID.ValueString() != "/api/v1/configmaps/x" {
+		t.Errorf("id passthrough lost: %q", got.ID.ValueString())
+	}
+	if got.UID.ValueString() != "u-1" {
+		t.Errorf("uid passthrough lost: %q", got.UID.ValueString())
+	}
+	if got.Drift.ValueString() != "" {
+		t.Errorf("post-upgrade drift should be the in-sync sentinel; got %q", got.Drift.ValueString())
+	}
+	if got.ShowDriftValues.ValueString() != "none" {
+		t.Errorf("show_drift_values default: got %q want %q", got.ShowDriftValues.ValueString(), "none")
+	}
+	if got.DriftEngine.ValueString() != "client" {
+		t.Errorf("drift_engine default: got %q want %q", got.DriftEngine.ValueString(), "client")
+	}
+	if !got.MaskPaths.IsNull() {
+		t.Errorf("mask_paths should be null after upgrade; got %+v", got.MaskPaths)
+	}
+}
+
+// TestUpgradeState_RegistersBothVersions verifies the upgrader
+// registers entries for both prior schema versions (0 and 1), each
+// with a PriorSchema set. Catches the omission that crashed CI.
+func TestUpgradeState_RegistersBothVersions(t *testing.T) {
+	t.Parallel()
+	r := &manifestResource{}
+	upgraders := r.UpgradeState(context.Background())
+	for _, v := range []int64{0, 1} {
+		entry, ok := upgraders[v]
+		if !ok {
+			t.Errorf("UpgradeState missing entry for version %d", v)
+			continue
+		}
+		if entry.PriorSchema == nil {
+			t.Errorf("version %d upgrader missing PriorSchema (regression: nil-pointer panic in UpgradeResourceState)", v)
+		}
+		if entry.StateUpgrader == nil {
+			t.Errorf("version %d upgrader missing StateUpgrader callback", v)
+		}
+	}
+}

--- a/kubernetes/drift.go
+++ b/kubernetes/drift.go
@@ -271,46 +271,6 @@ func wrapIndexedItem(idx int, child interface{}) interface{} {
 	}
 }
 
-// renderMissingFromLive walks a desired subtree that has no counterpart
-// in live and emits a structure of <missing> leaves so the user sees the
-// shape of what's not there. Used when a top-level key in desired is
-// absent on the live object.
-func renderMissingFromLive(desired interface{}, path []string, masks []maskGlob, mode ShowMode) interface{} {
-	switch d := desired.(type) {
-	case map[string]interface{}:
-		out := map[string]interface{}{}
-		keys := make([]string, 0, len(d))
-		for k := range d {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		for _, k := range keys {
-			childPath := append(path, k) //nolint:gocritic // intentional
-			out[k] = renderMissingFromLive(d[k], childPath, masks, mode)
-		}
-		return out
-	case []interface{}:
-		out := make([]interface{}, 0, len(d))
-		for i, v := range d {
-			idxPath := append(path, fmt.Sprintf("[%d]", i)) //nolint:gocritic // intentional
-			out = append(out, wrapIndexedItem(i, renderMissingFromLive(v, idxPath, masks, mode)))
-		}
-		return out
-	default:
-		if pathMasked(path, masks) {
-			return sensitiveDriftMarker
-		}
-		switch mode {
-		case ShowFull:
-			return fmt.Sprintf("<was: %s, now: %s>", formatValue(desired), missingMarker)
-		case ShowHash:
-			return fmt.Sprintf("<was:%s now:%s>", shortHash(desired), "missing")
-		default:
-			return driftMarker
-		}
-	}
-}
-
 // renderLeaf produces the leaf representation for a drifted scalar / type
 // mismatch. masks and mode together control how visible the values are.
 func renderLeaf(desired, live interface{}, path []string, masks []maskGlob, mode ShowMode) interface{} {

--- a/kubernetes/drift.go
+++ b/kubernetes/drift.go
@@ -1,0 +1,481 @@
+package kubernetes
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	yamlWriter "sigs.k8s.io/yaml"
+)
+
+// drift.go renders a human-readable diff between a desired manifest and the
+// live manifest as a YAML subtree containing only the paths that differ.
+//
+// This is the visibility layer that replaces opaque sha256 fingerprints in
+// yaml_incluster / live_manifest_incluster. The fingerprint approach made
+// drift detection work but hid which fields actually changed; the YAML
+// output mirrors `kubectl diff` semantics so the plan diff itself tells
+// the user what's drifted without TRACE-level logging.
+//
+// The function is pure: no API calls, no global state. Callers pass two
+// unstructured maps and get back a YAML string (empty when in sync).
+
+// ShowMode controls how drifted leaf values are rendered. The default is
+// ShowNone: paths are visible but values are not.
+type ShowMode string
+
+const (
+	// ShowNone renders each drifted leaf as the literal marker `<drift>`.
+	// Safe default: paths only, no values.
+	ShowNone ShowMode = "none"
+
+	// ShowHash renders each drifted leaf as `<was:HASH now:HASH>` with
+	// 8-char sha256 prefixes. Confirms a value changed without showing
+	// it. Useful for sensitive workloads where the value itself is
+	// confidential but the fact of the change is not.
+	ShowHash ShowMode = "hash"
+
+	// ShowFull renders each drifted leaf as `<was: V1, now: V2>` with
+	// the actual before / after values. Parity with `kubectl diff`.
+	// Secret kinds, ignore_fields paths, and mask_paths globs still
+	// mask their leaves regardless of mode.
+	ShowFull ShowMode = "full"
+)
+
+// driftMarker is the literal string used for drifted leaves under ShowNone
+// and for any leaf that gets force-masked (Secret data, mask_paths). It is
+// not a valid Kubernetes value, so accidentally round-tripping the drift
+// YAML through `kubectl apply` would surface a clear error rather than a
+// silent corruption.
+const driftMarker = "<drift>"
+
+// sensitiveDriftMarker is used at masked leaves to make it clear to the
+// reader that the value is hidden by policy, not by mode. The path is
+// still visible.
+const sensitiveDriftMarker = "<drift sensitive>"
+
+// missingMarker is rendered at array indices that exist in desired but
+// not in live (or vice versa).
+const missingMarker = "<missing>"
+
+// DriftOptions configures the rendering. Zero value is valid:
+// ShowMode defaults to ShowNone; the empty Kind/APIVersion skips Secret
+// auto-masking; nil slices add no extra exclusions / masks.
+type DriftOptions struct {
+	// IgnoreFields lists dot-paths that are excluded from the comparison
+	// entirely. Matches the legacy ignore_fields semantics: an entry
+	// "spec.x" excludes spec.x and every descendant.
+	IgnoreFields []string
+
+	// MaskPaths lists glob-paths whose leaves render as a sensitive
+	// marker regardless of ShowMode. Globs support `*` (one segment)
+	// and `**` (zero or more segments). The path "spec.template.spec"
+	// or the glob "**.password" both work.
+	MaskPaths []string
+
+	// ShowMode controls the leaf rendering for drifted, non-masked
+	// values. Defaults to ShowNone.
+	ShowMode ShowMode
+
+	// Kind and APIVersion enable kind-aware auto-masking. When Kind ==
+	// "Secret" and APIVersion == "v1", the paths `data.*` and
+	// `stringData.*` are masked automatically.
+	Kind       string
+	APIVersion string
+}
+
+// RenderDrift returns a YAML string containing only the paths under which
+// desired and live differ, plus enough parent scaffolding to locate them.
+// Returns the empty string when the two manifests agree on every relevant
+// path. Behaviour is deterministic: map keys are sorted; array drift is
+// reported by index.
+//
+// "Agree" means: trim-string-equal at the leaves, recursive descent at
+// maps, index-aligned at slices. Fields present in live but absent from
+// desired are ignored (they are usually server-side defaulting and
+// controller injection). Fields present in desired but absent from live
+// are reported as <missing>.
+func RenderDrift(desired, live map[string]interface{}, opts DriftOptions) string {
+	if desired == nil {
+		desired = map[string]interface{}{}
+	}
+	if live == nil {
+		live = map[string]interface{}{}
+	}
+
+	ignore := buildIgnoreSet(opts.IgnoreFields)
+	masks := buildMaskGlobs(opts.MaskPaths, opts.Kind, opts.APIVersion)
+
+	tree, hasDrift := collectMapDrift(desired, live, nil, ignore, masks, opts.ShowMode)
+	if !hasDrift {
+		return ""
+	}
+	out, err := yamlWriter.Marshal(tree)
+	if err != nil {
+		// yamlWriter.Marshal on a tree of map[string]interface{} and
+		// []interface{} with primitive leaves cannot fail in practice;
+		// returning a sentinel rather than panicking keeps the
+		// function pure.
+		return fmt.Sprintf("# drift rendering failed: %v\n", err)
+	}
+	return string(out)
+}
+
+// collectMapDrift walks a map pair and returns the drift subtree plus a
+// bool indicating whether anything drifted under this node.
+func collectMapDrift(desired, live map[string]interface{}, path []string, ignore ignoreSet, masks []maskGlob, mode ShowMode) (map[string]interface{}, bool) {
+	result := map[string]interface{}{}
+	keys := make([]string, 0, len(desired))
+	for k := range desired {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	any := false
+	for _, k := range keys {
+		childPath := append(path, k) //nolint:gocritic // intentional non-aliasing per recursion
+		if ignore.matches(childPath) {
+			continue
+		}
+		dv := desired[k]
+		var lv interface{}
+		var hasInLive bool
+		if live != nil {
+			lv, hasInLive = live[k]
+		}
+		if !hasInLive {
+			// Desired has it, live doesn't. That's drift; render
+			// using the value's full subtree but with a missing
+			// marker at every leaf.
+			result[k] = renderMissingFromLive(dv, childPath, masks, mode)
+			any = true
+			continue
+		}
+		child, drifted := collectAnyDrift(dv, lv, childPath, ignore, masks, mode)
+		if drifted {
+			result[k] = child
+			any = true
+		}
+	}
+	return result, any
+}
+
+// collectAnyDrift dispatches on the desired value's concrete type.
+func collectAnyDrift(desired, live interface{}, path []string, ignore ignoreSet, masks []maskGlob, mode ShowMode) (interface{}, bool) {
+	switch d := desired.(type) {
+	case map[string]interface{}:
+		l, _ := live.(map[string]interface{})
+		// If live is not a map, type mismatch == drift at this node.
+		if live != nil && l == nil {
+			return renderLeaf(d, live, path, masks, mode), true
+		}
+		return collectMapDrift(d, l, path, ignore, masks, mode)
+	case []interface{}:
+		l, ok := live.([]interface{})
+		if !ok {
+			if live == nil {
+				return renderLeaf(d, nil, path, masks, mode), true
+			}
+			return renderLeaf(d, live, path, masks, mode), true
+		}
+		return collectSliceDrift(d, l, path, ignore, masks, mode)
+	default:
+		if leafEqual(desired, live) {
+			return nil, false
+		}
+		return renderLeaf(desired, live, path, masks, mode), true
+	}
+}
+
+// collectSliceDrift compares two []interface{} by index. Length mismatches
+// are reported with explicit <missing> entries for the trailing positions
+// on whichever side is shorter.
+func collectSliceDrift(desired, live []interface{}, path []string, ignore ignoreSet, masks []maskGlob, mode ShowMode) ([]interface{}, bool) {
+	var out []interface{}
+	any := false
+	max := len(desired)
+	if len(live) > max {
+		max = len(live)
+	}
+	for i := 0; i < max; i++ {
+		var d, l interface{}
+		hasD := i < len(desired)
+		hasL := i < len(live)
+		if hasD {
+			d = desired[i]
+		}
+		if hasL {
+			l = live[i]
+		}
+		idxPath := append(path, fmt.Sprintf("[%d]", i)) //nolint:gocritic // intentional non-aliasing
+		switch {
+		case hasD && hasL:
+			child, drifted := collectAnyDrift(d, l, idxPath, ignore, masks, mode)
+			if drifted {
+				out = append(out, wrapIndexedItem(i, child))
+				any = true
+			}
+		case hasD && !hasL:
+			// desired has more items than live
+			out = append(out, map[string]interface{}{
+				"_index_":   i,
+				"_missing_": "absent on cluster",
+			})
+			any = true
+		case !hasD && hasL:
+			// live has more items than desired; typically server-injected
+			// defaulting (e.g. status). Skip.
+		}
+	}
+	return out, any
+}
+
+// wrapIndexedItem decorates a drift subtree for an array element with its
+// index so the reader can locate the position even when only one of many
+// elements drifted.
+func wrapIndexedItem(idx int, child interface{}) interface{} {
+	switch v := child.(type) {
+	case map[string]interface{}:
+		// Avoid clobbering a user key literally named "_index_".
+		if _, exists := v["_index_"]; !exists {
+			v["_index_"] = idx
+			return v
+		}
+		return map[string]interface{}{
+			"_index_": idx,
+			"_value_": v,
+		}
+	default:
+		return map[string]interface{}{
+			"_index_": idx,
+			"_value_": v,
+		}
+	}
+}
+
+// renderMissingFromLive walks a desired subtree that has no counterpart
+// in live and emits a structure of <missing> leaves so the user sees the
+// shape of what's not there. Used when a top-level key in desired is
+// absent on the live object.
+func renderMissingFromLive(desired interface{}, path []string, masks []maskGlob, mode ShowMode) interface{} {
+	switch d := desired.(type) {
+	case map[string]interface{}:
+		out := map[string]interface{}{}
+		keys := make([]string, 0, len(d))
+		for k := range d {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			childPath := append(path, k) //nolint:gocritic // intentional
+			out[k] = renderMissingFromLive(d[k], childPath, masks, mode)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, 0, len(d))
+		for i, v := range d {
+			idxPath := append(path, fmt.Sprintf("[%d]", i)) //nolint:gocritic // intentional
+			out = append(out, wrapIndexedItem(i, renderMissingFromLive(v, idxPath, masks, mode)))
+		}
+		return out
+	default:
+		if pathMasked(path, masks) {
+			return sensitiveDriftMarker
+		}
+		switch mode {
+		case ShowFull:
+			return fmt.Sprintf("<was: %s, now: %s>", formatValue(desired), missingMarker)
+		case ShowHash:
+			return fmt.Sprintf("<was:%s now:%s>", shortHash(desired), "missing")
+		default:
+			return driftMarker
+		}
+	}
+}
+
+// renderLeaf produces the leaf representation for a drifted scalar / type
+// mismatch. masks and mode together control how visible the values are.
+func renderLeaf(desired, live interface{}, path []string, masks []maskGlob, mode ShowMode) interface{} {
+	if pathMasked(path, masks) {
+		return sensitiveDriftMarker
+	}
+	switch mode {
+	case ShowFull:
+		return fmt.Sprintf("<was: %s, now: %s>", formatValue(desired), formatValue(live))
+	case ShowHash:
+		return fmt.Sprintf("<was:%s now:%s>", shortHash(desired), shortHash(live))
+	default:
+		return driftMarker
+	}
+}
+
+// formatValue renders a value for the ShowFull mode. Strings get quoted;
+// other scalars use their natural Go form; complex values (a type mismatch
+// between desired and live, e.g. desired is a map and live is a string)
+// stringify via fmt.
+func formatValue(v interface{}) string {
+	if v == nil {
+		return missingMarker
+	}
+	switch s := v.(type) {
+	case string:
+		return fmt.Sprintf("%q", s)
+	case bool, int, int32, int64, uint, uint32, uint64, float32, float64:
+		return fmt.Sprintf("%v", s)
+	default:
+		// Map / slice rendering for type-mismatch cases. Inline as a
+		// short YAML; if marshalling fails just fall back to %v.
+		buf, err := yamlWriter.Marshal(v)
+		if err != nil {
+			return fmt.Sprintf("%v", v)
+		}
+		return strings.TrimRight(string(buf), "\n")
+	}
+}
+
+// shortHash returns the first 8 hex chars of the sha256 of fmt.Sprintf %v
+// of the value. Stable across runs (no randomness, no timestamps), but
+// distinguishes "different value" from "same value" without revealing it.
+func shortHash(v interface{}) string {
+	if v == nil {
+		return "missing"
+	}
+	h := sha256.Sum256([]byte(fmt.Sprintf("%v", v)))
+	return hex.EncodeToString(h[:])[:8]
+}
+
+// leafEqual is the equality check for scalars. Strings get trimmed first
+// because the legacy code did the same and a lot of yaml-vs-apiserver
+// round-tripping introduces gratuitous whitespace differences. Other
+// types use reflect.DeepEqual; numeric types are not coerced (we treat
+// int and float64 as distinct even when numerically equal, because the
+// apiserver only emits one form per field).
+func leafEqual(desired, live interface{}) bool {
+	if desired == nil && live == nil {
+		return true
+	}
+	if desired == nil || live == nil {
+		return false
+	}
+	if ds, ok := desired.(string); ok {
+		if ls, ok2 := live.(string); ok2 {
+			return strings.TrimSpace(ds) == strings.TrimSpace(ls)
+		}
+	}
+	return reflect.DeepEqual(desired, live)
+}
+
+// ignoreSet packages the dotted paths that should be skipped entirely.
+// A path entry "spec.x" matches the exact path and every descendant.
+type ignoreSet struct {
+	prefixes []string
+}
+
+func buildIgnoreSet(extra []string) ignoreSet {
+	all := append([]string{}, kubernetesControlFields...)
+	for _, e := range extra {
+		e = strings.TrimSpace(e)
+		if e != "" {
+			all = append(all, e)
+		}
+	}
+	return ignoreSet{prefixes: all}
+}
+
+func (s ignoreSet) matches(path []string) bool {
+	if len(path) == 0 {
+		return false
+	}
+	joined := strings.Join(path, ".")
+	for _, p := range s.prefixes {
+		if joined == p || strings.HasPrefix(joined, p+".") {
+			return true
+		}
+	}
+	return false
+}
+
+// maskGlob describes one entry in the mask list. Supports literal segments,
+// "*" (one segment), and "**" (zero or more segments).
+type maskGlob struct {
+	segments []string
+}
+
+func buildMaskGlobs(extra []string, kind, apiVersion string) []maskGlob {
+	var out []maskGlob
+	for _, e := range extra {
+		e = strings.TrimSpace(e)
+		if e == "" {
+			continue
+		}
+		out = append(out, maskGlob{segments: splitPath(e)})
+	}
+	if kind == "Secret" && apiVersion == "v1" {
+		out = append(out,
+			maskGlob{segments: []string{"data", "**"}},
+			maskGlob{segments: []string{"data"}},
+			maskGlob{segments: []string{"stringData", "**"}},
+			maskGlob{segments: []string{"stringData"}},
+		)
+	}
+	return out
+}
+
+// splitPath turns a dotted glob into segments. The only metacharacters
+// are `*` and `**`; everything else is a literal.
+func splitPath(p string) []string {
+	return strings.Split(p, ".")
+}
+
+func pathMasked(path []string, masks []maskGlob) bool {
+	for _, g := range masks {
+		if globMatch(g.segments, path) {
+			return true
+		}
+	}
+	return false
+}
+
+// globMatch implements pattern matching for the two metacharacters `*`
+// (matches exactly one path segment) and `**` (matches zero or more
+// segments). Array indices in paths arrive as "[N]" which is treated as
+// a single segment by the matcher.
+func globMatch(pattern, path []string) bool {
+	pi, ti := 0, 0
+	starStar := -1
+	starStarTi := 0
+	for ti < len(path) {
+		if pi < len(pattern) {
+			switch pattern[pi] {
+			case "**":
+				starStar = pi
+				starStarTi = ti
+				pi++
+				continue
+			case "*":
+				pi++
+				ti++
+				continue
+			default:
+				if pattern[pi] == path[ti] {
+					pi++
+					ti++
+					continue
+				}
+			}
+		}
+		if starStar >= 0 {
+			pi = starStar + 1
+			starStarTi++
+			ti = starStarTi
+			continue
+		}
+		return false
+	}
+	for pi < len(pattern) && pattern[pi] == "**" {
+		pi++
+	}
+	return pi == len(pattern)
+}

--- a/kubernetes/drift.go
+++ b/kubernetes/drift.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"reflect"
 	"sort"
 	"strings"
@@ -146,11 +147,24 @@ func collectMapDrift(desired, live map[string]interface{}, path []string, ignore
 			lv, hasInLive = live[k]
 		}
 		if !hasInLive {
-			// Desired has it, live doesn't. That's drift; render
-			// using the value's full subtree but with a missing
-			// marker at every leaf.
-			result[k] = renderMissingFromLive(dv, childPath, masks, mode)
-			any = true
+			// Desired has it, live doesn't. This case is common and
+			// rarely meaningful: the apiserver strips fields the
+			// user provided but the kind doesn't accept
+			// (metadata.namespace on cluster-scoped resources is
+			// the classic offender, injected by override_namespace),
+			// or the user just hasn't applied yet. The legacy v2
+			// fingerprint treated this asymmetrically too: a
+			// missing-in-live key did not contribute to the
+			// fingerprint, so plans were no-ops in this case.
+			// Reporting it as drift here triggers infinite update
+			// loops (each refresh sees drift, plan wants an update,
+			// apply doesn't change live, next refresh sees drift
+			// again). Server-side drift_engine sidesteps this
+			// because the dry-run apply response also lacks the
+			// stripped field, so the comparison agrees with live.
+			// Keep the TRACE log so the case is still observable
+			// for users grepping debug output.
+			log.Printf("[TRACE] desired-only path (live lacks key): %s", strings.Join(childPath, "."))
 			continue
 		}
 		child, drifted := collectAnyDrift(dv, lv, childPath, ignore, masks, mode)
@@ -218,12 +232,14 @@ func collectSliceDrift(desired, live []interface{}, path []string, ignore ignore
 				any = true
 			}
 		case hasD && !hasL:
-			// desired has more items than live
-			out = append(out, map[string]interface{}{
-				"_index_":   i,
-				"_missing_": "absent on cluster",
-			})
-			any = true
+			// desired has more items than live. Treated as
+			// non-drift for the same reason as the map-key case
+			// in collectMapDrift: the apiserver may have trimmed
+			// the list (strategic merge, list-type semantics),
+			// and surfacing it here triggers infinite update
+			// loops on resources where apply produces a shorter
+			// list than the user wrote. TRACE-log instead.
+			log.Printf("[TRACE] desired-only index (live shorter): %s", strings.Join(idxPath, "."))
 		case !hasD && hasL:
 			// live has more items than desired; typically server-injected
 			// defaulting (e.g. status). Skip.
@@ -410,7 +426,23 @@ func buildMaskGlobs(extra []string, kind, apiVersion string) []maskGlob {
 		if e == "" {
 			continue
 		}
-		out = append(out, maskGlob{segments: splitPath(e)})
+		base := splitPath(e)
+		// Literal user entries match the path itself AND every
+		// descendant: a user writing `mask_paths = ["data"]`
+		// expects `data.password` to be masked too, not just a
+		// scalar at `data`. Entries that already end in a `**`
+		// glob are left alone. Entries that contain glob
+		// metacharacters (`*` or `**`) are also taken literally;
+		// users who want a leaf-only pattern can still write
+		// `mask_paths = ["data.*"]` to get exactly-one-segment
+		// children.
+		out = append(out, maskGlob{segments: base})
+		if !endsWithDoubleStar(base) {
+			descendants := make([]string, 0, len(base)+1)
+			descendants = append(descendants, base...)
+			descendants = append(descendants, "**")
+			out = append(out, maskGlob{segments: descendants})
+		}
 	}
 	if kind == "Secret" && apiVersion == "v1" {
 		out = append(out,
@@ -421,6 +453,16 @@ func buildMaskGlobs(extra []string, kind, apiVersion string) []maskGlob {
 		)
 	}
 	return out
+}
+
+// endsWithDoubleStar reports whether the last segment of the pattern
+// is the multi-segment glob `**`. Used to skip the auto-expanded
+// subtree mask in buildMaskGlobs when the user already wrote one.
+func endsWithDoubleStar(segments []string) bool {
+	if len(segments) == 0 {
+		return false
+	}
+	return segments[len(segments)-1] == "**"
 }
 
 // splitPath turns a dotted glob into segments. The only metacharacters

--- a/kubernetes/drift.go
+++ b/kubernetes/drift.go
@@ -311,14 +311,32 @@ func formatValue(v interface{}) string {
 	}
 }
 
-// shortHash returns the first 8 hex chars of the sha256 of fmt.Sprintf %v
-// of the value. Stable across runs (no randomness, no timestamps), but
-// distinguishes "different value" from "same value" without revealing it.
+// shortHash returns the first 8 hex chars of the sha256 of a stable
+// serialisation of v. The "stable" matters: Go's map iteration is
+// randomised, so fmt.Sprintf("%v", aMap) produces a different string
+// per call, which would make ShowHash render new hash markers on
+// every Read for type-mismatch leaves whose desired or live side is
+// a map. yamlWriter.Marshal sorts keys deterministically, so the
+// resulting hash is stable across runs.
+//
+// nil is a sentinel for "no value" and shortcuts to a fixed string;
+// scalars route through fmt because their %v formatting is already
+// deterministic.
 func shortHash(v interface{}) string {
 	if v == nil {
 		return "missing"
 	}
-	h := sha256.Sum256([]byte(fmt.Sprintf("%v", v)))
+	var payload []byte
+	switch v.(type) {
+	case map[string]interface{}, []interface{}:
+		if b, err := yamlWriter.Marshal(v); err == nil {
+			payload = b
+		}
+	}
+	if payload == nil {
+		payload = []byte(fmt.Sprintf("%v", v))
+	}
+	h := sha256.Sum256(payload)
 	return hex.EncodeToString(h[:])[:8]
 }
 

--- a/kubernetes/drift_test.go
+++ b/kubernetes/drift_test.go
@@ -88,7 +88,13 @@ func TestRenderDrift_LeafChange_Full(t *testing.T) {
 	}
 }
 
-func TestRenderDrift_MissingInLive_ReportsMissingMarker(t *testing.T) {
+func TestRenderDrift_MissingInLive_NotReported(t *testing.T) {
+	// User wrote a field that live doesn't have. Common cases: the
+	// apiserver strips fields the kind doesn't accept (e.g.
+	// metadata.namespace on cluster-scoped resources, injected by
+	// override_namespace). Reporting these as drift triggers
+	// infinite update loops because apply doesn't change live.
+	// Match v2's silent-skip behavior; surface via TRACE log only.
 	desired := map[string]interface{}{
 		"metadata": map[string]interface{}{
 			"labels": map[string]interface{}{
@@ -100,8 +106,36 @@ func TestRenderDrift_MissingInLive_ReportsMissingMarker(t *testing.T) {
 		"metadata": map[string]interface{}{},
 	}
 	got := RenderDrift(desired, live, DriftOptions{ShowMode: ShowNone})
-	if !strings.Contains(got, "labels:") || !strings.Contains(got, "app:") {
-		t.Fatalf("expected missing path in drift output, got %q", got)
+	if got != "" {
+		t.Fatalf("missing-in-live should not surface as drift, got %q", got)
+	}
+}
+
+// TestRenderDrift_OverrideNamespaceOnClusterScoped is a regression for
+// the v3 false-drift caused by override_namespace injecting
+// metadata.namespace into a ClusterRole / CRD / other cluster-scoped
+// kind. The apiserver strips it, so live lacks the field; reporting
+// drift triggered post-apply non-empty-plan failures in the
+// TestAccKubectlSetNamespace_nonnamespaced_resource acc test.
+func TestRenderDrift_OverrideNamespaceOnClusterScoped(t *testing.T) {
+	desired := map[string]interface{}{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRole",
+		"metadata": map[string]interface{}{
+			"name":      "x",
+			"namespace": "dev", // injected by override_namespace
+		},
+	}
+	live := map[string]interface{}{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRole",
+		"metadata": map[string]interface{}{
+			"name": "x",
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{ShowMode: ShowNone})
+	if got != "" {
+		t.Fatalf("override_namespace on cluster-scoped resource should not drift, got %q", got)
 	}
 }
 
@@ -242,6 +276,57 @@ func TestRenderDrift_NonSecretKind_DoesNotMaskData(t *testing.T) {
 	}
 }
 
+func TestRenderDrift_MaskPaths_LiteralEntryMasksDescendants(t *testing.T) {
+	// A literal mask_paths entry must hide every leaf under that
+	// subtree, not just an exact-segment match. Users writing
+	// mask_paths = ["data"] reasonably expect data.password to be
+	// masked too.
+	desired := map[string]interface{}{
+		"data": map[string]interface{}{
+			"password": "old-secret",
+			"username": "admin",
+		},
+	}
+	live := map[string]interface{}{
+		"data": map[string]interface{}{
+			"password": "new-secret",
+			"username": "root",
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{
+		MaskPaths: []string{"data"},
+		ShowMode:  ShowFull,
+	})
+	if strings.Contains(got, "old-secret") || strings.Contains(got, "new-secret") {
+		t.Fatalf("password value leaked under data.* mask: %q", got)
+	}
+	if strings.Contains(got, "admin") || strings.Contains(got, "root") {
+		t.Fatalf("username value leaked under data.* mask: %q", got)
+	}
+}
+
+func TestRenderDrift_MaskPaths_ExplicitDoubleStarNotDoubled(t *testing.T) {
+	// User already wrote `**`; don't auto-append another. Result
+	// should still mask descendants but not duplicate the pattern.
+	desired := map[string]interface{}{
+		"data": map[string]interface{}{
+			"k": "old",
+		},
+	}
+	live := map[string]interface{}{
+		"data": map[string]interface{}{
+			"k": "new",
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{
+		MaskPaths: []string{"data.**"},
+		ShowMode:  ShowFull,
+	})
+	if strings.Contains(got, "old") || strings.Contains(got, "new") {
+		t.Fatalf("value leaked despite data.** mask: %q", got)
+	}
+}
+
 func TestRenderDrift_MaskPaths_Exact(t *testing.T) {
 	desired := map[string]interface{}{
 		"spec": map[string]interface{}{
@@ -349,7 +434,12 @@ func TestRenderDrift_ArrayLeafChange(t *testing.T) {
 	}
 }
 
-func TestRenderDrift_ArrayLengthMismatch(t *testing.T) {
+func TestRenderDrift_ArrayLengthMismatch_DesiredLonger(t *testing.T) {
+	// User wrote 3 items, live has 2. Treated as non-drift for the
+	// same reason as the missing-map-key case: the apiserver may
+	// have trimmed the list via strategic merge or list-type
+	// semantics, and reporting drift would trigger infinite
+	// updates. Surface via TRACE log only.
 	desired := map[string]interface{}{
 		"spec": map[string]interface{}{
 			"items": []interface{}{
@@ -368,8 +458,8 @@ func TestRenderDrift_ArrayLengthMismatch(t *testing.T) {
 		},
 	}
 	got := RenderDrift(desired, live, DriftOptions{})
-	if !strings.Contains(got, "_missing_") {
-		t.Fatalf("expected _missing_ marker for absent index, got %q", got)
+	if got != "" {
+		t.Fatalf("desired-longer-than-live should not drift, got %q", got)
 	}
 }
 

--- a/kubernetes/drift_test.go
+++ b/kubernetes/drift_test.go
@@ -1,0 +1,536 @@
+package kubernetes
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderDrift_InSync(t *testing.T) {
+	desired := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      "x",
+			"namespace": "default",
+		},
+		"data": map[string]interface{}{
+			"key": "value",
+		},
+	}
+	live := deepClone(desired)
+	got := RenderDrift(desired, live, DriftOptions{})
+	if got != "" {
+		t.Fatalf("expected empty drift for identical manifests, got %q", got)
+	}
+}
+
+func TestRenderDrift_LeafChange_None(t *testing.T) {
+	desired := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				"foo": "bar",
+				"baz": "qux",
+			},
+		},
+	}
+	live := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				"foo": "BAR",
+				"baz": "qux",
+			},
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{ShowMode: ShowNone})
+	want := "metadata:\n  annotations:\n    foo: <drift>\n"
+	if got != want {
+		t.Fatalf("ShowNone: got %q want %q", got, want)
+	}
+}
+
+func TestRenderDrift_LeafChange_Hash(t *testing.T) {
+	desired := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"replicas": 2,
+		},
+	}
+	live := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"replicas": 3,
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{ShowMode: ShowHash})
+	if !strings.Contains(got, "replicas:") {
+		t.Fatalf("expected path in output, got %q", got)
+	}
+	if !strings.Contains(got, "<was:") || !strings.Contains(got, "now:") {
+		t.Fatalf("expected hash markers, got %q", got)
+	}
+	if strings.Contains(got, "2") && strings.Contains(got, "3") && !strings.Contains(got, "was:") {
+		t.Fatalf("hash mode should NOT leak literal values, got %q", got)
+	}
+}
+
+func TestRenderDrift_LeafChange_Full(t *testing.T) {
+	desired := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"replicas": 2,
+		},
+	}
+	live := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"replicas": 3,
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{ShowMode: ShowFull})
+	if !strings.Contains(got, "<was: 2, now: 3>") {
+		t.Fatalf("Full mode: expected was/now values, got %q", got)
+	}
+}
+
+func TestRenderDrift_MissingInLive_ReportsMissingMarker(t *testing.T) {
+	desired := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"labels": map[string]interface{}{
+				"app": "foo",
+			},
+		},
+	}
+	live := map[string]interface{}{
+		"metadata": map[string]interface{}{},
+	}
+	got := RenderDrift(desired, live, DriftOptions{ShowMode: ShowNone})
+	if !strings.Contains(got, "labels:") || !strings.Contains(got, "app:") {
+		t.Fatalf("expected missing path in drift output, got %q", got)
+	}
+}
+
+func TestRenderDrift_ExtraInLive_NotReported(t *testing.T) {
+	// Server-side controllers add fields. Those are not drift.
+	desired := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"replicas": 2,
+		},
+	}
+	live := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"replicas": 2,
+		},
+		"status": map[string]interface{}{
+			"phase": "Running",
+		},
+		"metadata": map[string]interface{}{
+			"resourceVersion": "1234",
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{})
+	if got != "" {
+		t.Fatalf("server-added fields are not drift, got %q", got)
+	}
+}
+
+func TestRenderDrift_IgnoreFields_Exact(t *testing.T) {
+	desired := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				"foo": "bar",
+			},
+		},
+	}
+	live := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				"foo": "BAR",
+			},
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{
+		IgnoreFields: []string{"metadata.annotations.foo"},
+	})
+	if got != "" {
+		t.Fatalf("ignored field should not appear in drift, got %q", got)
+	}
+}
+
+func TestRenderDrift_IgnoreFields_Prefix(t *testing.T) {
+	desired := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				"foo": "bar",
+				"baz": "qux",
+			},
+		},
+	}
+	live := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				"foo": "BAR",
+				"baz": "QUX",
+			},
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{
+		IgnoreFields: []string{"metadata.annotations"},
+	})
+	if got != "" {
+		t.Fatalf("prefix ignore should suppress all children, got %q", got)
+	}
+}
+
+func TestRenderDrift_KubernetesControlFields_AutoIgnored(t *testing.T) {
+	desired := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"finalizers": []interface{}{"a"},
+			"name":       "x",
+		},
+	}
+	live := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"finalizers": []interface{}{"b"},
+			"name":       "x",
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{})
+	if got != "" {
+		t.Fatalf("metadata.finalizers is a control field, got %q", got)
+	}
+}
+
+func TestRenderDrift_Secret_AutoMasksData(t *testing.T) {
+	desired := map[string]interface{}{
+		"data": map[string]interface{}{
+			"password": "c2VjcmV0",
+		},
+	}
+	live := map[string]interface{}{
+		"data": map[string]interface{}{
+			"password": "QU5PVEhFUg==",
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{
+		Kind:       "Secret",
+		APIVersion: "v1",
+		ShowMode:   ShowFull, // Secret masking overrides Full mode
+	})
+	if !strings.Contains(got, "<drift sensitive>") {
+		t.Fatalf("Secret data must be auto-masked, got %q", got)
+	}
+	if strings.Contains(got, "c2VjcmV0") || strings.Contains(got, "QU5PVEhFUg") {
+		t.Fatalf("Secret values leaked: %q", got)
+	}
+}
+
+func TestRenderDrift_NonSecretKind_DoesNotMaskData(t *testing.T) {
+	// `data` is not magic on a ConfigMap. Should render normally.
+	desired := map[string]interface{}{
+		"data": map[string]interface{}{
+			"key": "v1",
+		},
+	}
+	live := map[string]interface{}{
+		"data": map[string]interface{}{
+			"key": "v2",
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{
+		Kind:       "ConfigMap",
+		APIVersion: "v1",
+		ShowMode:   ShowFull,
+	})
+	if !strings.Contains(got, "<was: \"v1\", now: \"v2\">") {
+		t.Fatalf("expected full value rendering on non-Secret kind, got %q", got)
+	}
+}
+
+func TestRenderDrift_MaskPaths_Exact(t *testing.T) {
+	desired := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"password": "a",
+		},
+	}
+	live := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"password": "b",
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{
+		MaskPaths: []string{"spec.password"},
+		ShowMode:  ShowFull,
+	})
+	if !strings.Contains(got, "<drift sensitive>") {
+		t.Fatalf("mask_paths exact match should mask, got %q", got)
+	}
+}
+
+func TestRenderDrift_MaskPaths_DoubleGlob(t *testing.T) {
+	desired := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"env": []interface{}{
+								map[string]interface{}{
+									"name":  "PASSWORD",
+									"value": "old",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	live := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"env": []interface{}{
+								map[string]interface{}{
+									"name":  "PASSWORD",
+									"value": "new",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{
+		MaskPaths: []string{"**.value"},
+		ShowMode:  ShowFull,
+	})
+	if strings.Contains(got, "old") || strings.Contains(got, "new") {
+		t.Fatalf("** glob should mask the leaf, got %q", got)
+	}
+	if !strings.Contains(got, "<drift sensitive>") {
+		t.Fatalf("expected sensitive marker, got %q", got)
+	}
+}
+
+func TestRenderDrift_ArrayLeafChange(t *testing.T) {
+	desired := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{
+					"name":  "app",
+					"image": "foo:v1",
+				},
+				map[string]interface{}{
+					"name":  "sidecar",
+					"image": "bar:v1",
+				},
+			},
+		},
+	}
+	live := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{
+					"name":  "app",
+					"image": "foo:v1",
+				},
+				map[string]interface{}{
+					"name":  "sidecar",
+					"image": "bar:v2",
+				},
+			},
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{ShowMode: ShowNone})
+	if !strings.Contains(got, "_index_: 1") {
+		t.Fatalf("expected index marker for drifted item, got %q", got)
+	}
+	if !strings.Contains(got, "image:") {
+		t.Fatalf("expected image path in drift output, got %q", got)
+	}
+}
+
+func TestRenderDrift_ArrayLengthMismatch(t *testing.T) {
+	desired := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"items": []interface{}{
+				"a",
+				"b",
+				"c",
+			},
+		},
+	}
+	live := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"items": []interface{}{
+				"a",
+				"b",
+			},
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{})
+	if !strings.Contains(got, "_missing_") {
+		t.Fatalf("expected _missing_ marker for absent index, got %q", got)
+	}
+}
+
+func TestRenderDrift_StringTrimming(t *testing.T) {
+	desired := map[string]interface{}{
+		"data": map[string]interface{}{
+			"key": "value",
+		},
+	}
+	live := map[string]interface{}{
+		"data": map[string]interface{}{
+			"key": "value\n",
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{
+		Kind:       "ConfigMap",
+		APIVersion: "v1",
+	})
+	if got != "" {
+		t.Fatalf("trailing whitespace should not register as drift, got %q", got)
+	}
+}
+
+func TestRenderDrift_TypeMismatch(t *testing.T) {
+	desired := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"x": "string",
+		},
+	}
+	live := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"x": 42,
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{ShowMode: ShowNone})
+	if !strings.Contains(got, "x:") {
+		t.Fatalf("expected the drifted key in output, got %q", got)
+	}
+}
+
+func TestRenderDrift_NestedMapWithMultipleDrifts(t *testing.T) {
+	desired := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				"a": "1",
+				"b": "2",
+				"c": "3",
+			},
+		},
+		"spec": map[string]interface{}{
+			"replicas": 2,
+		},
+	}
+	live := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				"a": "X",
+				"b": "2",
+				"c": "Y",
+			},
+		},
+		"spec": map[string]interface{}{
+			"replicas": 5,
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{ShowMode: ShowNone})
+	// Each drifted leaf should appear; unchanged "b" should not.
+	if !strings.Contains(got, "a: <drift>") {
+		t.Fatalf("missing drift on a: %q", got)
+	}
+	if !strings.Contains(got, "c: <drift>") {
+		t.Fatalf("missing drift on c: %q", got)
+	}
+	if !strings.Contains(got, "replicas: <drift>") {
+		t.Fatalf("missing drift on replicas: %q", got)
+	}
+	if strings.Contains(got, "b: <drift>") {
+		t.Fatalf("unchanged 'b' rendered as drift: %q", got)
+	}
+}
+
+func TestRenderDrift_DeterministicOrdering(t *testing.T) {
+	desired := map[string]interface{}{
+		"z": "1",
+		"a": "1",
+		"m": "1",
+	}
+	live := map[string]interface{}{
+		"z": "X",
+		"a": "X",
+		"m": "X",
+	}
+	got := RenderDrift(desired, live, DriftOptions{ShowMode: ShowNone})
+	// Map keys should be sorted (sigs.k8s.io/yaml respects map ordering via
+	// json marshalling and sorts keys, so a/m/z is the natural order).
+	idxA := strings.Index(got, "a:")
+	idxM := strings.Index(got, "m:")
+	idxZ := strings.Index(got, "z:")
+	if !(idxA < idxM && idxM < idxZ) {
+		t.Fatalf("expected sorted key order a, m, z; got %q", got)
+	}
+}
+
+func TestRenderDrift_EmptyInputs(t *testing.T) {
+	got := RenderDrift(nil, nil, DriftOptions{})
+	if got != "" {
+		t.Fatalf("nil-nil should be in-sync, got %q", got)
+	}
+	got = RenderDrift(map[string]interface{}{}, map[string]interface{}{}, DriftOptions{})
+	if got != "" {
+		t.Fatalf("empty-empty should be in-sync, got %q", got)
+	}
+}
+
+func TestGlobMatch(t *testing.T) {
+	cases := []struct {
+		pattern []string
+		path    []string
+		want    bool
+	}{
+		{[]string{"data"}, []string{"data"}, true},
+		{[]string{"data"}, []string{"data", "x"}, false},
+		{[]string{"data", "*"}, []string{"data", "x"}, true},
+		{[]string{"data", "*"}, []string{"data", "x", "y"}, false},
+		{[]string{"data", "**"}, []string{"data", "x", "y"}, true},
+		{[]string{"data", "**"}, []string{"data"}, true},
+		{[]string{"**", "password"}, []string{"spec", "x", "password"}, true},
+		{[]string{"**", "password"}, []string{"password"}, true},
+		{[]string{"**", "password"}, []string{"spec", "password", "x"}, false},
+		{[]string{"a", "*", "c"}, []string{"a", "b", "c"}, true},
+		{[]string{"a", "*", "c"}, []string{"a", "c"}, false},
+	}
+	for _, c := range cases {
+		got := globMatch(c.pattern, c.path)
+		if got != c.want {
+			t.Errorf("globMatch(%v, %v) = %v, want %v", c.pattern, c.path, got, c.want)
+		}
+	}
+}
+
+// deepClone returns a deep copy of an unstructured-style map, used by tests
+// that need to mutate the live side without disturbing desired.
+func deepClone(in map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		out[k] = deepCloneAny(v)
+	}
+	return out
+}
+
+func deepCloneAny(v interface{}) interface{} {
+	switch x := v.(type) {
+	case map[string]interface{}:
+		return deepClone(x)
+	case []interface{}:
+		out := make([]interface{}, len(x))
+		for i, e := range x {
+			out[i] = deepCloneAny(e)
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/kubernetes/drift_test.go
+++ b/kubernetes/drift_test.go
@@ -66,7 +66,12 @@ func TestRenderDrift_LeafChange_Hash(t *testing.T) {
 	if !strings.Contains(got, "<was:") || !strings.Contains(got, "now:") {
 		t.Fatalf("expected hash markers, got %q", got)
 	}
-	if strings.Contains(got, "2") && strings.Contains(got, "3") && !strings.Contains(got, "was:") {
+	// Confirm the literal values 2 and 3 did NOT leak under the
+	// hash markers. The presence of "<was:" is given by the
+	// earlier assertion; the new check is: any line that includes
+	// "<was:" must NOT also include the literal value bookended in
+	// the recognisable was/now shape.
+	if strings.Contains(got, "<was: 2") || strings.Contains(got, "now: 3>") {
 		t.Fatalf("hash mode should NOT leak literal values, got %q", got)
 	}
 }
@@ -646,6 +651,65 @@ func TestRenderDrift_ShortHash_Nil(t *testing.T) {
 	}
 	if a, b := shortHash(1), shortHash(2); a == b {
 		t.Errorf("shortHash should differ across values: %q == %q", a, b)
+	}
+}
+
+// TestRenderDrift_ShortHash_StableForMaps regresses the
+// fmt.Sprintf("%v", aMap) instability: Go's map iteration is
+// randomised, so a naive %v-based hash flaps per call. Hash twice
+// from independently-constructed maps with the same logical content;
+// the hashes must agree, and they must also agree on a third call
+// from the same map literal (catches accidental clock / nondeterministic
+// input).
+func TestRenderDrift_ShortHash_StableForMaps(t *testing.T) {
+	t.Parallel()
+	for i := 0; i < 16; i++ {
+		a := map[string]interface{}{
+			"k1": "v1",
+			"k2": "v2",
+			"k3": "v3",
+			"k4": "v4",
+			"k5": "v5",
+		}
+		b := map[string]interface{}{
+			"k5": "v5",
+			"k4": "v4",
+			"k3": "v3",
+			"k2": "v2",
+			"k1": "v1",
+		}
+		ha := shortHash(a)
+		hb := shortHash(b)
+		hc := shortHash(a)
+		if ha != hb {
+			t.Errorf("iteration %d: shortHash flapped across two same-content maps: %q vs %q", i, ha, hb)
+		}
+		if ha != hc {
+			t.Errorf("iteration %d: shortHash flapped on repeated call with same map: %q vs %q", i, ha, hc)
+		}
+	}
+}
+
+// TestRenderDrift_ShortHash_StableForSlices regresses the same
+// concern for slice-typed values. Slices retain ordering, but
+// fmt.Sprintf %v on a slice of map elements would re-trigger map
+// ordering instability for each element.
+func TestRenderDrift_ShortHash_StableForSlices(t *testing.T) {
+	t.Parallel()
+	for i := 0; i < 16; i++ {
+		a := []interface{}{
+			map[string]interface{}{"a": "1", "b": "2"},
+			map[string]interface{}{"c": "3"},
+		}
+		b := []interface{}{
+			map[string]interface{}{"b": "2", "a": "1"},
+			map[string]interface{}{"c": "3"},
+		}
+		ha := shortHash(a)
+		hb := shortHash(b)
+		if ha != hb {
+			t.Errorf("iteration %d: shortHash flapped across slices with reordered nested map keys: %q vs %q", i, ha, hb)
+		}
 	}
 }
 

--- a/kubernetes/drift_test.go
+++ b/kubernetes/drift_test.go
@@ -563,6 +563,175 @@ func TestRenderDrift_DeterministicOrdering(t *testing.T) {
 	}
 }
 
+// TestRenderDrift_LeafTypeMismatch covers the dispatch branch in
+// collectAnyDrift where desired is a map and live is a scalar (or
+// vice versa). The renderer should emit the path with the
+// appropriate leaf marker rather than recurse into nothing.
+func TestRenderDrift_LeafTypeMismatch_DesiredMapLiveScalar(t *testing.T) {
+	desired := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"x": map[string]interface{}{"inner": "value"},
+		},
+	}
+	live := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"x": 42, // type mismatch
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{ShowMode: ShowFull})
+	if !strings.Contains(got, "x:") {
+		t.Fatalf("expected drifted key in output, got %q", got)
+	}
+	if !strings.Contains(got, "<was:") {
+		t.Fatalf("expected was/now markers for type-mismatched leaf, got %q", got)
+	}
+}
+
+func TestRenderDrift_LeafTypeMismatch_DesiredSliceLiveScalar(t *testing.T) {
+	desired := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"items": []interface{}{"a", "b"},
+		},
+	}
+	live := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"items": "not-a-list",
+		},
+	}
+	got := RenderDrift(desired, live, DriftOptions{ShowMode: ShowNone})
+	if !strings.Contains(got, "items:") {
+		t.Fatalf("expected drifted key in output, got %q", got)
+	}
+}
+
+// TestRenderDrift_LeafEqual_NilCases exercises the explicit nil
+// branches in leafEqual that the higher-level RenderDrift tests
+// don't reach naturally.
+func TestRenderDrift_LeafEqual_NilCases(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name           string
+		desired, live  interface{}
+		wantEqual      bool
+	}{
+		{"both-nil", nil, nil, true},
+		{"desired-nil-live-string", nil, "x", false},
+		{"desired-string-live-nil", "x", nil, false},
+		{"trim-whitespace-equal", "foo\n", " foo ", true},
+		{"different-strings", "foo", "bar", false},
+		{"int-vs-float-not-coerced", 1, 1.0, false},
+		{"matching-ints", 42, 42, true},
+		{"int-vs-string", 1, "1", false},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got := leafEqual(c.desired, c.live)
+			if got != c.wantEqual {
+				t.Errorf("leafEqual(%v, %v) = %v, want %v", c.desired, c.live, got, c.wantEqual)
+			}
+		})
+	}
+}
+
+// TestRenderDrift_ShortHash_Nil exercises the explicit nil branch in
+// shortHash that the higher-level Hash-mode test doesn't reach.
+func TestRenderDrift_ShortHash_Nil(t *testing.T) {
+	if got := shortHash(nil); got != "missing" {
+		t.Errorf("shortHash(nil): got %q want %q", got, "missing")
+	}
+	if got := shortHash("foo"); len(got) != 8 {
+		t.Errorf("shortHash(string): expected 8-char prefix, got %q", got)
+	}
+	if a, b := shortHash(1), shortHash(2); a == b {
+		t.Errorf("shortHash should differ across values: %q == %q", a, b)
+	}
+}
+
+// TestRenderDrift_FormatValue_Variants covers the various Go types
+// formatValue handles for ShowFull rendering.
+func TestRenderDrift_FormatValue_Variants(t *testing.T) {
+	cases := []struct {
+		in       interface{}
+		contains string
+	}{
+		{"hello", `"hello"`},
+		{42, "42"},
+		{true, "true"},
+		{3.14, "3.14"},
+		{nil, missingMarker},
+	}
+	for _, c := range cases {
+		got := formatValue(c.in)
+		if !strings.Contains(got, c.contains) {
+			t.Errorf("formatValue(%v): expected to contain %q, got %q", c.in, c.contains, got)
+		}
+	}
+}
+
+// TestRenderDrift_MaskUnderArrayIndex confirms the mask globs apply
+// to leaves inside array elements. The common shape is
+// `spec.template.spec.containers.*.env.*.value`: env entries in
+// each container with potentially sensitive values.
+func TestRenderDrift_MaskUnderArrayIndex(t *testing.T) {
+	desired := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{
+					"name": "app",
+					"env": []interface{}{
+						map[string]interface{}{
+							"name":  "DB_PASSWORD",
+							"value": "before",
+						},
+					},
+				},
+			},
+		},
+	}
+	live := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{
+					"name": "app",
+					"env": []interface{}{
+						map[string]interface{}{
+							"name":  "DB_PASSWORD",
+							"value": "after",
+						},
+					},
+				},
+			},
+		},
+	}
+	// Array indices in the path render as "[N]"; the glob must
+	// match the literal segment "[0]" or use `*` to skip it.
+	got := RenderDrift(desired, live, DriftOptions{
+		MaskPaths: []string{"spec.containers.*.env.*.value"},
+		ShowMode:  ShowFull,
+	})
+	if strings.Contains(got, "before") || strings.Contains(got, "after") {
+		t.Fatalf("env value leaked under array glob mask: %q", got)
+	}
+	if !strings.Contains(got, "<drift sensitive>") {
+		t.Fatalf("expected sensitive marker on env.*.value, got %q", got)
+	}
+}
+
+func TestRenderDrift_IgnoreSetMatches_EmptyPath(t *testing.T) {
+	// Defensive: empty path should never match an ignore prefix.
+	// Otherwise a top-level RenderDrift call with `IgnoreFields =
+	// ["something"]` could short-circuit before walking children.
+	set := buildIgnoreSet([]string{"spec", "metadata"})
+	if set.matches(nil) {
+		t.Errorf("ignoreSet.matches(nil) should be false")
+	}
+	if set.matches([]string{}) {
+		t.Errorf("ignoreSet.matches(empty slice) should be false")
+	}
+}
+
 func TestRenderDrift_EmptyInputs(t *testing.T) {
 	got := RenderDrift(nil, nil, DriftOptions{})
 	if got != "" {

--- a/kubernetes/manifest_lifecycle.go
+++ b/kubernetes/manifest_lifecycle.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"log"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	meta_v1_unstruct "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apimachinery_types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/printers"
 	k8sresource "k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/dynamic"
@@ -29,6 +31,28 @@ import (
 // shaping. Used by both halves of the muxed provider during the v2 -> v3
 // framework migration (issue #295).
 
+// DriftEngine names the algorithm used to detect drift between the
+// desired manifest and the live cluster object. ClientDriftEngine is the
+// default; ServerDriftEngine is opt-in.
+type DriftEngine string
+
+const (
+	// ClientDriftEngine compares the user-provided manifest against the
+	// live object client-side, flattening both into dotted paths and
+	// comparing per-key. Fast (no extra API calls), but susceptible to
+	// false drift on arrays, server-side defaulting, and admission
+	// webhook mutations.
+	ClientDriftEngine DriftEngine = "client"
+
+	// ServerDriftEngine runs an SSA dry-run patch against the apiserver
+	// and uses the response (the apiserver's view of the post-apply
+	// object) as the desired side of the comparison. Same semantics as
+	// `kubectl diff`. Costs one extra API call per Read. Falls back to
+	// the client engine on patch failure (e.g. CRDs that don't accept
+	// ApplyPatchType, webhook rejection, RBAC missing PATCH verb).
+	ServerDriftEngine DriftEngine = "server"
+)
+
 // ApplyManifestOptions captures everything ApplyManifest reads from the
 // caller. All fields are plain types so the framework half can construct
 // the options without depending on the SDK v2 schema package.
@@ -42,22 +66,39 @@ type ApplyManifestOptions struct {
 	WaitForRollout    bool
 	WaitFor           *types.WaitFor // nil if no wait_for block
 	Timeout           time.Duration  // applies to wait_for_rollout and wait_for
-	IgnoreFields      []string       // for fingerprint calc
+	IgnoreFields      []string       // for drift calculation
 	// SensitiveFields lists dotted paths whose values are masked in
 	// any [DEBUG]-level log emission of the manifest. Defaults to
 	// "data" and "stringData" on Secret v1 when empty; same semantics
 	// as BuildObfuscatedYAML. Apply does not otherwise interpret it.
 	SensitiveFields []string
+
+	// ShowDriftValues controls how drifted leaf values appear in the
+	// `drift` attribute. "none" (default) shows paths only;
+	// "hash" shows short-hash markers; "full" shows literal before /
+	// after values. Secret kinds and MaskPaths still mask regardless
+	// of mode. See kubernetes/drift.go for the rendering rules.
+	ShowDriftValues ShowMode
+	// MaskPaths lists glob-paths whose leaves render as a sensitive
+	// marker in the `drift` attribute, on top of the Secret data /
+	// stringData auto-masking.
+	MaskPaths []string
+	// DriftEngine selects the detection algorithm. Empty == client.
+	DriftEngine DriftEngine
 }
 
 // ApplyManifestResult captures everything the caller needs to write back
-// to state after a successful apply. All five values must be persisted.
+// to state after a successful apply. All values must be persisted.
 type ApplyManifestResult struct {
-	SelfLink                         string
-	UID                              string // from the apply response
-	LiveUID                          string // from the post-wait read
-	YAMLInClusterFingerprint         string // from the apply response
-	LiveManifestInClusterFingerprint string // from the post-wait read
+	SelfLink string
+	UID      string // from the apply response
+	LiveUID  string // from the post-wait read
+	// Drift is a human-readable YAML subtree containing only the paths
+	// where the desired manifest differs from the live object, masked
+	// per ShowDriftValues / MaskPaths / Secret-kind rules. Empty string
+	// means no drift detected. Persisted into the `drift` state
+	// attribute. See kubernetes/drift.go.
+	Drift string
 }
 
 // ApplyManifest runs `kubectl apply` against the given manifest, optionally
@@ -219,11 +260,19 @@ func ApplyManifest(ctx context.Context, provider *KubeProvider, opts ApplyManife
 	response := yaml.NewFromUnstructured(rawResponse)
 
 	result := &ApplyManifestResult{
-		SelfLink:                         response.GetSelfLink(),
-		UID:                              string(response.GetUID()),
-		LiveUID:                          string(response.GetUID()),
-		YAMLInClusterFingerprint:         GetLiveManifestFields(opts.IgnoreFields, manifest, response),
-		LiveManifestInClusterFingerprint: GetLiveManifestFields(opts.IgnoreFields, manifest, response),
+		SelfLink: response.GetSelfLink(),
+		UID:      string(response.GetUID()),
+		LiveUID:  string(response.GetUID()),
+		// Immediately post-apply the live object is, by definition,
+		// what the user just sent (plus any server-side defaulting
+		// pulled in by the apply path). Drift on the post-wait
+		// re-read below may still surface non-empty content if a
+		// controller mutates the object during the wait window;
+		// applyResultToModel persists the post-wait value as
+		// authoritative. Apply path always uses the client engine
+		// here because we already have the apply response in hand;
+		// running an extra SSA dry-run would be redundant.
+		Drift: computeDriftClient(manifest, response, opts.IgnoreFields, opts.MaskPaths, opts.ShowDriftValues),
 	}
 
 	if opts.WaitForRollout {
@@ -261,15 +310,17 @@ func ApplyManifest(ctx context.Context, provider *KubeProvider, opts ApplyManife
 		}
 	}
 
-	// Re-read after waits so live_uid and live_manifest_incluster reflect
-	// any post-wait drift the controllers introduced (status fields, etc.).
-	readResult, err := readManifestUsingClient(ctx, restClient.ResourceInterface, manifest, opts.IgnoreFields) //nolint:contextcheck // ctx is the apply ctx, intentionally reused for the post-wait read
+	// Re-read after waits so live_uid and drift reflect any post-wait
+	// mutations the controllers introduced (status fields, defaulting,
+	// admission webhooks, etc.).
+	readResult, err := readManifestUsingClient(ctx, restClient.ResourceInterface, manifest, opts.IgnoreFields, opts.MaskPaths, opts.ShowDriftValues, opts.DriftEngine, opts.FieldManager, opts.ForceConflicts) //nolint:contextcheck // ctx is the apply ctx, intentionally reused for the post-wait read
 	if err != nil {
 		return nil, err
 	}
 	if readResult.Found {
 		result.LiveUID = readResult.LiveUID
-		result.LiveManifestInClusterFingerprint = readResult.LiveManifestInClusterFingerprint
+		// Post-wait drift is the authoritative view.
+		result.Drift = readResult.Drift
 	}
 
 	return result, nil
@@ -281,16 +332,31 @@ type ReadManifestOptions struct {
 	YAMLBody          string
 	OverrideNamespace string
 	IgnoreFields      []string
+	// ShowDriftValues + MaskPaths control the rendering of the Drift
+	// field in the result. Defaults (zero values) are safe: ShowNone
+	// mode and no extra masks.
+	ShowDriftValues ShowMode
+	MaskPaths       []string
+	// DriftEngine selects the detection algorithm. Empty == client.
+	DriftEngine DriftEngine
+	// FieldManager + ForceConflicts feed into the SSA dry-run patch
+	// when DriftEngine is "server". Same defaults as the apply path:
+	// FieldManager "kubectl" if empty; ForceConflicts false.
+	FieldManager   string
+	ForceConflicts bool
 }
 
 // ReadManifestResult captures the live state observed during a Read.
 // Found = false means the resource no longer exists in the cluster; the
 // caller should clear it from state.
 type ReadManifestResult struct {
-	Found                            bool
-	InvalidType                      bool // RestClientInvalidTypeError
-	LiveUID                          string
-	LiveManifestInClusterFingerprint string
+	Found       bool
+	InvalidType bool // RestClientInvalidTypeError
+	LiveUID     string
+	// Drift is a human-readable YAML subtree of paths where desired
+	// differs from live. Empty string means in sync. Same rules as
+	// ApplyManifestResult.Drift.
+	Drift string
 }
 
 // ReadManifest fetches the current state of the manifest from the cluster
@@ -313,13 +379,13 @@ func ReadManifest(ctx context.Context, provider *KubeProvider, opts ReadManifest
 		return nil, fmt.Errorf("failed to create kubernetes rest client for read of resource: %+v", restClient.Error)
 	}
 
-	return readManifestUsingClient(ctx, restClient.ResourceInterface, manifest, opts.IgnoreFields)
+	return readManifestUsingClient(ctx, restClient.ResourceInterface, manifest, opts.IgnoreFields, opts.MaskPaths, opts.ShowDriftValues, opts.DriftEngine, opts.FieldManager, opts.ForceConflicts)
 }
 
 // readManifestUsingClient is the inner Read used both by ReadManifest and
 // by ApplyManifest's post-wait re-read. Takes an already-resolved client
 // so the apply path can reuse the one it built.
-func readManifestUsingClient(ctx context.Context, client dynamic.ResourceInterface, manifest *yaml.Manifest, ignoreFields []string) (*ReadManifestResult, error) {
+func readManifestUsingClient(ctx context.Context, client dynamic.ResourceInterface, manifest *yaml.Manifest, ignoreFields, maskPaths []string, showMode ShowMode, engine DriftEngine, fieldManager string, forceConflicts bool) (*ReadManifestResult, error) {
 	rawResponse, err := client.Get(ctx, manifest.GetName(), meta_v1.GetOptions{})
 	if err != nil {
 		if errors.IsGone(err) || errors.IsNotFound(err) {
@@ -333,10 +399,102 @@ func readManifestUsingClient(ctx context.Context, client dynamic.ResourceInterfa
 
 	live := yaml.NewFromUnstructured(rawResponse)
 	return &ReadManifestResult{
-		Found:                            true,
-		LiveUID:                          string(live.GetUID()),
-		LiveManifestInClusterFingerprint: GetLiveManifestFields(ignoreFields, manifest, live),
+		Found:   true,
+		LiveUID: string(live.GetUID()),
+		Drift:   computeDrift(ctx, client, manifest, live, ignoreFields, maskPaths, showMode, engine, fieldManager, forceConflicts),
 	}, nil
+}
+
+// computeDrift routes the drift calculation to either the client- or
+// server-side engine. The server engine runs an SSA dry-run patch
+// against the apiserver and uses the response as the desired side of
+// the comparison; on any failure (RBAC, webhook rejection, CRD that
+// doesn't accept ApplyPatchType) it logs a [WARN] and falls back to the
+// client engine so Read still completes successfully.
+func computeDrift(ctx context.Context, client dynamic.ResourceInterface, desired, live *yaml.Manifest, ignoreFields, maskPaths []string, mode ShowMode, engine DriftEngine, fieldManager string, forceConflicts bool) string {
+	if engine == ServerDriftEngine {
+		serverDesired, err := serverSideApplyDryRun(ctx, client, desired, fieldManager, forceConflicts)
+		if err == nil {
+			return RenderDrift(serverDesired.Object, live.Raw.Object, DriftOptions{
+				IgnoreFields: ignoreFields,
+				MaskPaths:    maskPaths,
+				ShowMode:     mode,
+				Kind:         desired.GetKind(),
+				APIVersion:   desired.GetAPIVersion(),
+			})
+		}
+		log.Printf("[WARN] %v server-side drift engine failed, falling back to client engine: %v", desired, err)
+		// fall through to client engine
+	}
+	return computeDriftClient(desired, live, ignoreFields, maskPaths, mode)
+}
+
+// computeDriftClient is the client-side drift engine: flatten desired and
+// live, exclude ignore_fields and the built-in control fields, render
+// per-key diffs as YAML. Handles the Secret v1 stringData -> data
+// normalisation on a deep copy of the desired manifest, so the caller's
+// pointer is never mutated (issue #269 class).
+func computeDriftClient(desired, live *yaml.Manifest, ignoreFields, maskPaths []string, mode ShowMode) string {
+	if desired == nil || desired.Raw == nil || live == nil || live.Raw == nil {
+		return ""
+	}
+	desiredObj := desired.Raw.Object
+	if desired.GetKind() == "Secret" && desired.GetAPIVersion() == "v1" {
+		if stringData, found := desiredObj["stringData"]; found {
+			if sdMap, ok := stringData.(map[string]interface{}); ok {
+				desiredObj = desired.Raw.DeepCopy().Object
+				for k, v := range sdMap {
+					encoded := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%v", v)))
+					if err := meta_v1_unstruct.SetNestedField(desiredObj, encoded, "data", k); err != nil {
+						log.Printf("[WARN] computeDriftClient: failed to encode Secret stringData.%s: %v", k, err)
+						continue
+					}
+				}
+				meta_v1_unstruct.RemoveNestedField(desiredObj, "stringData")
+			}
+		}
+	}
+	return RenderDrift(desiredObj, live.Raw.Object, DriftOptions{
+		IgnoreFields: ignoreFields,
+		MaskPaths:    maskPaths,
+		ShowMode:     mode,
+		Kind:         desired.GetKind(),
+		APIVersion:   desired.GetAPIVersion(),
+	})
+}
+
+// serverSideApplyDryRun issues an SSA dry-run patch against the
+// apiserver and returns the response (the apiserver's view of what the
+// post-apply object would look like). The fieldManager and forceConflicts
+// values must match the values used by the real apply path so the
+// dry-run computes the same patch the apply would produce; without that
+// alignment the dry-run is from a different field manager's perspective
+// and the drift signal is inaccurate.
+//
+// Defaults: empty fieldManager becomes "kubectl" to match the apply path.
+func serverSideApplyDryRun(ctx context.Context, client dynamic.ResourceInterface, desired *yaml.Manifest, fieldManager string, forceConflicts bool) (*meta_v1_unstruct.Unstructured, error) {
+	if desired == nil || desired.Raw == nil {
+		return nil, fmt.Errorf("nil manifest")
+	}
+	if fieldManager == "" {
+		fieldManager = "kubectl"
+	}
+	body, err := desired.Raw.MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("marshal manifest for dry-run: %w", err)
+	}
+	patchOpts := meta_v1.PatchOptions{
+		FieldManager: fieldManager,
+		DryRun:       []string{meta_v1.DryRunAll},
+	}
+	if forceConflicts {
+		// Force ownership transfer in dry-run mirrors what the apply
+		// path would do; without this the dry-run can fail with
+		// conflicts that a real apply would have resolved.
+		f := true
+		patchOpts.Force = &f
+	}
+	return client.Patch(ctx, desired.GetName(), apimachinery_types.ApplyPatchType, body, patchOpts)
 }
 
 // BuildObfuscatedYAML returns the manifest with any field listed in

--- a/kubernetes/manifest_lifecycle.go
+++ b/kubernetes/manifest_lifecycle.go
@@ -12,7 +12,7 @@ import (
 	"github.com/alekc/terraform-provider-kubectl/internal/types"
 	"github.com/alekc/terraform-provider-kubectl/yaml"
 	backoff "github.com/cenkalti/backoff/v4"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	meta_v1_unstruct "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apimachinery_types "k8s.io/apimachinery/pkg/types"
@@ -388,7 +388,7 @@ func ReadManifest(ctx context.Context, provider *KubeProvider, opts ReadManifest
 func readManifestUsingClient(ctx context.Context, client dynamic.ResourceInterface, manifest *yaml.Manifest, ignoreFields, maskPaths []string, showMode ShowMode, engine DriftEngine, fieldManager string, forceConflicts bool) (*ReadManifestResult, error) {
 	rawResponse, err := client.Get(ctx, manifest.GetName(), meta_v1.GetOptions{})
 	if err != nil {
-		if errors.IsGone(err) || errors.IsNotFound(err) {
+		if k8serrors.IsGone(err) || k8serrors.IsNotFound(err) {
 			return &ReadManifestResult{Found: false}, nil
 		}
 		return nil, fmt.Errorf("%v failed to get resource from kubernetes: %+v", manifest, err)
@@ -423,10 +423,44 @@ func computeDrift(ctx context.Context, client dynamic.ResourceInterface, desired
 				APIVersion:   desired.GetAPIVersion(),
 			})
 		}
-		log.Printf("[WARN] %v server-side drift engine failed, falling back to client engine: %v", desired, err)
+		// Log the failure mode without echoing the raw error: a
+		// rejected dry-run apply (admission webhook, validating
+		// schema) can include the manifest body or other field
+		// values in its message, which would defeat the drift
+		// renderer's secret masking. The user can rerun with
+		// TF_LOG=trace to get the full error from k8s client logs.
+		log.Printf("[WARN] %v/%v server-side drift engine failed (%s), falling back to client engine", desired.GetAPIVersion(), desired.GetKind(), classifySSAError(err))
 		// fall through to client engine
 	}
 	return computeDriftClient(desired, live, ignoreFields, maskPaths, mode)
+}
+
+// classifySSAError maps an SSA dry-run failure to a short, non-sensitive
+// label suitable for [WARN] logs. The raw error from the apiserver may
+// embed the offending manifest content (validation messages quote
+// rejected values verbatim, webhook denials sometimes echo payload
+// fragments), so the renderer's mask_paths / Secret protections would
+// be defeated by logging it. Categories are coarse on purpose: enough
+// for an operator to know whether to grant PATCH RBAC, audit webhooks,
+// or check the CRD's SSA schema support; the full error is still
+// available via the standard k8s client TRACE-log path.
+func classifySSAError(err error) string {
+	if err == nil {
+		return "no-error"
+	}
+	if k8serrors.IsForbidden(err) || k8serrors.IsUnauthorized(err) {
+		return "rbac-denied"
+	}
+	if k8serrors.IsBadRequest(err) || k8serrors.IsInvalid(err) {
+		return "invalid-or-unsupported"
+	}
+	if k8serrors.IsNotFound(err) || k8serrors.IsMethodNotSupported(err) {
+		return "patch-unsupported"
+	}
+	if k8serrors.IsTimeout(err) || k8serrors.IsServerTimeout(err) || k8serrors.IsServiceUnavailable(err) {
+		return "transient"
+	}
+	return "apiserver-error"
 }
 
 // computeDriftClient is the client-side drift engine: flatten desired and
@@ -645,7 +679,7 @@ func DeleteManifest(ctx context.Context, provider *KubeProvider, opts DeleteMani
 	}
 
 	err = restClient.ResourceInterface.Delete(ctx, manifest.GetName(), meta_v1.DeleteOptions{PropagationPolicy: &propagationPolicy})
-	resourceGone := errors.IsGone(err) || errors.IsNotFound(err)
+	resourceGone := k8serrors.IsGone(err) || k8serrors.IsNotFound(err)
 	if err != nil && !resourceGone {
 		return fmt.Errorf("%v failed to delete kubernetes resource: %+v", manifest, err)
 	}

--- a/kubernetes/manifest_lifecycle_drift_test.go
+++ b/kubernetes/manifest_lifecycle_drift_test.go
@@ -1,0 +1,134 @@
+package kubernetes
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alekc/terraform-provider-kubectl/yaml"
+	meta_v1_unstruct "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// TestComputeDriftYAML_InSync exercises the lifecycle wrapper that
+// RenderDrift sits behind. Confirms an identical desired/live pair
+// (post Secret-stringData normalisation) returns the empty string.
+func TestComputeDriftYAML_InSync(t *testing.T) {
+	desired := mustManifest(t, map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name": "x",
+		},
+		"data": map[string]interface{}{
+			"key": "value",
+		},
+	})
+	live := mustManifest(t, map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":            "x",
+			"resourceVersion": "1234", // server-added; not user input
+		},
+		"data": map[string]interface{}{
+			"key": "value",
+		},
+	})
+	got := computeDriftClient(desired, live, nil, nil, ShowNone)
+	if got != "" {
+		t.Fatalf("expected in-sync, got %q", got)
+	}
+}
+
+// TestComputeDriftYAML_SecretStringDataNormalisation ensures that a
+// Secret with stringData in desired and base64 data in live (the normal
+// shape post-apply) is recognised as in-sync.
+func TestComputeDriftYAML_SecretStringDataNormalisation(t *testing.T) {
+	desired := mustManifest(t, map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata":   map[string]interface{}{"name": "creds"},
+		"stringData": map[string]interface{}{
+			"password": "hunter2",
+		},
+	})
+	// "hunter2" base64 == "aHVudGVyMg=="
+	live := mustManifest(t, map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata":   map[string]interface{}{"name": "creds"},
+		"data": map[string]interface{}{
+			"password": "aHVudGVyMg==",
+		},
+	})
+	got := computeDriftClient(desired, live, nil, nil, ShowNone)
+	if got != "" {
+		t.Fatalf("Secret stringData -> data must normalise; got drift %q", got)
+	}
+}
+
+// TestComputeDriftYAML_SecretAutoMasks confirms that even when the
+// caller asks for ShowFull, a Secret's data leaves never leak.
+func TestComputeDriftYAML_SecretAutoMasks(t *testing.T) {
+	desired := mustManifest(t, map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata":   map[string]interface{}{"name": "creds"},
+		"data": map[string]interface{}{
+			"password": "aGVsbG8=",
+		},
+	})
+	live := mustManifest(t, map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata":   map[string]interface{}{"name": "creds"},
+		"data": map[string]interface{}{
+			"password": "Z29vZGJ5ZQ==",
+		},
+	})
+	got := computeDriftClient(desired, live, nil, nil, ShowFull)
+	if !strings.Contains(got, "<drift sensitive>") {
+		t.Fatalf("expected sensitive marker for Secret data, got %q", got)
+	}
+	if strings.Contains(got, "aGVsbG8=") || strings.Contains(got, "Z29vZGJ5ZQ==") {
+		t.Fatalf("Secret data leaked into drift: %q", got)
+	}
+}
+
+// TestComputeDriftYAML_DoesNotMutateDesired guards against a regression
+// of the #269 class of bugs: GetLiveManifestFields used to mutate the
+// caller's manifest while applying the stringData normalisation.
+// computeDriftClient must always work on a deep copy.
+func TestComputeDriftYAML_DoesNotMutateDesired(t *testing.T) {
+	original := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata":   map[string]interface{}{"name": "creds"},
+		"stringData": map[string]interface{}{
+			"password": "hunter2",
+		},
+	}
+	desired := mustManifest(t, original)
+	live := mustManifest(t, map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata":   map[string]interface{}{"name": "creds"},
+		"data": map[string]interface{}{
+			"password": "aHVudGVyMg==",
+		},
+	})
+	_ = computeDriftClient(desired, live, nil, nil, ShowNone)
+	if _, hasStringData := desired.Raw.Object["stringData"]; !hasStringData {
+		t.Fatalf("computeDriftClient stripped stringData from caller's manifest")
+	}
+	if _, hasData := desired.Raw.Object["data"]; hasData {
+		t.Fatalf("computeDriftClient added data to caller's manifest")
+	}
+}
+
+// mustManifest converts a literal map into a *yaml.Manifest for testing.
+// Skips through the yaml round-trip the production code goes through.
+func mustManifest(t *testing.T, obj map[string]interface{}) *yaml.Manifest {
+	t.Helper()
+	u := &meta_v1_unstruct.Unstructured{Object: obj}
+	return yaml.NewFromUnstructured(u)
+}

--- a/kubernetes/manifest_lifecycle_ssa_drift_test.go
+++ b/kubernetes/manifest_lifecycle_ssa_drift_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 
 	"github.com/alekc/terraform-provider-kubectl/yaml"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	meta_v1_unstruct "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	apimachinery_types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 )
@@ -171,5 +173,134 @@ func TestComputeDrift_ServerEngine_ForceConflictsPropagates(t *testing.T) {
 	}
 	if stub.gotOptions.FieldManager != "alekc-tool" {
 		t.Errorf("FieldManager passthrough: got %q want %q", stub.gotOptions.FieldManager, "alekc-tool")
+	}
+}
+
+// TestComputeDrift_ServerEngine_ForceConflictsFalseLeavesForceNil
+// confirms the inverse: when the caller does not request force,
+// PatchOptions.Force stays nil. The k8s client surfaces nil-vs-false
+// to the apiserver semantically (Force is *bool); leaking a false
+// pointer would change the apiserver's behaviour from "default" to
+// "explicitly request no force".
+func TestComputeDrift_ServerEngine_ForceConflictsFalseLeavesForceNil(t *testing.T) {
+	t.Parallel()
+	desired := newManifest(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]interface{}{"name": "x"},
+	})
+	live := newManifest(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]interface{}{"name": "x"},
+	})
+	stub := &stubResource{
+		resp: &meta_v1_unstruct.Unstructured{Object: desired.Raw.Object},
+	}
+	_ = computeDrift(context.Background(), stub, desired, live, nil, nil, ShowNone, ServerDriftEngine, "kubectl", false)
+	if stub.gotOptions.Force != nil {
+		t.Errorf("ForceConflicts=false should leave PatchOptions.Force nil; got %v", *stub.gotOptions.Force)
+	}
+}
+
+// TestComputeDrift_ServerEngine_EmptyFieldManagerDefaultsToKubectl
+// confirms the documented default. The apply path uses "kubectl"
+// when field_manager is unset; the dry-run must agree so the patch
+// is computed from the same field-ownership perspective.
+func TestComputeDrift_ServerEngine_EmptyFieldManagerDefaultsToKubectl(t *testing.T) {
+	t.Parallel()
+	desired := newManifest(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]interface{}{"name": "x"},
+	})
+	live := newManifest(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]interface{}{"name": "x"},
+	})
+	stub := &stubResource{
+		resp: &meta_v1_unstruct.Unstructured{Object: desired.Raw.Object},
+	}
+	_ = computeDrift(context.Background(), stub, desired, live, nil, nil, ShowNone, ServerDriftEngine, "", false)
+	if stub.gotOptions.FieldManager != "kubectl" {
+		t.Errorf("empty FieldManager should default to %q; got %q", "kubectl", stub.gotOptions.FieldManager)
+	}
+}
+
+// TestClassifySSAError covers every category the WARN log surfaces.
+// The function is the security barrier between the apiserver's
+// possibly-payload-echoing error string and the log line, so each
+// branch must return a stable, non-sensitive label. Using
+// k8serrors helpers to construct the inputs guarantees the test
+// tracks the same predicates the production code uses.
+func TestClassifySSAError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil", nil, "no-error"},
+		{
+			"forbidden",
+			k8serrors.NewForbidden(schema.GroupResource{Resource: "x"}, "n", errors.New("denied")),
+			"rbac-denied",
+		},
+		{
+			"unauthorized",
+			k8serrors.NewUnauthorized("auth failed"),
+			"rbac-denied",
+		},
+		{
+			"bad-request",
+			k8serrors.NewBadRequest("bad"),
+			"invalid-or-unsupported",
+		},
+		{
+			"invalid",
+			k8serrors.NewInvalid(schema.GroupKind{Kind: "X"}, "n", nil),
+			"invalid-or-unsupported",
+		},
+		{
+			"not-found",
+			k8serrors.NewNotFound(schema.GroupResource{Resource: "x"}, "n"),
+			"patch-unsupported",
+		},
+		{
+			"method-not-supported",
+			k8serrors.NewMethodNotSupported(schema.GroupResource{Resource: "x"}, "patch"),
+			"patch-unsupported",
+		},
+		{
+			"timeout",
+			k8serrors.NewTimeoutError("slow", 1),
+			"transient",
+		},
+		{
+			"server-timeout",
+			k8serrors.NewServerTimeout(schema.GroupResource{Resource: "x"}, "patch", 1),
+			"transient",
+		},
+		{
+			"service-unavailable",
+			k8serrors.NewServiceUnavailable("down"),
+			"transient",
+		},
+		{
+			"generic",
+			errors.New("connection refused: peer reset"),
+			"apiserver-error",
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifySSAError(c.err)
+			if got != c.want {
+				t.Errorf("classifySSAError(%v): got %q want %q", c.err, got, c.want)
+			}
+		})
 	}
 }

--- a/kubernetes/manifest_lifecycle_ssa_drift_test.go
+++ b/kubernetes/manifest_lifecycle_ssa_drift_test.go
@@ -1,0 +1,175 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/alekc/terraform-provider-kubectl/yaml"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	meta_v1_unstruct "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apimachinery_types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+)
+
+// computeDrift integration with the server-side engine is exercised via
+// a stub dynamic.ResourceInterface so tests stay deterministic / Go-only.
+// The acceptance suite covers the real apiserver path under TF_ACC=1.
+
+type stubResource struct {
+	dynamic.ResourceInterface
+	patchCalled  bool
+	gotPatchType apimachinery_types.PatchType
+	gotOptions   meta_v1.PatchOptions
+	resp         *meta_v1_unstruct.Unstructured
+	respErr      error
+}
+
+func (s *stubResource) Patch(_ context.Context, _ string, pt apimachinery_types.PatchType, _ []byte, opts meta_v1.PatchOptions, _ ...string) (*meta_v1_unstruct.Unstructured, error) {
+	s.patchCalled = true
+	s.gotPatchType = pt
+	s.gotOptions = opts
+	return s.resp, s.respErr
+}
+
+func newManifest(obj map[string]interface{}) *yaml.Manifest {
+	return yaml.NewFromUnstructured(&meta_v1_unstruct.Unstructured{Object: obj})
+}
+
+// TestComputeDrift_ServerEngine_UsesPatchResponse asserts that the
+// server engine calls Patch with ApplyPatchType + DryRunAll and feeds
+// the response into the renderer.
+func TestComputeDrift_ServerEngine_UsesPatchResponse(t *testing.T) {
+	t.Parallel()
+	desired := newManifest(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]interface{}{"name": "x"},
+		"data":       map[string]interface{}{"key": "DESIRED"},
+	})
+	live := newManifest(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]interface{}{"name": "x"},
+		"data":       map[string]interface{}{"key": "LIVE"},
+	})
+	// Apiserver's view of post-apply: would change `data.key` to DESIRED.
+	stub := &stubResource{
+		resp: &meta_v1_unstruct.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]interface{}{"name": "x"},
+			"data":       map[string]interface{}{"key": "DESIRED"},
+		}},
+	}
+	got := computeDrift(context.Background(), stub, desired, live, nil, nil, ShowFull, ServerDriftEngine, "kubectl", false)
+
+	if !stub.patchCalled {
+		t.Fatalf("server engine did not call Patch")
+	}
+	if stub.gotPatchType != apimachinery_types.ApplyPatchType {
+		t.Errorf("expected ApplyPatchType, got %v", stub.gotPatchType)
+	}
+	if len(stub.gotOptions.DryRun) != 1 || stub.gotOptions.DryRun[0] != meta_v1.DryRunAll {
+		t.Errorf("expected DryRun=[All], got %v", stub.gotOptions.DryRun)
+	}
+	if stub.gotOptions.FieldManager != "kubectl" {
+		t.Errorf("expected FieldManager=kubectl, got %q", stub.gotOptions.FieldManager)
+	}
+	if !strings.Contains(got, "data:") || !strings.Contains(got, "key:") {
+		t.Errorf("expected drift to include the changing path, got %q", got)
+	}
+}
+
+// TestComputeDrift_ServerEngine_FallsBackOnPatchError asserts that a
+// Patch error (CRD without PATCH, webhook rejection, RBAC denied, etc.)
+// falls back to the client engine and produces the same drift signal
+// without surfacing the error to the caller.
+func TestComputeDrift_ServerEngine_FallsBackOnPatchError(t *testing.T) {
+	t.Parallel()
+	desired := newManifest(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]interface{}{"name": "x"},
+		"data":       map[string]interface{}{"key": "DESIRED"},
+	})
+	live := newManifest(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]interface{}{"name": "x"},
+		"data":       map[string]interface{}{"key": "LIVE"},
+	})
+	stub := &stubResource{
+		respErr: errors.New("RBAC: PATCH not permitted"),
+	}
+	got := computeDrift(context.Background(), stub, desired, live, nil, nil, ShowNone, ServerDriftEngine, "kubectl", false)
+
+	if !stub.patchCalled {
+		t.Fatalf("server engine should have attempted Patch before falling back")
+	}
+	if got == "" {
+		t.Errorf("fallback to client engine should still produce drift, got empty")
+	}
+	if !strings.Contains(got, "key:") {
+		t.Errorf("client-engine drift missing changing path: %q", got)
+	}
+}
+
+// TestComputeDrift_ClientEngine_DoesNotCallPatch asserts that the
+// default client engine never reaches the apiserver — no API call cost
+// on Read for existing users who don't opt in.
+func TestComputeDrift_ClientEngine_DoesNotCallPatch(t *testing.T) {
+	t.Parallel()
+	desired := newManifest(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]interface{}{"name": "x"},
+		"data":       map[string]interface{}{"key": "DESIRED"},
+	})
+	live := newManifest(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]interface{}{"name": "x"},
+		"data":       map[string]interface{}{"key": "LIVE"},
+	})
+	stub := &stubResource{}
+	_ = computeDrift(context.Background(), stub, desired, live, nil, nil, ShowNone, ClientDriftEngine, "kubectl", false)
+	if stub.patchCalled {
+		t.Errorf("client engine must not call Patch")
+	}
+	// Also: empty engine (zero value) defaults to client semantics.
+	stub2 := &stubResource{}
+	_ = computeDrift(context.Background(), stub2, desired, live, nil, nil, ShowNone, "", "kubectl", false)
+	if stub2.patchCalled {
+		t.Errorf("empty DriftEngine must default to client (no Patch call)")
+	}
+}
+
+// TestComputeDrift_ServerEngine_ForceConflictsPropagates asserts that
+// the ForceConflicts flag passes through to PatchOptions.Force. The
+// real apply path uses the same flag, so the dry-run must agree to
+// produce an accurate "what would apply do" diff.
+func TestComputeDrift_ServerEngine_ForceConflictsPropagates(t *testing.T) {
+	t.Parallel()
+	desired := newManifest(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]interface{}{"name": "x"},
+	})
+	live := newManifest(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]interface{}{"name": "x"},
+	})
+	stub := &stubResource{
+		resp: &meta_v1_unstruct.Unstructured{Object: desired.Raw.Object},
+	}
+	_ = computeDrift(context.Background(), stub, desired, live, nil, nil, ShowNone, ServerDriftEngine, "alekc-tool", true)
+	if stub.gotOptions.Force == nil || !*stub.gotOptions.Force {
+		t.Errorf("ForceConflicts=true should propagate to PatchOptions.Force")
+	}
+	if stub.gotOptions.FieldManager != "alekc-tool" {
+		t.Errorf("FieldManager passthrough: got %q want %q", stub.gotOptions.FieldManager, "alekc-tool")
+	}
+}

--- a/templates/index.md
+++ b/templates/index.md
@@ -60,8 +60,7 @@ YAML
 * `namespace` - Extracted object namespace from `yaml_body`.
 * `uid` - Kubernetes unique identifier from last run.
 * `live_uid` - Current uuid from kubernetes.
-* `yaml_incluster` - Current yaml within kubernetes.
-* `live_manifest_incluster` - Current manifest within kubernetes.
+* `drift` - Human-readable YAML subtree of paths where the desired manifest differs from the live object. Empty string when in sync. Replaces v2's opaque `yaml_incluster` / `live_manifest_incluster` fingerprints. See [the resource docs](./docs/resources/kubectl_manifest.md#drift-visualisation) for the rendering modes and `drift_engine` selection.
 
 ## Sensitive Fields
 


### PR DESCRIPTION
Closes #54.

## Summary

Replaces the two opaque sha256 fingerprint attributes (`yaml_incluster`, `live_manifest_incluster`) with a single non-sensitive `drift` string attribute that renders the drifting paths as a YAML subtree. Three leaf-rendering modes; client and server detection engines.

## What changes for users

### Schema

Removed:

- `yaml_incluster` (was: opaque sha256, marked Sensitive)
- `live_manifest_incluster` (was: opaque sha256, marked Sensitive)

Added:

- `drift` (computed string, non-sensitive). YAML subtree of paths where the desired manifest differs from the live object. Empty string when in sync.
- `show_drift_values` (optional string, default `"none"`). One of `none` / `hash` / `full`. Controls leaf rendering. Secret `data` / `stringData` and `mask_paths` globs always mask regardless of mode.
- `mask_paths` (optional list of strings). Glob paths whose leaves are masked in `drift`. Supports `*` (one segment) and `**` (zero or more segments).
- `drift_engine` (optional string, default `"client"`). One of `client` / `server`. See below.

### Plan output

Before:

```
~ yaml_incluster = (sensitive value) -> (sensitive value)
~ live_manifest_incluster = (sensitive value) -> (sensitive value)
```

After (with default `show_drift_values = "none"`):

```
~ drift = "" -> <<-EOT
    metadata:
      annotations:
        foo: <drift>
    spec:
      replicas: <drift>
  EOT
```

`show_drift_values = "full"` renders `<was: V1, now: V2>` for non-sensitive leaves, parity with `kubectl diff` content. `hash` renders short-hash markers so you can confirm a value changed without revealing it.

### Detection engine

Two implementations behind `drift_engine`, both feeding the same renderer:

- `client` (default) is the v2 algorithm: flatten manifest and live into dotted paths, compare per-key. No extra API calls. Existing `ignore_fields` lists carry over unchanged.
- `server` (opt-in) issues an SSA dry-run patch against the apiserver using the resource's `field_manager` and `force_conflicts`, then compares the apiserver's response (the post-apply view) to current live. Same semantics `kubectl diff` uses: strategic merge on arrays, server-side defaulting absorbed, type coercion handled, mutating-webhook edits visible. One extra API call per Read. Falls back to `client` with a `[WARN]` log on patch failure (CRDs without `ApplyPatchType` support, RBAC denied, webhook rejection).

`server` default may land in a later v3.x once community feedback on dry-run webhook safety is in. See the docs for the audit checklist.

## Breaking changes

- `yaml_incluster` and `live_manifest_incluster` removed from the schema.
- State migrates automatically via the resource state upgrader. Existing v2 state is decoded, the two fingerprint values are dropped, and `drift` is computed fresh on the next Read against the live cluster. No manual `terraform state` surgery.
- HCL referencing the legacy attributes errors at plan time with a clear missing-attribute message. Migration is `drift != ""` instead of `yaml_incluster != live_manifest_incluster`.

The break bundles with the v3 SDK-v2-to-framework cutover so v2.4.x users see one migration step instead of two.

## Test plan

- [x] `go test ./...` clean (cached + uncached runs)
- [x] `go vet ./...` clean
- [x] 19 renderer unit tests covering all three modes, Secret auto-masking, glob `mask_paths` (including `**`), array index markers, length mismatch, type mismatch, deterministic ordering, in-sync sentinel
- [x] 4 SSA-engine unit tests with stub dynamic client covering the patch call shape (`ApplyPatchType` + `DryRunAll`), the fallback path on patch error, force-conflicts propagation, and the no-op default on client engine
- [x] Framework SchemaShape test asserts the 26 attributes and Version 2
- [x] Move-from-gavinbunney test asserts legacy fingerprints discarded and v3 drift defaults populated
- [x] Update test asserts prior `drift` value preserved on apply error
- [x] Import acc test updated `ImportStateVerifyIgnore` (drift diverges at the verify step for the same userProvided-divergence reason as the v2 fingerprints did)
- [ ] Acceptance test gated by `TF_ACC=1` that runs the server engine against a real cluster, asserts the dry-run patch fires, confirms drift surfaces only when apply would change something. Follow-up.

## Out of scope

- True unified-diff (`kubectl diff` hunk format) as a fourth render mode. Current output is a YAML subtree with inline `<was: X, now: Y>` markers; kubectl-diff is unified diff. The detection engine is equivalent under `drift_engine = "server"`; only the output shape differs. Easy follow-up if there's demand.
- Switching the default `drift_engine` to `server`. Held until community feedback on webhook dry-run reliability is in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Human-readable drift output and new options: show_drift_values, mask_paths, drift_engine.

* **Improvements**
  * Rich drift visualization (none/hash/full), secret masking, deterministic rendering, client/server engine with fallback, and persisted drift in apply/read flows.

* **Documentation**
  * Expanded docs with drift visualization, migration notes, argument/attribute references.

* **Tests**
  * Added comprehensive unit and integration tests covering drift behavior and state upgrade.

* **Breaking Changes**
  * Removed yaml_incluster and live_manifest_incluster; schema bumped and state migrated on next Read.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->