### PR TITLE
fix(fields): support bracket-quoted segments for dotted map keys

### DIFF
--- a/docs/data-sources/kubectl_manifest.md
+++ b/docs/data-sources/kubectl_manifest.md
@@ -117,8 +117,9 @@ data "kubectl_manifest" "tls" {
   namespace   = "default"
 
   fields = {
-    crt = "data.tls\\.crt"
-    key = "data.tls\\.key"
+    # Bracket form for the dotted keys `tls.crt` and `tls.key`.
+    crt = "data[\"tls.crt\"]"
+    key = "data[\"tls.key\"]"
   }
 }
 

--- a/docs/data-sources/kubectl_manifest.md
+++ b/docs/data-sources/kubectl_manifest.md
@@ -4,7 +4,7 @@ Reads a single Kubernetes object from the cluster by `api_version` + `kind` + `n
 
 The fetched object is exposed as both raw YAML and raw JSON. A `fields` map can declare named extractions that are returned in `results`.
 
-> **Tip:** the `fields` map is **optional**. Use it for cheap scalar extractions on simple gojsonq dot-paths; reach for `yamldecode(data.kubectl_manifest.x.yaml)` (or `jsondecode(data.kubectl_manifest.x.json)`, identical in shape) when you need arrays, nested maps, or keys containing dots, which gojsonq's dot-path syntax cannot address (see [#271](https://github.com/alekc/terraform-provider-kubectl/issues/271)).
+> **Tip:** the `fields` map is **optional**. Use it for cheap scalar extractions on a single value; reach for `yamldecode(data.kubectl_manifest.x.yaml)` (or `jsondecode(data.kubectl_manifest.x.json)`, identical in shape) when you want to traverse the object structurally (arrays of objects, `for` expressions, nested maps you keep referencing). `fields` paths support dotted keys via a bracket form (`metadata.labels["app.kubernetes.io/name"]`); see [Argument Reference](#argument-reference) for the full path grammar.
 
 For reads of sensitive data that must **never** be written to Terraform state, use the [`kubectl_manifest` ephemeral resource](../ephemeral-resources/kubectl_manifest.md) instead.
 
@@ -31,8 +31,8 @@ locals {
   dns_owner      = local.kube_dns.metadata.labels["app.kubernetes.io/name"]
 
   # Iterate the array. Terraform's `for` expression composes
-  # naturally with the decoded object; gojsonq `fields` paths
-  # cannot express this.
+  # naturally with the decoded object; `fields` paths address
+  # a single value per entry, not a list of derived values.
   dns_port_names = [for p in local.kube_dns.spec.ports : p.name]
 }
 ```
@@ -47,7 +47,8 @@ data "kubectl_manifest" "ca" {
   namespace   = "kube-system"
 
   fields = {
-    ca = "data.ca\\.crt"
+    # Bracket form for the dotted key `ca.crt`.
+    ca = "data[\"ca.crt\"]"
   }
 }
 
@@ -74,9 +75,13 @@ data "kubectl_manifest" "ns" {
 
 ### Read a CRD object and walk a nested array
 
-`fields` paths use [gojsonq](https://github.com/thedevsaddam/gojsonq)
-dot-notation. Array elements are addressed with the `[N]` form
-(`containers.[0]`, not `containers.0`).
+`fields` paths use a simple dot-and-bracket grammar:
+
+- `metadata.name`: plain dot-separated map keys.
+- `spec.containers[0].image` or `spec.containers.[0].image`: array index by bracketed or dotted integer; both forms work, dot-only `spec.containers.0.image` works too.
+- `metadata.labels["app.kubernetes.io/name"]`: quoted bracketed segment when the key itself contains dots, slashes, or any other character that a bare segment can't carry. Either `"..."` or `'...'` quotes are accepted; the content is taken as a literal map key.
+
+A path that does not resolve fails the read with an error naming the offending key.
 
 ```hcl
 data "kubectl_manifest" "dep" {
@@ -87,8 +92,10 @@ data "kubectl_manifest" "dep" {
 
   fields = {
     replicas        = "spec.replicas"
-    first_image     = "spec.template.spec.containers.[0].image"
+    first_image     = "spec.template.spec.containers[0].image"
     labels          = "metadata.labels"
+    # Domain-prefixed label keys need the bracketed form.
+    app_name        = "metadata.labels[\"app.kubernetes.io/name\"]"
   }
 }
 
@@ -141,7 +148,12 @@ The value is still written to `terraform.tfstate` in cleartext. If state-persist
 * `kind` - **(Required)** The Kind of the resource (e.g. `ConfigMap`, `Deployment`).
 * `name` - **(Required)** The `metadata.name` of the resource.
 * `namespace` - **(Optional)** The `metadata.namespace` of the resource. Leave empty for cluster-scoped kinds. For namespaced kinds, an empty value defaults to `default`. A namespace supplied for a cluster-scoped kind is silently ignored.
-* `fields` - **(Optional)** Map of named extractions to perform on the fetched object. Each value is a gojsonq dot-path expression. Each path must resolve; missing paths produce an error.
+* `fields` - **(Optional)** Map of named extractions to perform on the fetched object. Each value is a dot-and-bracket path expression:
+    * `metadata.name`: dot-separated map keys.
+    * `spec.containers[0].image` (or `spec.containers.[0].image`, or `spec.containers.0.image`): array index.
+    * `metadata.labels["app.kubernetes.io/name"]` (or single-quoted `'...'`): quoted bracketed segment for map keys that themselves contain dots, slashes, or any other character a bare segment can't carry.
+
+    Each path must resolve; missing paths produce an error naming the offending key. Scalar values are returned as their natural string form; objects and arrays are JSON-encoded so callers can `jsondecode()` to recover structure.
 
 ## Attribute Reference
 

--- a/docs/ephemeral-resources/kubectl_manifest.md
+++ b/docs/ephemeral-resources/kubectl_manifest.md
@@ -60,7 +60,7 @@ Same as the [data source](../data-sources/kubectl_manifest.md):
 * `kind` - **(Required)**
 * `name` - **(Required)**
 * `namespace` - **(Optional)** — leave empty for cluster-scoped kinds.
-* `fields` - **(Optional)** map of named extractions; gojsonq dot-paths.
+* `fields` - **(Optional)** map of named extractions. Same dot-and-bracket path grammar as the data source's `fields` (plain dotted keys, `[N]` for array indices, `["key.with.dots"]` for map keys whose name contains dots or other reserved characters). See the data source's [Argument Reference](../data-sources/kubectl_manifest.md#argument-reference) for the full grammar.
 
 ## Attribute Reference
 
@@ -74,4 +74,4 @@ Same as the [data source](../data-sources/kubectl_manifest.md):
 * **Ephemeral values cannot be exported via `output`.** Terraform forbids this — the value can only flow through write-only resource attributes, provisioners, and check blocks during apply.
 * **Re-fetched every run.** The resource opens on each plan/apply that references it. Live cluster state changes are picked up automatically (and may produce different downstream behaviour run-to-run).
 * **No state, no plan file.** The value never appears in `terraform.tfstate` or in `terraform plan -out` plan files. This is the protection ephemeral resources provide; if you need state-persistent reads, use the data source instead.
-* Errors (object not found, gojsonq path not resolving) abort the open and propagate as Terraform diagnostics, same as for the data source.
+* Errors (object not found, `fields` path not resolving, malformed path syntax) abort the open and propagate as Terraform diagnostics, same as for the data source.

--- a/docs/resources/kubectl_manifest.md
+++ b/docs/resources/kubectl_manifest.md
@@ -101,7 +101,7 @@ YAML
 * `validate_schema` - Optional. Setting to `false` will mimic `kubectl apply --validate=false` mode. Default `true`.
 * `wait` - Optional. When `true`, wait for finalizers to complete on deleted objects before returning. Default `false`.
 * `wait_for_rollout` - Optional. Set this flag to wait or not for `Deployment`, `DaemonSet`, `StatefulSet` & `APIService`  resources to complete rollout. Default `true`.
-* `wait_for` - Optional. If set, will wait until either all conditions are satisfied, or until timeout is reached (see [below for nested schema](#wait_for)). Under the hood [gojsonq](https://github.com/thedevsaddam/gojsonq) is used for querying, see the related syntax and examples.
+* `wait_for` - Optional. If set, will wait until either all conditions are satisfied, or until timeout is reached (see [below for nested schema](#wait_for)). `wait_for.field.key` uses the same dot-and-bracket path grammar as the data source's `fields` (plain dotted keys, `[N]` for array indices, `["key.with.dots"]` for keys whose name contains dots, slashes, or other reserved characters); see the [`kubectl_manifest` data source `fields` reference](../data-sources/kubectl_manifest.md#argument-reference) for the full grammar.
 * `delete_cascade` - Optional; `Background` or `Foreground` are valid options. If set this overrides the default provider behaviour which is to use `Background` unless `wait` is `true` when `Foreground` will be used. To duplicate the default behaviour of `kubectl` this should be explicitly set to `Background`.
 
 ### `wait_for`

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/icza/dyno v0.0.0-20200205103839-49cb13720835
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/stretchr/testify v1.11.1
-	github.com/thedevsaddam/gojsonq/v2 v2.5.2
 	github.com/zclconf/go-cty v1.18.1
 	github.com/zclconf/go-cty-yaml v1.2.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -486,8 +486,6 @@ github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BST
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
 github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20190808065407-f07404cefc8c/go.mod h1:wk2XFUg6egk4tSDNZtXeKfe2G6690UVyt163PuUxBZk=
 github.com/terraform-providers/terraform-provider-openstack v1.15.0/go.mod h1:2aQ6n/BtChAl1y2S60vebhyJyZXBsuAI5G4+lHrT1Ew=
-github.com/thedevsaddam/gojsonq/v2 v2.5.2 h1:CoMVaYyKFsVj6TjU6APqAhAvC07hTI6IQen8PHzHYY0=
-github.com/thedevsaddam/gojsonq/v2 v2.5.2/go.mod h1:bv6Xa7kWy82uT0LnXPE2SzGqTj33TAEeR560MdJkiXs=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v0.0.0-20180813092308-00b869d2f4a5/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=

--- a/internal/framework/data_source_kubectl_manifest.go
+++ b/internal/framework/data_source_kubectl_manifest.go
@@ -91,10 +91,12 @@ func (d *manifestDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 			"fields": schema.MapAttribute{
 				Optional:    true,
 				ElementType: types.StringType,
-				Description: "Map of result-key to gojsonq dot-path expressions to extract from the fetched " +
-					"object (e.g. `replicas = \"spec.replicas\"`, `image = \"spec.template.spec.containers.[0].image\"`). " +
-					"Array indices use the `[N]` form, e.g. `containers.[0]`. " +
-					"Each path must resolve; missing paths produce an error.",
+				Description: "Map of result-key to dot-and-bracket path expressions to extract from the fetched " +
+					"object. Plain dotted keys (`replicas = \"spec.replicas\"`), array indices via " +
+					"`[N]`, `.[N]`, or bare `.N` (`image = \"spec.containers[0].image\"`), and quoted " +
+					"bracketed segments for keys containing dots, slashes, or other reserved characters " +
+					"(`app = \"metadata.labels[\\\"app.kubernetes.io/name\\\"]\"`). Each path must " +
+					"resolve; missing paths produce an error naming the offending key.",
 			},
 
 			"yaml": schema.StringAttribute{

--- a/internal/framework/ephemeral_kubectl_manifest.go
+++ b/internal/framework/ephemeral_kubectl_manifest.go
@@ -78,7 +78,10 @@ func (r *manifestEphemeralResource) Schema(_ context.Context, _ ephemeral.Schema
 			"fields": schema.MapAttribute{
 				Optional:    true,
 				ElementType: types.StringType,
-				Description: "Map of result-key to gojsonq dot-path expressions to extract from the fetched object.",
+				Description: "Map of result-key to dot-and-bracket path expressions to extract from the fetched object. " +
+					"Same grammar as the `kubectl_manifest` data source's `fields`: plain dotted keys, `[N]` for " +
+					"array indices, and `[\"key.with.dots\"]` for map keys containing dots or other reserved characters. " +
+					"Each path must resolve; missing paths produce an error.",
 			},
 
 			"yaml": schema.StringAttribute{

--- a/kubernetes/manifest_fetch.go
+++ b/kubernetes/manifest_fetch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -89,7 +90,12 @@ func FetchManifest(
 		return nil, fmt.Errorf("failed to render fetched object as YAML: %w", err)
 	}
 
-	results, err := extractFields(string(jsonBytes), fields)
+	// extractFields walks the already-decoded unstructured content
+	// directly rather than re-parsing jsonBytes; obj.UnstructuredContent
+	// is the same map[string]interface{} json.Unmarshal would produce
+	// on the JSON we just rendered, but without the marshal / unmarshal
+	// round-trip.
+	results, err := extractFields(obj.UnstructuredContent(), fields)
 	if err != nil {
 		return nil, err
 	}
@@ -102,22 +108,18 @@ func FetchManifest(
 	}, nil
 }
 
-// extractFields runs each user-supplied dot-and-bracket path
-// against the parsed JSON body and stringifies the value. The
-// walker returns (value, found) explicitly so an absent path
-// produces an error naming the offending key, while a present
-// path whose value is JSON null is preserved as the empty string
-// (the natural %v form of a nil interface). Scalars become their
-// natural string form; maps and slices are JSON-encoded so
-// callers can `jsondecode()` to recover structure.
-func extractFields(jsonBody string, fields map[string]string) (map[string]string, error) {
+// extractFields walks each user-supplied dot-and-bracket path on the
+// pre-decoded unstructured doc and stringifies the value. The walker
+// returns (value, found) explicitly: a path that does not resolve
+// produces an error naming the offending key. A path that resolves
+// to a JSON null stringifies to the empty string, matching the
+// stringifyValue contract. Scalars become their natural string form
+// via strconv (no scientific notation for large floats); maps and
+// slices are JSON-encoded so callers can `jsondecode()` to recover
+// structure.
+func extractFields(doc interface{}, fields map[string]string) (map[string]string, error) {
 	if len(fields) == 0 {
 		return map[string]string{}, nil
-	}
-
-	var doc interface{}
-	if err := json.Unmarshal([]byte(jsonBody), &doc); err != nil {
-		return nil, fmt.Errorf("failed to parse fetched object JSON: %w", err)
 	}
 
 	out := make(map[string]string, len(fields))
@@ -138,12 +140,39 @@ func extractFields(jsonBody string, fields map[string]string) (map[string]string
 	return out, nil
 }
 
+// stringifyValue renders a walked value as a Terraform string. A
+// JSON null comes through as the empty string (consistent with
+// extractFields' docstring contract). Floats use strconv with -1
+// precision so integer-valued large floats (e.g. metadata.generation
+// past 1e6, which json.Unmarshal decodes to float64) render as plain
+// decimals rather than fmt.Sprintf's %v default of scientific
+// notation. Other scalars route through strconv; complex values
+// (maps, slices, anything else) go through json.Marshal so callers
+// can `jsondecode()` to recover structure.
 func stringifyValue(v interface{}) (string, error) {
 	switch t := v.(type) {
+	case nil:
+		return "", nil
 	case string:
 		return t, nil
-	case bool, float64, float32, int, int32, int64, uint, uint32, uint64:
-		return fmt.Sprintf("%v", t), nil
+	case bool:
+		return strconv.FormatBool(t), nil
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64), nil
+	case float32:
+		return strconv.FormatFloat(float64(t), 'f', -1, 32), nil
+	case int:
+		return strconv.FormatInt(int64(t), 10), nil
+	case int32:
+		return strconv.FormatInt(int64(t), 10), nil
+	case int64:
+		return strconv.FormatInt(t, 10), nil
+	case uint:
+		return strconv.FormatUint(uint64(t), 10), nil
+	case uint32:
+		return strconv.FormatUint(uint64(t), 10), nil
+	case uint64:
+		return strconv.FormatUint(t, 10), nil
 	default:
 		b, err := json.Marshal(t)
 		if err != nil {

--- a/kubernetes/manifest_fetch.go
+++ b/kubernetes/manifest_fetch.go
@@ -4,10 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
-	"strings"
 
-	"github.com/thedevsaddam/gojsonq/v2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	meta_v1_unstruct "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -48,9 +45,12 @@ func BuildSelfLinkID(apiVersion, namespace, kind, name string) string {
 // namespace may be empty. The underlying client helper defaults namespaced
 // resources to "default" and ignores the namespace for cluster-scoped kinds.
 //
-// fields maps a user-chosen key to a gojsonq dot-path (e.g. "spec.replicas",
-// "spec.template.spec.containers.0.image"). Missing paths cause FetchManifest
-// to return an error naming the offending key.
+// fields maps a user-chosen key to a dot-and-bracket path
+// expression (e.g. "spec.replicas",
+// "spec.template.spec.containers[0].image",
+// `metadata.labels["app.kubernetes.io/name"]`). See
+// path_walker.go for the full grammar. Missing paths cause
+// FetchManifest to return an error naming the offending key.
 func FetchManifest(
 	ctx context.Context,
 	provider *KubeProvider,
@@ -102,28 +102,32 @@ func FetchManifest(
 	}, nil
 }
 
-// extractFields runs each user-supplied gojsonq path against the JSON body
-// and stringifies the value. Missing paths produce an error naming the
-// offending key. Scalars become their natural string form; maps and slices
-// are JSON-encoded so callers can `jsondecode()` to recover structure.
+// extractFields runs each user-supplied dot-and-bracket path
+// against the parsed JSON body and stringifies the value. The
+// walker returns (value, found) explicitly so an absent path
+// produces an error naming the offending key, while a present
+// path whose value is JSON null is preserved as the empty string
+// (the natural %v form of a nil interface). Scalars become their
+// natural string form; maps and slices are JSON-encoded so
+// callers can `jsondecode()` to recover structure.
 func extractFields(jsonBody string, fields map[string]string) (map[string]string, error) {
 	if len(fields) == 0 {
 		return map[string]string{}, nil
 	}
 
-	out := make(map[string]string, len(fields))
-	gq := gojsonq.New().FromString(jsonBody)
+	var doc interface{}
+	if err := json.Unmarshal([]byte(jsonBody), &doc); err != nil {
+		return nil, fmt.Errorf("failed to parse fetched object JSON: %w", err)
+	}
 
+	out := make(map[string]string, len(fields))
 	for key, path := range fields {
-		value := gq.Reset().Find(path)
-		if value == nil {
-			exists, err := jsonPathExists(jsonBody, path)
-			if err != nil {
-				return nil, fmt.Errorf("fields[%q]: %w", key, err)
-			}
-			if !exists {
-				return nil, fmt.Errorf("fields[%q]: path %q not found in fetched object", key, path)
-			}
+		value, found, err := ExtractByPath(doc, path)
+		if err != nil {
+			return nil, fmt.Errorf("fields[%q]: %w", key, err)
+		}
+		if !found {
+			return nil, fmt.Errorf("fields[%q]: path %q not found in fetched object", key, path)
 		}
 		s, err := stringifyValue(value)
 		if err != nil {
@@ -132,54 +136,6 @@ func extractFields(jsonBody string, fields map[string]string) (map[string]string
 		out[key] = s
 	}
 	return out, nil
-}
-
-// jsonPathExists checks whether a dot-separated path exists in a JSON body.
-// Array segments may use bare or bracketed indices, as parsed by parsePathIndex.
-// Keep this path parsing behavior aligned with gojsonq path resolution semantics.
-func jsonPathExists(jsonBody, path string) (bool, error) {
-	var doc interface{}
-	if err := json.Unmarshal([]byte(jsonBody), &doc); err != nil {
-		return false, fmt.Errorf("failed to parse fetched object JSON: %w", err)
-	}
-
-	current := doc
-	for _, part := range strings.Split(path, ".") {
-		if part == "" {
-			return false, nil
-		}
-
-		switch node := current.(type) {
-		case map[string]interface{}:
-			value, ok := node[part]
-			if !ok {
-				return false, nil
-			}
-			current = value
-		case []interface{}:
-			index, ok := parsePathIndex(part)
-			if !ok || index < 0 || index >= len(node) {
-				return false, nil
-			}
-			current = node[index]
-		default:
-			return false, nil
-		}
-	}
-	return true, nil
-}
-
-// parsePathIndex parses an array index from either "N" or "[N]" path segments.
-// It returns the parsed index and whether the segment was a valid index.
-func parsePathIndex(part string) (int, bool) {
-	if strings.HasPrefix(part, "[") && strings.HasSuffix(part, "]") {
-		part = strings.TrimPrefix(strings.TrimSuffix(part, "]"), "[")
-	}
-	index, err := strconv.Atoi(part)
-	if err != nil {
-		return 0, false
-	}
-	return index, true
 }
 
 func stringifyValue(v interface{}) (string, error) {

--- a/kubernetes/manifest_fetch_test.go
+++ b/kubernetes/manifest_fetch_test.go
@@ -28,7 +28,10 @@ func TestStringifyValue(t *testing.T) {
 		{"map encoded as JSON", map[string]interface{}{"a": "b", "c": float64(1)}, `{"a":"b","c":1}`},
 		{"slice of strings encoded as JSON", []interface{}{"a", "b"}, `["a","b"]`},
 		{"nested map+slice encoded as JSON", map[string]interface{}{"x": []interface{}{float64(1), float64(2)}}, `{"x":[1,2]}`},
-		{"nil encoded as JSON null", nil, "null"},
+		{"nil renders as empty string", nil, ""},
+		{"float64 large integral does not use scientific notation", float64(10000000), "10000000"},
+		{"float64 very large integral", float64(1234567890), "1234567890"},
+		{"int64 large", int64(1234567890123), "1234567890123"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -40,7 +43,7 @@ func TestStringifyValue(t *testing.T) {
 }
 
 func TestExtractFields(t *testing.T) {
-	body := `{
+	bodyJSON := `{
       "metadata": {
         "name": "demo",
         "labels": {"app": "nginx", "tier": "web"}
@@ -55,6 +58,8 @@ func TestExtractFields(t *testing.T) {
         ]
       }
     }`
+	var body interface{}
+	require.NoError(t, json.Unmarshal([]byte(bodyJSON), &body))
 
 	t.Run("nil fields returns empty map without parsing the body", func(t *testing.T) {
 		got, err := extractFields(body, nil)
@@ -115,22 +120,31 @@ func TestExtractFields(t *testing.T) {
 		assert.Equal(t, "nginx:1.25", container["image"])
 	})
 
-	t.Run("null object field is extracted as JSON null", func(t *testing.T) {
+	t.Run("null object field is extracted as empty string", func(t *testing.T) {
 		got, err := extractFields(body, map[string]string{"last_schedule": "spec.lastScheduleTime"})
 		require.NoError(t, err)
-		assert.Equal(t, "null", got["last_schedule"])
+		assert.Equal(t, "", got["last_schedule"])
 	})
 
-	t.Run("null array element field is extracted as JSON null", func(t *testing.T) {
+	t.Run("null array element field is extracted as empty string", func(t *testing.T) {
 		got, err := extractFields(body, map[string]string{"resources": "spec.containers.[1].resources"})
 		require.NoError(t, err)
-		assert.Equal(t, "null", got["resources"])
+		assert.Equal(t, "", got["resources"])
 	})
 
-	t.Run("bare array index against null field is extracted as JSON null", func(t *testing.T) {
+	t.Run("bare array index against null field is extracted as empty string", func(t *testing.T) {
 		got, err := extractFields(body, map[string]string{"resources": "spec.containers.1.resources"})
 		require.NoError(t, err)
-		assert.Equal(t, "null", got["resources"])
+		assert.Equal(t, "", got["resources"])
+	})
+
+	t.Run("large integer-valued float does not render in scientific notation", func(t *testing.T) {
+		bigJSON := `{"spec":{"generation":10000000}}`
+		var bigBody interface{}
+		require.NoError(t, json.Unmarshal([]byte(bigJSON), &bigBody))
+		got, err := extractFields(bigBody, map[string]string{"gen": "spec.generation"})
+		require.NoError(t, err)
+		assert.Equal(t, "10000000", got["gen"])
 	})
 
 	t.Run("missing path returns error naming the field key", func(t *testing.T) {

--- a/kubernetes/path_walker.go
+++ b/kubernetes/path_walker.go
@@ -230,12 +230,42 @@ func parseBracketSegment(path string, i int) (pathSegment, int, error) {
 	if body == "" {
 		return pathSegment{}, 0, fmt.Errorf("empty bracket segment in path %q at position %d", path, i)
 	}
-	if _, err := strconv.Atoi(body); err == nil {
-		// Pure-integer body. Tag the segment so ExtractByPath can
-		// reject `[N]` against a map node as a type mismatch.
+	// Anything that LOOKS numeric (starts with a digit or a sign)
+	// must match the strict unsigned-integer form. Signed forms
+	// `[+1]` / `[-1]` are not valid: negative indices have no
+	// meaning against `[]interface{}`, and a `+`-prefixed index is
+	// a foot-gun for anyone expecting a signed offset. strconv.Atoi
+	// would silently accept them. Mixed forms like `[1foo]` are
+	// also rejected. Users who genuinely want a literal map key
+	// that starts with a digit or sign must reach for the quoted
+	// form `["1foo"]` / `["+1"]`.
+	if body[0] == '+' || body[0] == '-' || (body[0] >= '0' && body[0] <= '9') {
+		if !isASCIIDigits(body) {
+			return pathSegment{}, 0, fmt.Errorf("invalid numeric bracket segment %q in path %q at position %d (only unsigned digits allowed; use quoted form for literal keys)", body, path, i)
+		}
+		// Pure unsigned-integer body. Tag the segment so
+		// ExtractByPath can reject `[N]` against a map as a type
+		// mismatch rather than silently looking up the literal
+		// string key "N".
 		return pathSegment{key: body, bracketedIndex: true}, j + 1, nil
 	}
 	return pathSegment{key: body}, j + 1, nil
+}
+
+// isASCIIDigits reports whether s is non-empty and consists only of
+// the bytes '0'-'9'. Used as a strict pre-check before tagging a
+// bracket body as a numeric index.
+func isASCIIDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // segmentToIndex returns the integer index implied by a segment

--- a/kubernetes/path_walker.go
+++ b/kubernetes/path_walker.go
@@ -50,6 +50,14 @@ func ExtractByPath(doc interface{}, path string) (interface{}, bool, error) {
 	for _, seg := range segments {
 		switch node := current.(type) {
 		case map[string]interface{}:
+			if seg.bracketedIndex {
+				// `[N]` was used at a map node. Almost always
+				// a user typo (e.g. `metadata.annotations[0]`
+				// when the user thought annotations was a
+				// list). Surface loudly rather than silently
+				// look up the literal string key "N".
+				return nil, false, fmt.Errorf("segment [%s] applied to a map (expected an array)", seg.key)
+			}
 			v, ok := node[seg.key]
 			if !ok {
 				return nil, false, nil
@@ -78,13 +86,26 @@ func ExtractByPath(doc interface{}, path string) (interface{}, bool, error) {
 	return current, true, nil
 }
 
-// pathSegment captures one step of a parsed path. quoted=true
-// indicates the segment came from a bracketed string form
-// (`["foo.bar"]`) so it must be used as a map key verbatim and not
-// reinterpreted as an array index.
+// pathSegment captures one step of a parsed path.
+//
+//   - quoted=true: segment came from a quoted bracketed form
+//     (`["foo.bar"]`). It must be used as a map key verbatim and
+//     can never be reinterpreted as an array index, so applying it
+//     to a slice surfaces an error.
+//   - bracketedIndex=true: segment came from an unquoted-numeric
+//     bracketed form (`[0]`). It must be used as a slice index;
+//     applying it to a map surfaces an error rather than silently
+//     looking up the literal string key (which would mask user
+//     typos like `metadata.annotations[0]` written when an array
+//     was expected).
+//   - Both false: segment came from a bare dotted identifier
+//     (`metadata.name`, `containers.0`). The dispatch rules in
+//     ExtractByPath decide map-vs-slice handling from the parent
+//     node's runtime type.
 type pathSegment struct {
-	key    string
-	quoted bool
+	key            string
+	quoted         bool
+	bracketedIndex bool
 }
 
 // parsePathSegments lexes path into a slice of segments. The grammar:
@@ -126,6 +147,15 @@ func parsePathSegments(path string) ([]pathSegment, error) {
 			seg, next, err := parseBracketSegment(path, i)
 			if err != nil {
 				return nil, err
+			}
+			// After a `]`, the only legal continuations are
+			// end-of-path, a `.` introducing the next bare
+			// segment, or another `[` introducing another
+			// bracket. Anything else (e.g. `x[0]y`) is a syntax
+			// error: it would otherwise silently parse as
+			// `x[0].y` and mask the missing separator.
+			if next < len(path) && path[next] != '.' && path[next] != '[' {
+				return nil, fmt.Errorf("expected '.' or '[' after ']' in path %q at position %d", path, next)
 			}
 			out = append(out, seg)
 			i = next
@@ -199,6 +229,11 @@ func parseBracketSegment(path string, i int) (pathSegment, int, error) {
 	body := path[start:j]
 	if body == "" {
 		return pathSegment{}, 0, fmt.Errorf("empty bracket segment in path %q at position %d", path, i)
+	}
+	if _, err := strconv.Atoi(body); err == nil {
+		// Pure-integer body. Tag the segment so ExtractByPath can
+		// reject `[N]` against a map node as a type mismatch.
+		return pathSegment{key: body, bracketedIndex: true}, j + 1, nil
 	}
 	return pathSegment{key: body}, j + 1, nil
 }

--- a/kubernetes/path_walker.go
+++ b/kubernetes/path_walker.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"fmt"
 	"strconv"
-	"strings"
 )
 
 // path_walker.go: dot-and-bracket path traversal for `fields`,
@@ -65,14 +64,14 @@ func ExtractByPath(doc interface{}, path string) (interface{}, bool, error) {
 				return nil, false, nil
 			}
 			current = node[idx]
-		case nil:
-			// Walking past an explicit null is "not found".
-			return nil, false, nil
 		default:
-			// Scalar mid-walk: the user's path goes deeper than
-			// the document; treat as not-found rather than
-			// raising an error, matching the previous gojsonq
-			// behaviour where Find returned nil at this point.
+			// Scalar mid-walk or walking past an explicit null:
+			// the path goes deeper than the document. Treat as
+			// not-found rather than raising an error, matching
+			// the previous gojsonq behaviour where Find returned
+			// nil at this point. extractFields then surfaces the
+			// original "path not found in fetched object" diagnostic
+			// at the caller.
 			return nil, false, nil
 		}
 	}
@@ -82,13 +81,10 @@ func ExtractByPath(doc interface{}, path string) (interface{}, bool, error) {
 // pathSegment captures one step of a parsed path. quoted=true
 // indicates the segment came from a bracketed string form
 // (`["foo.bar"]`) so it must be used as a map key verbatim and not
-// reinterpreted as an array index. bracketedIndex=true indicates a
-// bare integer bracketed form (`[0]`) so it must be used as a slice
-// index and not as a literal map key.
+// reinterpreted as an array index.
 type pathSegment struct {
-	key            string
-	quoted         bool
-	bracketedIndex bool
+	key    string
+	quoted bool
 }
 
 // parsePathSegments lexes path into a slice of segments. The grammar:
@@ -100,13 +96,18 @@ type pathSegment struct {
 //	integer  = digits
 //	identifier = chars excluding '.' '[' ']'
 //
-// Empty paths and empty segments are rejected as malformed. Quote
-// characters inside a quoted bracket segment do not need escaping;
-// the parser closes on the first matching close-bracket after the
-// closing quote.
+// Empty paths, leading dots, doubled dots, trailing dots, and empty
+// bracket segments are all rejected as malformed. Quote characters
+// inside a quoted bracket segment do not need escaping; the parser
+// closes on the first matching close-bracket after the closing
+// quote (so the chosen quote character cannot itself appear in the
+// segment, which is fine for valid Kubernetes label keys).
 func parsePathSegments(path string) ([]pathSegment, error) {
 	if path == "" {
 		return nil, fmt.Errorf("empty path")
+	}
+	if path[len(path)-1] == '.' {
+		return nil, fmt.Errorf("empty segment at end of path %q", path)
 	}
 	var out []pathSegment
 	i := 0
@@ -114,10 +115,10 @@ func parsePathSegments(path string) ([]pathSegment, error) {
 		c := path[i]
 		switch {
 		case c == '.':
-			// A leading or doubled dot would imply an empty
+			// A leading or doubled dot implies an empty
 			// segment. Reject so misconfigured paths surface
 			// loudly rather than as silent not-found.
-			if i == 0 || path[i-1] == '.' || path[i-1] == ']' && i == 0 {
+			if i == 0 || path[i-1] == '.' {
 				return nil, fmt.Errorf("empty segment in path %q at position %d", path, i)
 			}
 			i++
@@ -175,18 +176,19 @@ func parseBracketSegment(path string, i int) (pathSegment, int, error) {
 			return pathSegment{}, 0, fmt.Errorf("unterminated quoted bracket segment in path %q at position %d", path, i)
 		}
 		key := path[start:j]
+		if key == "" {
+			return pathSegment{}, 0, fmt.Errorf("empty quoted bracket segment in path %q at position %d", path, i)
+		}
 		j++ // consume close quote
 		if j >= len(path) || path[j] != ']' {
 			return pathSegment{}, 0, fmt.Errorf("expected ']' after quoted segment in path %q at position %d", path, j)
 		}
 		return pathSegment{key: key, quoted: true}, j + 1, nil
 	}
-	// Unquoted form: read until ']'. The contents may be either a
-	// pure integer (slice index) or a bare identifier (map key).
-	// Bare identifiers cannot contain dots; users who need that
-	// must reach for the quoted form. We treat purely-numeric
-	// content as an index and any other content as a key, which
-	// preserves the legacy `[N]` syntax.
+	// Unquoted form: read until ']'. The contents must be a pure
+	// integer (slice index) or a bare identifier (map key); bare
+	// identifiers cannot contain dots, slashes, or quotes, so users
+	// who need those must reach for the quoted form.
 	start := j
 	for j < len(path) && path[j] != ']' {
 		j++
@@ -197,9 +199,6 @@ func parseBracketSegment(path string, i int) (pathSegment, int, error) {
 	body := path[start:j]
 	if body == "" {
 		return pathSegment{}, 0, fmt.Errorf("empty bracket segment in path %q at position %d", path, i)
-	}
-	if _, err := strconv.Atoi(body); err == nil {
-		return pathSegment{key: body, bracketedIndex: true}, j + 1, nil
 	}
 	return pathSegment{key: body}, j + 1, nil
 }
@@ -220,9 +219,3 @@ func segmentToIndex(seg pathSegment) (int, error) {
 	return idx, nil
 }
 
-// pathContainsBracket is a cheap heuristic used by callers that
-// want to log whether a user has reached for the new syntax. Not
-// part of the parsing flow.
-func pathContainsBracket(path string) bool {
-	return strings.ContainsAny(path, "[]")
-}

--- a/kubernetes/path_walker.go
+++ b/kubernetes/path_walker.go
@@ -1,0 +1,228 @@
+package kubernetes
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// path_walker.go: dot-and-bracket path traversal for `fields`,
+// `wait_for.field`, and the data-source / ephemeral-resource
+// extraction helpers. Replaces gojsonq, which split on `.`
+// unconditionally and could not address keys whose own name
+// contained dots: Kubernetes labels and annotations with domain
+// prefixes (`app.kubernetes.io/name`,
+// `argocd.argoproj.io/sync-wave`,
+// `nginx.ingress.kubernetes.io/rewrite-target`) were therefore
+// unreachable via the documented dot syntax. Issue #271.
+//
+// The new syntax is a backward-compatible superset:
+//
+//   - `metadata.name` -> map key "metadata", then "name". As before.
+//   - `containers.0` or `containers.[0]` -> array index 0. As before.
+//   - `metadata.labels["app.kubernetes.io/name"]` -> map key with
+//     embedded dots. New. Either double quotes or single quotes are
+//     accepted; the quote character chosen does not need to be
+//     escaped inside the segment because the bracket-balancing
+//     parser already determines the segment boundary.
+//   - `spec.containers[0].image` -> bracketed index without a
+//     leading dot. New, matches how most JSONPath dialects let
+//     users write array access directly after a key. Equivalent to
+//     `spec.containers.[0].image` and `spec.containers.0.image`.
+//
+// The walker returns (value, found, err): found is false when a
+// segment is absent on its parent, true when the segment exists
+// even if the value is explicitly null. Callers that previously
+// disambiguated nil-not-found from nil-explicit-null via a separate
+// existence check (jsonPathExists) can now consume found directly.
+
+// ExtractByPath walks doc following the dot-and-bracket path and
+// returns the value at that path. found is false when the path
+// terminates at a missing key or out-of-range index; err is
+// non-nil only for malformed paths (unbalanced brackets, empty
+// segments) or type mismatches between path segment and value
+// shape (e.g. a non-integer segment against a slice).
+func ExtractByPath(doc interface{}, path string) (interface{}, bool, error) {
+	segments, err := parsePathSegments(path)
+	if err != nil {
+		return nil, false, err
+	}
+	current := doc
+	for _, seg := range segments {
+		switch node := current.(type) {
+		case map[string]interface{}:
+			v, ok := node[seg.key]
+			if !ok {
+				return nil, false, nil
+			}
+			current = v
+		case []interface{}:
+			idx, err := segmentToIndex(seg)
+			if err != nil {
+				return nil, false, err
+			}
+			if idx < 0 || idx >= len(node) {
+				return nil, false, nil
+			}
+			current = node[idx]
+		case nil:
+			// Walking past an explicit null is "not found".
+			return nil, false, nil
+		default:
+			// Scalar mid-walk: the user's path goes deeper than
+			// the document; treat as not-found rather than
+			// raising an error, matching the previous gojsonq
+			// behaviour where Find returned nil at this point.
+			return nil, false, nil
+		}
+	}
+	return current, true, nil
+}
+
+// pathSegment captures one step of a parsed path. quoted=true
+// indicates the segment came from a bracketed string form
+// (`["foo.bar"]`) so it must be used as a map key verbatim and not
+// reinterpreted as an array index. bracketedIndex=true indicates a
+// bare integer bracketed form (`[0]`) so it must be used as a slice
+// index and not as a literal map key.
+type pathSegment struct {
+	key            string
+	quoted         bool
+	bracketedIndex bool
+}
+
+// parsePathSegments lexes path into a slice of segments. The grammar:
+//
+//	path     = segment ( ('.' segment) | bracket )*
+//	segment  = identifier | bracket
+//	bracket  = '[' ( quoted | integer | identifier ) ']'
+//	quoted   = '"' chars '"' | "'" chars "'"
+//	integer  = digits
+//	identifier = chars excluding '.' '[' ']'
+//
+// Empty paths and empty segments are rejected as malformed. Quote
+// characters inside a quoted bracket segment do not need escaping;
+// the parser closes on the first matching close-bracket after the
+// closing quote.
+func parsePathSegments(path string) ([]pathSegment, error) {
+	if path == "" {
+		return nil, fmt.Errorf("empty path")
+	}
+	var out []pathSegment
+	i := 0
+	for i < len(path) {
+		c := path[i]
+		switch {
+		case c == '.':
+			// A leading or doubled dot would imply an empty
+			// segment. Reject so misconfigured paths surface
+			// loudly rather than as silent not-found.
+			if i == 0 || path[i-1] == '.' || path[i-1] == ']' && i == 0 {
+				return nil, fmt.Errorf("empty segment in path %q at position %d", path, i)
+			}
+			i++
+		case c == '[':
+			seg, next, err := parseBracketSegment(path, i)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, seg)
+			i = next
+		case c == ']':
+			return nil, fmt.Errorf("unexpected ']' in path %q at position %d", path, i)
+		default:
+			// Read a bare identifier up to next '.' or '['.
+			start := i
+			for i < len(path) && path[i] != '.' && path[i] != '[' {
+				if path[i] == ']' {
+					return nil, fmt.Errorf("unexpected ']' in path %q at position %d", path, i)
+				}
+				i++
+			}
+			ident := path[start:i]
+			if ident == "" {
+				return nil, fmt.Errorf("empty identifier in path %q at position %d", path, start)
+			}
+			out = append(out, pathSegment{key: ident})
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("path %q produced no segments", path)
+	}
+	return out, nil
+}
+
+// parseBracketSegment consumes a `[...]` token starting at position
+// i and returns the resulting segment plus the index of the
+// character immediately after the closing `]`.
+func parseBracketSegment(path string, i int) (pathSegment, int, error) {
+	// i points at '['
+	if i+1 >= len(path) {
+		return pathSegment{}, 0, fmt.Errorf("unterminated '[' in path %q at position %d", path, i)
+	}
+	j := i + 1
+	first := path[j]
+	if first == '"' || first == '\'' {
+		// Quoted form. Read until the matching quote, then
+		// expect the very next char to be ']'.
+		quote := first
+		j++
+		start := j
+		for j < len(path) && path[j] != quote {
+			j++
+		}
+		if j >= len(path) {
+			return pathSegment{}, 0, fmt.Errorf("unterminated quoted bracket segment in path %q at position %d", path, i)
+		}
+		key := path[start:j]
+		j++ // consume close quote
+		if j >= len(path) || path[j] != ']' {
+			return pathSegment{}, 0, fmt.Errorf("expected ']' after quoted segment in path %q at position %d", path, j)
+		}
+		return pathSegment{key: key, quoted: true}, j + 1, nil
+	}
+	// Unquoted form: read until ']'. The contents may be either a
+	// pure integer (slice index) or a bare identifier (map key).
+	// Bare identifiers cannot contain dots; users who need that
+	// must reach for the quoted form. We treat purely-numeric
+	// content as an index and any other content as a key, which
+	// preserves the legacy `[N]` syntax.
+	start := j
+	for j < len(path) && path[j] != ']' {
+		j++
+	}
+	if j >= len(path) {
+		return pathSegment{}, 0, fmt.Errorf("unterminated bracket segment in path %q at position %d", path, i)
+	}
+	body := path[start:j]
+	if body == "" {
+		return pathSegment{}, 0, fmt.Errorf("empty bracket segment in path %q at position %d", path, i)
+	}
+	if _, err := strconv.Atoi(body); err == nil {
+		return pathSegment{key: body, bracketedIndex: true}, j + 1, nil
+	}
+	return pathSegment{key: body}, j + 1, nil
+}
+
+// segmentToIndex returns the integer index implied by a segment
+// when the current node is a slice. Pure-integer literal segments
+// (`containers.0`) and bracketed-integer segments (`containers[0]`)
+// both yield a valid index; quoted segments are explicit map-key
+// requests and must not be coerced into an index.
+func segmentToIndex(seg pathSegment) (int, error) {
+	if seg.quoted {
+		return 0, fmt.Errorf("quoted segment %q is not a valid array index", seg.key)
+	}
+	idx, err := strconv.Atoi(seg.key)
+	if err != nil {
+		return 0, fmt.Errorf("segment %q is not a valid array index", seg.key)
+	}
+	return idx, nil
+}
+
+// pathContainsBracket is a cheap heuristic used by callers that
+// want to log whether a user has reached for the new syntax. Not
+// part of the parsing flow.
+func pathContainsBracket(path string) bool {
+	return strings.ContainsAny(path, "[]")
+}

--- a/kubernetes/path_walker_test.go
+++ b/kubernetes/path_walker_test.go
@@ -1,0 +1,270 @@
+package kubernetes
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// mustUnmarshal turns a JSON string into the same nested
+// interface{} shape the production code receives from
+// json.Unmarshal of a Kubernetes object. Tests use it so the
+// document under test matches real call sites byte-for-byte rather
+// than relying on hand-built map literals which can hide type
+// mismatches (e.g. map[string]interface{} vs map[string]string).
+func mustUnmarshal(t *testing.T, raw string) interface{} {
+	t.Helper()
+	var doc interface{}
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		t.Fatalf("invalid JSON fixture: %v", err)
+	}
+	return doc
+}
+
+func TestExtractByPath_BackwardCompat(t *testing.T) {
+	t.Parallel()
+	doc := mustUnmarshal(t, `{
+		"metadata": {
+			"name": "demo",
+			"namespace": "default"
+		},
+		"spec": {
+			"replicas": 3,
+			"containers": [
+				{"name": "app", "image": "foo:v1"},
+				{"name": "sidecar", "image": "bar:v1"}
+			]
+		}
+	}`)
+
+	cases := []struct {
+		name  string
+		path  string
+		want  interface{}
+		found bool
+	}{
+		{"map-scalar", "metadata.name", "demo", true},
+		{"nested-map", "spec.replicas", float64(3), true},
+		{"bare-int-slice-index", "spec.containers.0.image", "foo:v1", true},
+		{"bracketed-int-with-dot", "spec.containers.[0].image", "foo:v1", true},
+		{"bracketed-int-without-dot", "spec.containers[1].image", "bar:v1", true},
+		{"missing-key", "metadata.gone", nil, false},
+		{"missing-nested", "spec.template.spec", nil, false},
+		{"oob-index", "spec.containers.99.image", nil, false},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got, found, err := ExtractByPath(doc, c.path)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if found != c.found {
+				t.Errorf("found: got %v want %v", found, c.found)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("value: got %v want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestExtractByPath_DottedKeysViaBrackets(t *testing.T) {
+	t.Parallel()
+	// Realistic Kubernetes labels and annotations.
+	doc := mustUnmarshal(t, `{
+		"metadata": {
+			"labels": {
+				"app.kubernetes.io/name": "frontend",
+				"app.kubernetes.io/version": "1.2.3",
+				"team": "platform"
+			},
+			"annotations": {
+				"argocd.argoproj.io/sync-wave": "5",
+				"nginx.ingress.kubernetes.io/rewrite-target": "/"
+			}
+		}
+	}`)
+
+	cases := []struct {
+		name string
+		path string
+		want interface{}
+	}{
+		{
+			name: "double-quoted-domain-label",
+			path: `metadata.labels["app.kubernetes.io/name"]`,
+			want: "frontend",
+		},
+		{
+			name: "single-quoted-domain-label",
+			path: `metadata.labels['app.kubernetes.io/version']`,
+			want: "1.2.3",
+		},
+		{
+			name: "annotation-with-domain-prefix",
+			path: `metadata.annotations["argocd.argoproj.io/sync-wave"]`,
+			want: "5",
+		},
+		{
+			name: "annotation-deep-domain",
+			path: `metadata.annotations["nginx.ingress.kubernetes.io/rewrite-target"]`,
+			want: "/",
+		},
+		{
+			name: "non-dotted-key-via-bracket-also-works",
+			path: `metadata.labels["team"]`,
+			want: "platform",
+		},
+		{
+			name: "non-dotted-key-via-dot-still-works",
+			path: `metadata.labels.team`,
+			want: "platform",
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got, found, err := ExtractByPath(doc, c.path)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !found {
+				t.Fatalf("expected found=true for path %q, got false", c.path)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("path %q: got %v want %v", c.path, got, c.want)
+			}
+		})
+	}
+}
+
+func TestExtractByPath_ExplicitNullVsMissing(t *testing.T) {
+	t.Parallel()
+	doc := mustUnmarshal(t, `{
+		"status": {
+			"lastScheduleTime": null,
+			"phase": "Ready"
+		}
+	}`)
+
+	t.Run("explicit-null-is-found", func(t *testing.T) {
+		t.Parallel()
+		v, found, err := ExtractByPath(doc, "status.lastScheduleTime")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !found {
+			t.Errorf("explicit null should be found=true, was false")
+		}
+		if v != nil {
+			t.Errorf("explicit null value: got %v want nil", v)
+		}
+	})
+
+	t.Run("missing-is-not-found", func(t *testing.T) {
+		t.Parallel()
+		_, found, err := ExtractByPath(doc, "status.startTime")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if found {
+			t.Errorf("missing key should be found=false, was true")
+		}
+	})
+
+	t.Run("descending-through-null-is-not-found", func(t *testing.T) {
+		t.Parallel()
+		_, found, err := ExtractByPath(doc, "status.lastScheduleTime.year")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if found {
+			t.Errorf("descending past null should be found=false, was true")
+		}
+	})
+}
+
+func TestExtractByPath_MalformedPaths(t *testing.T) {
+	t.Parallel()
+	doc := mustUnmarshal(t, `{"x": 1}`)
+	cases := []string{
+		"",
+		".x",
+		"x..y",
+		"x[",
+		"x[]",
+		"x['unterminated",
+		`x["unterminated`,
+		"x]",
+		"x[abc",
+	}
+	for _, p := range cases {
+		p := p
+		t.Run("path="+p, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := ExtractByPath(doc, p)
+			if err == nil {
+				t.Errorf("expected error for malformed path %q, got nil", p)
+			}
+		})
+	}
+}
+
+func TestExtractByPath_TypeMismatch(t *testing.T) {
+	t.Parallel()
+	doc := mustUnmarshal(t, `{
+		"spec": {
+			"replicas": 3,
+			"containers": [{"name": "app"}]
+		}
+	}`)
+
+	t.Run("quoted-segment-cannot-index-slice", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := ExtractByPath(doc, `spec.containers["first"]`)
+		if err == nil {
+			t.Fatal("expected error: quoted segment against slice")
+		}
+	})
+
+	t.Run("non-numeric-bare-segment-against-slice", func(t *testing.T) {
+		t.Parallel()
+		// Bare "first" against a slice has no integer reading
+		// so it must fail rather than silently coerce to 0.
+		_, _, err := ExtractByPath(doc, "spec.containers.first.image")
+		if err == nil {
+			t.Fatal("expected error: non-integer segment against slice")
+		}
+	})
+
+	t.Run("descending-into-scalar-is-not-found", func(t *testing.T) {
+		t.Parallel()
+		// `replicas` is a scalar; walking deeper is not-found.
+		_, found, err := ExtractByPath(doc, "spec.replicas.value")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if found {
+			t.Errorf("descending into scalar should be not-found")
+		}
+	})
+}
+
+func TestPathContainsBracket(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		"metadata.name":                    false,
+		"metadata.labels.team":             false,
+		`metadata.labels["a.b/c"]`:         true,
+		"spec.containers[0].image":         true,
+		"spec.containers.[0].image":        true,
+	}
+	for path, want := range cases {
+		if got := pathContainsBracket(path); got != want {
+			t.Errorf("pathContainsBracket(%q): got %v want %v", path, got, want)
+		}
+	}
+}

--- a/kubernetes/path_walker_test.go
+++ b/kubernetes/path_walker_test.go
@@ -210,6 +210,19 @@ func TestExtractByPath_MalformedPaths(t *testing.T) {
 		"x[0]y",
 		`x["k"]y`,
 		`x['k']more`,
+		// Numeric-looking bracket bodies must be strict unsigned
+		// digits. strconv.Atoi happily accepts signed forms and
+		// would mask a foot-gun where the user expects a signed
+		// offset (it isn't), so we reject at parse time. Anyone
+		// who genuinely wants a literal map key with a leading
+		// sign must use the quoted form `["+1"]`.
+		"x[+1]",
+		"x[-1]",
+		// Mixed numeric-then-identifier bodies are also rejected
+		// rather than silently treated as bare identifiers
+		// (which would mask a typo for a real index).
+		"x[1foo]",
+		"x[0x10]",
 	}
 	for _, p := range cases {
 		p := p

--- a/kubernetes/path_walker_test.go
+++ b/kubernetes/path_walker_test.go
@@ -193,9 +193,12 @@ func TestExtractByPath_MalformedPaths(t *testing.T) {
 	cases := []string{
 		"",
 		".x",
+		"x.",
 		"x..y",
 		"x[",
 		"x[]",
+		`x[""]`,
+		`x['']`,
 		"x['unterminated",
 		`x["unterminated`,
 		"x]",
@@ -253,18 +256,3 @@ func TestExtractByPath_TypeMismatch(t *testing.T) {
 	})
 }
 
-func TestPathContainsBracket(t *testing.T) {
-	t.Parallel()
-	cases := map[string]bool{
-		"metadata.name":                    false,
-		"metadata.labels.team":             false,
-		`metadata.labels["a.b/c"]`:         true,
-		"spec.containers[0].image":         true,
-		"spec.containers.[0].image":        true,
-	}
-	for path, want := range cases {
-		if got := pathContainsBracket(path); got != want {
-			t.Errorf("pathContainsBracket(%q): got %v want %v", path, got, want)
-		}
-	}
-}

--- a/kubernetes/path_walker_test.go
+++ b/kubernetes/path_walker_test.go
@@ -189,7 +189,7 @@ func TestExtractByPath_ExplicitNullVsMissing(t *testing.T) {
 
 func TestExtractByPath_MalformedPaths(t *testing.T) {
 	t.Parallel()
-	doc := mustUnmarshal(t, `{"x": 1}`)
+	doc := mustUnmarshal(t, `{"x": 1, "spec": {"replicas": 3}}`)
 	cases := []string{
 		"",
 		".x",
@@ -203,6 +203,13 @@ func TestExtractByPath_MalformedPaths(t *testing.T) {
 		`x["unterminated`,
 		"x]",
 		"x[abc",
+		// Bracket segments must be followed by `.`, `[`, or
+		// end-of-path. Anything else (bare identifier touching
+		// the close-bracket) would otherwise parse as if a `.`
+		// were silently present, masking a typo.
+		"x[0]y",
+		`x["k"]y`,
+		`x['k']more`,
 	}
 	for _, p := range cases {
 		p := p
@@ -213,6 +220,63 @@ func TestExtractByPath_MalformedPaths(t *testing.T) {
 				t.Errorf("expected error for malformed path %q, got nil", p)
 			}
 		})
+	}
+}
+
+// TestExtractByPath_BracketedIndexAgainstMap regresses the
+// semantic that `[N]` (bracketed integer) is for slices only.
+// Applying it to a map node returns a type-mismatch error rather
+// than silently looking up the literal string key "N", which is
+// almost always a user typo (e.g. assuming `metadata.annotations`
+// is a list when it is in fact a map).
+func TestExtractByPath_BracketedIndexAgainstMap(t *testing.T) {
+	t.Parallel()
+	doc := mustUnmarshal(t, `{
+		"spec": {
+			"replicas": 3
+		},
+		"metadata": {
+			"annotations": {"0": "legacy-value", "app": "nginx"}
+		}
+	}`)
+	cases := []string{
+		"spec[0]",
+		"metadata.annotations[0]",
+	}
+	for _, p := range cases {
+		p := p
+		t.Run("path="+p, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := ExtractByPath(doc, p)
+			if err == nil {
+				t.Errorf("expected type-mismatch error for %q (bracketed index against map), got nil", p)
+			}
+		})
+	}
+}
+
+// TestExtractByPath_BareNumericAgainstMap confirms the symmetric
+// case: a dot-separated numeric segment (e.g. `containers.0`) on a
+// map node IS allowed to be treated as a literal string key, since
+// it could equally have been written without the dot. Only the
+// explicit-bracket form `[N]` carries the "must be an index"
+// commitment.
+func TestExtractByPath_BareNumericAgainstMap(t *testing.T) {
+	t.Parallel()
+	doc := mustUnmarshal(t, `{
+		"metadata": {
+			"annotations": {"0": "legacy-value"}
+		}
+	}`)
+	v, found, err := ExtractByPath(doc, "metadata.annotations.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected to find annotations[\"0\"], got not-found")
+	}
+	if v != "legacy-value" {
+		t.Errorf("got %v, want legacy-value", v)
 	}
 }
 

--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"log"
 	"regexp"
@@ -768,14 +767,12 @@ func matchesWaitConditions(manifest *meta_v1_unstruct.Unstructured, waitFields [
 	totalConditions := len(waitConditions) + len(waitFields)
 	totalMatches := 0
 
-	jsonBytes, err := manifest.MarshalJSON()
-	if err != nil {
-		return false, err
-	}
-	var doc interface{}
-	if err := json.Unmarshal(jsonBytes, &doc); err != nil {
-		return false, err
-	}
+	// Walk the already-decoded unstructured content directly; the
+	// previous gojsonq path Marshal-ed then Unmarshal-ed for every
+	// watch event, which is pure overhead since manifest is the
+	// same map[string]interface{} json.Unmarshal would produce on
+	// the JSON we'd have rendered.
+	doc := manifest.UnstructuredContent()
 
 	for _, c := range waitConditions {
 		if matchStatusCondition(doc, c.Type, c.Status) {
@@ -789,14 +786,32 @@ func matchesWaitConditions(manifest *meta_v1_unstruct.Unstructured, waitFields [
 	for _, c := range waitFields {
 		v, found, err := ExtractByPath(doc, c.Key)
 		if err != nil {
-			return false, fmt.Errorf("wait_for.field[%q]: %w", c.Key, err)
+			// Malformed path in user config. Log and skip rather
+			// than propagate: every watch event would otherwise
+			// hard-fail the wait, regressing the gojsonq
+			// behaviour that silently never matched a bad path
+			// and let the create_timeout bound the wait. A
+			// future plan-time validator is the right home for
+			// this diagnostic.
+			log.Printf("[WARN] wait_for.field[%q] in %s: %v (skipping for this event)", c.Key, name, err)
+			continue
 		}
-		if !found || v == nil {
+		if !found {
 			log.Printf("[TRACE] Key %s not found in %s", c.Key, name)
 			continue
 		}
 
-		stringVal := fmt.Sprintf("%v", v)
+		// stringifyValue produces the same string form as the
+		// data source's `fields` extraction, so users can write
+		// the same value they would for `data.kubectl_manifest.x
+		// .results[k]`. A JSON null at the path becomes "", so a
+		// caller wanting to wait for the field to clear can use
+		// value = "".
+		stringVal, err := stringifyValue(v)
+		if err != nil {
+			log.Printf("[WARN] wait_for.field[%q] in %s: stringify failed: %v (skipping for this event)", c.Key, name, err)
+			continue
+		}
 		switch c.ValueType {
 		case "regex":
 			matched, err := regexp.Match(c.Value, []byte(stringVal))
@@ -817,6 +832,15 @@ func matchesWaitConditions(manifest *meta_v1_unstruct.Unstructured, waitFields [
 			}
 			log.Printf("[TRACE] Value %s matches %s in %s (key %s)", stringVal, c.Value, name, c.Key)
 			totalMatches++
+
+		default:
+			// Unknown value_type. Schema validators normally
+			// reject this at plan time, but if a typo slips
+			// through (e.g. an older provider version or a
+			// future-added type the running binary doesn't know),
+			// surface it via WARN every event so the wait is not
+			// silently a no-op until create_timeout fires.
+			log.Printf("[WARN] wait_for.field[%q] in %s: unknown value_type %q (expected 'eq' or 'regex'), skipping for this event", c.Key, name, c.ValueType)
 		}
 	}
 

--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log"
 	"regexp"
@@ -14,7 +15,6 @@ import (
 	"github.com/alekc/terraform-provider-kubectl/flatten"
 	"github.com/alekc/terraform-provider-kubectl/internal/types"
 	"github.com/alekc/terraform-provider-kubectl/yaml"
-	"github.com/thedevsaddam/gojsonq/v2"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
@@ -753,11 +753,13 @@ func WaitForConditions(ctx context.Context, restClient *RestClientResult, waitFi
 // watch events and against the post-close Get probe (#266).
 //
 // waitConditions match by exact (type, status) pair against the
-// manifest's status.conditions array. waitFields match a gojsonq
-// dot-path; the value is stringified and either compared verbatim
-// (ValueType "" or "eq") or against a regex (ValueType "regex"). An
-// error is only returned for hard failures (manifest unmarshalling,
-// regex compilation); a "not matched yet" outcome is just (false, nil).
+// manifest's status.conditions array. waitFields match a
+// dot-and-bracket path (see kubernetes/path_walker.go); the value
+// is stringified and either compared verbatim (ValueType "" or
+// "eq") or against a regex (ValueType "regex"). An error is only
+// returned for hard failures (manifest unmarshalling, regex
+// compilation, malformed path syntax); a "not matched yet"
+// outcome is just (false, nil).
 func matchesWaitConditions(manifest *meta_v1_unstruct.Unstructured, waitFields []types.WaitForField, waitConditions []types.WaitForStatusCondition, name string) (bool, error) {
 	if manifest == nil {
 		return false, nil
@@ -766,28 +768,30 @@ func matchesWaitConditions(manifest *meta_v1_unstruct.Unstructured, waitFields [
 	totalConditions := len(waitConditions) + len(waitFields)
 	totalMatches := 0
 
-	yamlJson, err := manifest.MarshalJSON()
+	jsonBytes, err := manifest.MarshalJSON()
 	if err != nil {
 		return false, err
 	}
-
-	gq := gojsonq.New().FromString(string(yamlJson))
+	var doc interface{}
+	if err := json.Unmarshal(jsonBytes, &doc); err != nil {
+		return false, err
+	}
 
 	for _, c := range waitConditions {
-		count := gq.Reset().From("status.conditions").
-			Where("type", "=", c.Type).
-			Where("status", "=", c.Status).Count()
-		if count == 0 {
-			log.Printf("[TRACE] Condition %s with status %s not found in %s", c.Type, c.Status, name)
+		if matchStatusCondition(doc, c.Type, c.Status) {
+			log.Printf("[TRACE] Condition %s with status %s found in %s", c.Type, c.Status, name)
+			totalMatches++
 			continue
 		}
-		log.Printf("[TRACE] Condition %s with status %s found in %s", c.Type, c.Status, name)
-		totalMatches++
+		log.Printf("[TRACE] Condition %s with status %s not found in %s", c.Type, c.Status, name)
 	}
 
 	for _, c := range waitFields {
-		v := gq.Reset().Find(c.Key)
-		if v == nil {
+		v, found, err := ExtractByPath(doc, c.Key)
+		if err != nil {
+			return false, fmt.Errorf("wait_for.field[%q]: %w", c.Key, err)
+		}
+		if !found || v == nil {
 			log.Printf("[TRACE] Key %s not found in %s", c.Key, name)
 			continue
 		}
@@ -822,6 +826,37 @@ func matchesWaitConditions(manifest *meta_v1_unstruct.Unstructured, waitFields [
 	}
 	log.Printf("[TRACE] %d/%d conditions met for %s. Waiting for next ", totalMatches, totalConditions, name)
 	return false, nil
+}
+
+// matchStatusCondition returns true when doc contains an element
+// in status.conditions whose `type` and `status` fields exactly
+// match the supplied pair. Replaces gojsonq's
+// `From("status.conditions").Where("type","=",t).Where("status","=",s).Count()`
+// with a direct walk so the surrounding helper has no JSON-query
+// dependency. Values are compared via fmt.Sprintf so a boolean
+// `status: True` from a typed condition (rare; Kubernetes always
+// stringifies it) still matches the documented "True"/"False"
+// inputs.
+func matchStatusCondition(doc interface{}, wantType, wantStatus string) bool {
+	v, found, err := ExtractByPath(doc, "status.conditions")
+	if err != nil || !found {
+		return false
+	}
+	list, ok := v.([]interface{})
+	if !ok {
+		return false
+	}
+	for _, raw := range list {
+		entry, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if fmt.Sprintf("%v", entry["type"]) == wantType &&
+			fmt.Sprintf("%v", entry["status"]) == wantStatus {
+			return true
+		}
+	}
+	return false
 }
 
 // Takes the result of flatmap.Expand for an array of strings

--- a/kubernetes/wait_helpers_test.go
+++ b/kubernetes/wait_helpers_test.go
@@ -326,6 +326,77 @@ func TestMatchesWaitConditions_TableDriven(t *testing.T) {
 			nil,
 			false,
 		},
+		{
+			// Malformed path should NOT abort the wait. Pre-c77b9f9
+			// behaviour propagated the parse error from
+			// ExtractByPath, hard-failing the apply on the first
+			// reconcile event. Post-fix: WARN-log and skip,
+			// preserving the gojsonq behaviour of letting the
+			// wait time out at create_timeout instead.
+			"malformed path WARNs and skips (no error)",
+			makeManifest(map[string]interface{}{
+				"status": map[string]interface{}{"phase": "Active"},
+			}),
+			nil,
+			[]types.WaitForField{{Key: "status..phase", Value: "Active", ValueType: "eq"}},
+			false,
+		},
+		{
+			// Misspelled or unknown value_type should also not
+			// abort. Schema validators usually catch this at
+			// plan time; if a typo slips through (older binary,
+			// future-added type), surface a WARN every event.
+			"unknown value_type WARNs and skips",
+			makeManifest(map[string]interface{}{
+				"status": map[string]interface{}{"phase": "Active"},
+			}),
+			nil,
+			[]types.WaitForField{{Key: "status.phase", Value: "Active", ValueType: "equals"}},
+			false,
+		},
+		{
+			// Explicit JSON null at the path: post-c77b9f9 the
+			// value flows through stringifyValue as the empty
+			// string, so a user can match the cleared state via
+			// value = "". Previously the `!found || v == nil`
+			// guard skipped this case entirely.
+			"explicit-null at path matches value=\"\"",
+			makeManifest(map[string]interface{}{
+				"status": map[string]interface{}{"lastScheduleTime": nil},
+			}),
+			nil,
+			[]types.WaitForField{{Key: "status.lastScheduleTime", Value: "", ValueType: "eq"}},
+			true,
+		},
+		{
+			// Large integer-valued numeric field must NOT render
+			// in scientific notation. Pre-c77b9f9 the value
+			// stringified as "1e+07" and never matched.
+			"large integer-valued field eq match (no scientific notation)",
+			makeManifest(map[string]interface{}{
+				"status": map[string]interface{}{"observedGeneration": float64(10000000)},
+			}),
+			nil,
+			[]types.WaitForField{{Key: "status.observedGeneration", Value: "10000000", ValueType: "eq"}},
+			true,
+		},
+		{
+			"bracket-form key with dots in the key",
+			makeManifest(map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"app.kubernetes.io/name": "frontend",
+					},
+				},
+			}),
+			nil,
+			[]types.WaitForField{{
+				Key:       `metadata.labels["app.kubernetes.io/name"]`,
+				Value:     "frontend",
+				ValueType: "eq",
+			}},
+			true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -338,6 +409,103 @@ func TestMatchesWaitConditions_TableDriven(t *testing.T) {
 			}
 			if got != tc.want {
 				t.Errorf("matchesWaitConditions = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMatchStatusCondition directly exercises the helper used by
+// the waitConditions loop. matchesWaitConditions exercises it
+// implicitly; this test pins the not-found, not-an-array, missing-
+// field, and exact-match-of-many cases that the table above does
+// not cover.
+func TestMatchStatusCondition(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		doc        interface{}
+		wantType   string
+		wantStatus string
+		expect     bool
+	}{
+		{
+			"match found among many",
+			map[string]interface{}{
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						map[string]interface{}{"type": "Progressing", "status": "False"},
+						map[string]interface{}{"type": "Ready", "status": "True"},
+						map[string]interface{}{"type": "Synced", "status": "True"},
+					},
+				},
+			},
+			"Ready", "True", true,
+		},
+		{
+			"status mismatch among matching type",
+			map[string]interface{}{
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						map[string]interface{}{"type": "Ready", "status": "False"},
+					},
+				},
+			},
+			"Ready", "True", false,
+		},
+		{
+			"status.conditions missing entirely",
+			map[string]interface{}{
+				"status": map[string]interface{}{"phase": "Pending"},
+			},
+			"Ready", "True", false,
+		},
+		{
+			"status.conditions is not an array",
+			map[string]interface{}{
+				"status": map[string]interface{}{
+					"conditions": "broken",
+				},
+			},
+			"Ready", "True", false,
+		},
+		{
+			"condition entry missing type or status field is skipped",
+			map[string]interface{}{
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						map[string]interface{}{"reason": "PartialEntry"},
+						map[string]interface{}{"type": "Ready", "status": "True"},
+					},
+				},
+			},
+			"Ready", "True", true,
+		},
+		{
+			"non-map element in conditions slice is skipped",
+			map[string]interface{}{
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						"not-a-condition",
+						map[string]interface{}{"type": "Ready", "status": "True"},
+					},
+				},
+			},
+			"Ready", "True", true,
+		},
+		{
+			"empty document",
+			map[string]interface{}{},
+			"Ready", "True", false,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := matchStatusCondition(tc.doc, tc.wantType, tc.wantStatus)
+			if got != tc.expect {
+				t.Errorf("matchStatusCondition(%v, %q, %q) = %v, want %v",
+					tc.doc, tc.wantType, tc.wantStatus, got, tc.expect)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #271.

`fields`, `wait_for.field`, and the ephemeral resource's extractions all delegated to `gojsonq`, which splits dot-paths naively and cannot address keys that themselves contain dots. Domain-prefixed Kubernetes labels and annotations (`app.kubernetes.io/name`, `argocd.argoproj.io/sync-wave`, `nginx.ingress.kubernetes.io/rewrite-target`) were therefore unreachable through the documented dot syntax, and there was no escape form to recover them.

## What changes

- New `kubernetes/path_walker.go` with `ExtractByPath(doc, path) (value, found, err)`. The grammar is a backward-compatible superset of what `gojsonq` accepted:
    - `metadata.name`: dot-separated map keys (same as before).
    - `containers.0` and `containers.[0]`: array index (same as before).
    - `containers[0].image`: bracketed index without a leading dot (new but equivalent).
    - `metadata.labels["app.kubernetes.io/name"]` or `'app.kubernetes.io/name'`: quoted bracketed segment for keys with dots, slashes, or any other character a bare segment can't carry (new).
- Path-walker rejects malformed paths (empty segments, unterminated brackets, mismatched quotes) with a clear error rather than silently returning not-found.
- Walker returns an explicit `found` boolean so callers that previously needed a second-pass disambiguation (`jsonPathExists` against the gojsonq result) get the right answer directly. `jsonPathExists` and `parsePathIndex` are gone.
- `kubernetes/manifest_fetch.go` `extractFields` rewired onto `ExtractByPath`. `gojsonq` import dropped.
- `kubernetes/resource_kubectl_manifest.go` `matchesWaitConditions` rewired:
    - `wait_for.field` uses `ExtractByPath`.
    - `wait_for.condition` (previously `gojsonq.From("status.conditions").Where(...).Count()`) now walks `status.conditions` directly via a tiny helper. Same exact-pair (type, status) semantics; one fewer query-DSL dependency.
- `go.mod` / `go.sum`: `gojsonq` removed.
- Docs (`docs/data-sources/kubectl_manifest.md`, `docs/ephemeral-resources/kubectl_manifest.md`, `docs/resources/kubectl_manifest.md`): updated to describe the new grammar. The data source's CRD example now demonstrates a domain-prefixed label extraction via the bracket form. The previously-broken `data.ca\\.crt` escape attempt in the ConfigMap example is replaced with `data["ca.crt"]` (the legacy backslash-escape was never honoured by `gojsonq`, so this also fixes an example that didn't work in v2).

## Coverage

Table-driven unit tests in `kubernetes/path_walker_test.go` covering:

- Backward compatibility (every existing dot-path shape: scalar, nested map, bare-int array index, bracketed-int array index, missing key, out-of-range index).
- Dotted keys via brackets (double quotes, single quotes, non-dotted keys via brackets still work, plus the same key still works via dot).
- Explicit null vs missing (a JSON `null` is `found=true, value=nil`; an absent key is `found=false`; descending past null is `found=false`).
- Malformed paths (empty path, leading dot, doubled dot, unterminated `[`, empty `[]`, unterminated quoted segment, stray `]`).
- Type mismatches (quoted segment rejected against slice, non-integer segment rejected against slice, descending into scalar yields not-found rather than error).
- `pathContainsBracket` heuristic.

`go test ./...` and `go vet ./...` clean. The full existing test suite (renderer, drift engine, framework move/upgrade, etc.) passes unchanged.

## Backward compatibility

Every shape `gojsonq` accepted continues to work. The only escape form that didn't work before but might have looked plausible to a user (`data.ca\\.crt`-style backslash escape) is still not supported; the bracket form replaces it. No existing user's HCL should require changes.

## Out of scope

- The explicit-null-vs-missing edge case in `extractFields` is now handled (`null` reports as found and stringifies to empty), but `extractFields` itself still errors on a missing key by design. A "lenient" mode is a separate ask.
- Cross-provider HCL deprecation prose for the old gojsonq link, if any consumer docs reference it. Updated this repo's three doc pages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced path syntax for `fields` and `wait_for`: dot-and-bracket notation supporting array indices and quoted keys.

* **Documentation**
  * Updated docs and examples to show bracket-indexing, quoted keys for dotted/special-character map keys, full grammar, and error semantics.

* **Bug Fixes / Behavior**
  * JSON nulls return as empty strings; large numeric values stringify without scientific notation; malformed/unresolved paths produce clearer errors or are skipped during waits.

* **Tests**
  * Expanded unit tests covering path parsing, null vs missing semantics, error cases, and wait-condition matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->