### PR TITLE
feat(data-source,ephemeral): add wait_for to kubectl_manifest read paths

### DIFF
--- a/docs/data-sources/kubectl_manifest.md
+++ b/docs/data-sources/kubectl_manifest.md
@@ -156,6 +156,71 @@ The value is still written to `terraform.tfstate` in cleartext. If state-persist
 
     Each path must resolve; missing paths produce an error naming the offending key. Scalar values are returned as their natural string form; objects and arrays are JSON-encoded so callers can `jsondecode()` to recover structure.
 
+* `wait_for` - **(Optional)** Block. If set, the read blocks until the target object exists and any supplied predicates match, or until `timeouts.read` elapses. See [Wait for the object to exist](#wait-for-the-object-to-exist).
+
+* `timeouts` - **(Optional)** Block. Honoured only when `wait_for` is set. Supports a single attribute `read` (Go duration string, default `5m`).
+
+## Wait for the object to exist
+
+By default, reading an object that does not exist fails immediately with an error. When the object is created by another controller in the same plan/apply (e.g. an Operator that materialises a `Secret` after a CRD is applied), set `wait_for` to block the read until the object exists and any supplied predicates are satisfied.
+
+The block mirrors the `kubectl_manifest` resource's `wait_for` shape so users have one mental model across resource / data source / ephemeral. Inside the block:
+
+* `field` blocks compare a dot-and-bracket path value against a literal. Use `value_type = "regex"` for regex match; the default is `eq`.
+* `condition` blocks match `status.conditions[type=X, status=Y]` entries, the standard Kubernetes "Ready / Available / Synced" pattern.
+
+A bare `wait_for {}` block with no nested children waits only for the object to exist; predicates make the wait stricter.
+
+```hcl
+data "kubectl_manifest" "cert_tls" {
+  api_version = "v1"
+  kind        = "Secret"
+  name        = "wildcard-tls"
+  namespace   = "ingress"
+
+  # Block until cert-manager has materialised the Secret AND the
+  # parent Certificate's Ready condition is true.
+  wait_for {
+    field {
+      key   = "type"
+      value = "kubernetes.io/tls"
+    }
+  }
+
+  timeouts {
+    read = "10m"
+  }
+}
+
+output "tls_crt_pem" {
+  value     = base64decode(data.kubectl_manifest.cert_tls.results["crt"])
+  sensitive = true
+}
+```
+
+```hcl
+data "kubectl_manifest" "argo_app" {
+  api_version = "argoproj.io/v1alpha1"
+  kind        = "Application"
+  name        = "platform-bootstrap"
+  namespace   = "argocd"
+
+  # Wait until Argo CD reports both Synced=True and Healthy=True.
+  wait_for {
+    condition {
+      type   = "Synced"
+      status = "True"
+    }
+    condition {
+      type   = "Healthy"
+      status = "True"
+    }
+  }
+}
+```
+
+Internally the helper runs a poll-then-watch hybrid: a short polling loop (1s initial, capped at 10s) until the apiserver returns the object, then a watch with field-selector on the resource name driven by the existing `wait_for` predicate engine. Conditions and fields are re-evaluated on each Added / Modified event. RBAC: the data source's service account must hold `get` and `watch` on the target kind for the wait to succeed.
+
 ## Attribute Reference
 
 * `yaml` - The fetched object serialised as YAML.
@@ -165,6 +230,6 @@ The value is still written to `terraform.tfstate` in cleartext. If state-persist
 
 ## Notes
 
-* If the requested object does not exist on the cluster, the data source fails with an error. (Convention shared with `data "kubernetes_secret"` in `terraform-provider-kubernetes`.)
+* If the requested object does not exist on the cluster AND `wait_for` is unset, the data source fails immediately. With `wait_for` set, the read blocks until the object exists or `timeouts.read` elapses.
 * If `fields` declares a path that does not resolve, the read fails with an error naming the offending key. There is no per-field "lenient" mode today.
 * `kind` is matched as-supplied — `Deployment` works, `deployment` does not. Match the actual Kubernetes object Kind exactly.

--- a/docs/data-sources/kubectl_manifest.md
+++ b/docs/data-sources/kubectl_manifest.md
@@ -178,13 +178,19 @@ data "kubectl_manifest" "cert_tls" {
   name        = "wildcard-tls"
   namespace   = "ingress"
 
-  # Block until cert-manager has materialised the Secret AND the
-  # parent Certificate's Ready condition is true.
+  # Block until cert-manager has materialised the Secret with the
+  # expected TLS type. If you also need to gate on the parent
+  # Certificate's Ready condition, target a `Certificate` resource
+  # in a separate data block with a `condition { type = "Ready" }`.
   wait_for {
     field {
       key   = "type"
       value = "kubernetes.io/tls"
     }
+  }
+
+  fields = {
+    crt = "data[\"tls.crt\"]"
   }
 
   timeouts {

--- a/docs/ephemeral-resources/kubectl_manifest.md
+++ b/docs/ephemeral-resources/kubectl_manifest.md
@@ -62,6 +62,10 @@ Same as the [data source](../data-sources/kubectl_manifest.md):
 * `namespace` - **(Optional)** — leave empty for cluster-scoped kinds.
 * `fields` - **(Optional)** map of named extractions. Same dot-and-bracket path grammar as the data source's `fields` (plain dotted keys, `[N]` for array indices, `["key.with.dots"]` for map keys whose name contains dots or other reserved characters). See the data source's [Argument Reference](../data-sources/kubectl_manifest.md#argument-reference) for the full grammar.
 
+* `wait_for` - **(Optional)** Block. Same shape as the [data source's `wait_for`](../data-sources/kubectl_manifest.md#wait-for-the-object-to-exist): blocks the open until the target object exists and any supplied `field` / `condition` predicates match. Use when reading a Secret a controller hasn't yet materialised, or a CRD whose status fields need to converge before the value is meaningful.
+
+* `timeouts` - **(Optional)** Block. Honoured only when `wait_for` is set. Supports `open` (Go duration string, default `5m`).
+
 ## Attribute Reference
 
 * `yaml` - The fetched object serialised as YAML.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/terraform v0.12.29
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0
+	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/icza/dyno v0.0.0-20200205103839-49cb13720835

--- a/go.sum
+++ b/go.sum
@@ -280,6 +280,8 @@ github.com/hashicorp/terraform-plugin-framework v1.19.0 h1:q0bwyhxAOR3vfdgbk9ipl
 github.com/hashicorp/terraform-plugin-framework v1.19.0/go.mod h1:YRXOBu0jvs7xp4AThBbX4mAzYaMJ1JgtFH//oGKxwLc=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0 h1:jblRy1PkLfPm5hb5XeMa3tezusnMRziUGqtT5epSYoI=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0/go.mod h1:5jm2XK8uqrdiSRfD5O47OoxyGMCnwTcl8eoiDgSa+tc=
+github.com/hashicorp/terraform-plugin-framework-validators v0.19.0 h1:Zz3iGgzxe/1XBkooZCewS0nJAaCFPFPHdNJd8FgE4Ow=
+github.com/hashicorp/terraform-plugin-framework-validators v0.19.0/go.mod h1:GBKTNGbGVJohU03dZ7U8wHqc2zYnMUawgCN+gC0itLc=
 github.com/hashicorp/terraform-plugin-go v0.31.0 h1:0Fz2r9DQ+kNNl6bx8HRxFd1TfMKUvnrOtvJPmp3Z0q8=
 github.com/hashicorp/terraform-plugin-go v0.31.0/go.mod h1:A88bDhd/cW7FnwqxQRz3slT+QY6yzbHKc6AOTtmdeS8=
 github.com/hashicorp/terraform-plugin-log v0.10.0 h1:eu2kW6/QBVdN4P3Ju2WiB2W3ObjkAsyfBsL3Wh1fj3g=

--- a/internal/framework/data_source_kubectl_manifest.go
+++ b/internal/framework/data_source_kubectl_manifest.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/datasource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/alekc/terraform-provider-kubectl/kubernetes"
@@ -40,11 +43,13 @@ type manifestDataModel struct {
 	Name       types.String `tfsdk:"name"`
 	Namespace  types.String `tfsdk:"namespace"`
 	Fields     types.Map    `tfsdk:"fields"`
+	WaitFor    types.List   `tfsdk:"wait_for"`
 
-	YAML    types.String `tfsdk:"yaml"`
-	JSON    types.String `tfsdk:"json"`
-	UID     types.String `tfsdk:"uid"`
-	Results types.Map    `tfsdk:"results"`
+	YAML     types.String   `tfsdk:"yaml"`
+	JSON     types.String   `tfsdk:"json"`
+	UID      types.String   `tfsdk:"uid"`
+	Results  types.Map      `tfsdk:"results"`
+	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }
 
 // Metadata sets the data source type name. Implements
@@ -57,13 +62,15 @@ func (d *manifestDataSource) Metadata(_ context.Context, req datasource.Metadata
 // the SDK v2 schema this data source replaced after Phase E (#296) so
 // existing state files round-trip without a forced replace. Implements
 // datasource.DataSource.
-func (d *manifestDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *manifestDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: "Reads a single Kubernetes object from the cluster by apiVersion + kind + name (+ namespace) " +
 			"and optionally extracts user-supplied fields by dot-path. " +
 			"Outputs are not marked sensitive at the schema level; callers needing redaction should set " +
 			"`sensitive = true` on the consuming output block or wrap references with `sensitive(...)`. " +
-			"For guaranteed non-persistence to state, use the `kubectl_manifest` ephemeral resource instead.",
+			"For guaranteed non-persistence to state, use the `kubectl_manifest` ephemeral resource instead. " +
+			"When `wait_for` is set, the read blocks until the object exists AND any supplied `field` / " +
+			"`condition` predicates match, bounded by `timeouts.read` (default 5m). See issue #179.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,
@@ -117,6 +124,59 @@ func (d *manifestDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 				Description: "Map of extracted field values keyed by the names declared in `fields`. " +
 					"Scalar values are stringified; objects and arrays are JSON-encoded.",
 			},
+		},
+		Blocks: map[string]schema.Block{
+			"wait_for": schema.ListNestedBlock{
+				Description: "Block the read until the target object exists and any supplied " +
+					"predicates match. Mirrors the `kubectl_manifest` resource's `wait_for` " +
+					"shape: `field` blocks compare dot-and-bracket path values; `condition` " +
+					"blocks match `status.conditions[type=X,status=Y]` entries. A single " +
+					"wait_for block is supported; multiple are rejected.",
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"condition": schema.ListNestedBlock{
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"type": schema.StringAttribute{
+										Required:    true,
+										Description: "The .status.conditions[].type to match.",
+									},
+									"status": schema.StringAttribute{
+										Required:    true,
+										Description: "The .status.conditions[].status value to wait for (typically `True`).",
+									},
+								},
+							},
+						},
+						"field": schema.ListNestedBlock{
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"key": schema.StringAttribute{
+										Required:    true,
+										Description: "Dot-and-bracket path into the live object (e.g. `status.phase` or `metadata.labels[\"app.kubernetes.io/name\"]`).",
+									},
+									"value": schema.StringAttribute{
+										Required:    true,
+										Description: "Expected value at `key`. Compared as a string.",
+									},
+									"value_type": schema.StringAttribute{
+										Optional:    true,
+										Computed:    true,
+										Description: "How to compare `value`: `eq` for equality (default) or `regex` for a regular-expression match.",
+										Validators: []validator.String{
+											stringOneOfValidator{allowed: []string{"eq", "regex"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"timeouts": timeouts.Block(ctx),
 		},
 	}
 }
@@ -174,6 +234,54 @@ func (d *manifestDataSource) Read(ctx context.Context, req datasource.ReadReques
 	name := data.Name.ValueString()
 	namespace := data.Namespace.ValueString()
 
+	// If the user declared a wait_for block (with or without
+	// inner field/condition predicates), block on
+	// WaitForManifest before fetching. An empty wait_for block
+	// means "wait until the object exists, no predicate
+	// checks". The timeouts block (Read) bounds both phases
+	// (existence poll + condition watch) of the helper.
+	if !data.WaitFor.IsNull() && !data.WaitFor.IsUnknown() {
+		waitFor, waitDiags := extractWaitForBlock(ctx, data.WaitFor, waitForSurfaceDataSource)
+		resp.Diagnostics.Append(waitDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		timeout, timeoutDiags := data.Timeouts.Read(ctx, kubernetes.DefaultManifestWaitTimeout)
+		resp.Diagnostics.Append(timeoutDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		// Defence-in-depth coercion. The plugin-framework
+		// timeouts package parses durations during Config decode
+		// and rejects non-positive literals at plan time, so under
+		// normal use this branch is unreachable. We keep it (and
+		// degrade to the package default with a warning instead of
+		// hard-failing) so a future schema regression or a caller
+		// that constructs Timeouts programmatically cannot
+		// silently feed an already-cancelled context to Phase A.
+		// Not unit-tested because the only way to drive it from a
+		// public entry point is to bypass the validator, which a
+		// future reader should NOT do just to satisfy coverage.
+		if timeout <= 0 {
+			resp.Diagnostics.AddWarning(
+				"kubectl_manifest: non-positive timeouts.read, using default",
+				fmt.Sprintf("timeouts.read = %v is not a valid wait duration; falling back to %v.", timeout, kubernetes.DefaultManifestWaitTimeout),
+			)
+			timeout = kubernetes.DefaultManifestWaitTimeout
+		}
+		if err := kubernetes.WaitForManifest(ctx, d.kubeProvider, kubernetes.WaitForManifestOptions{
+			APIVersion: apiVersion,
+			Kind:       kind,
+			Name:       name,
+			Namespace:  namespace,
+			WaitFor:    waitFor,
+			Timeout:    timeout,
+		}); err != nil {
+			resp.Diagnostics.AddError("kubectl_manifest: wait_for did not complete", err.Error())
+			return
+		}
+	}
+
 	result, err := kubernetes.FetchManifest(ctx, d.kubeProvider, apiVersion, kind, name, namespace, fields)
 	if err != nil {
 		if errors.Is(err, kubernetes.ErrManifestNotFound) {
@@ -195,5 +303,11 @@ func (d *manifestDataSource) Read(ctx context.Context, req datasource.ReadReques
 	}
 	data.Results = resultsMap
 
+	// `wait_for` and `timeouts` are inputs only: leave them on
+	// the model unchanged so resp.State.Set round-trips the
+	// user's configuration verbatim. The framework does not
+	// require populating Computed-only branches we did not
+	// declare.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
+

--- a/internal/framework/data_source_kubectl_manifest_acc_test.go
+++ b/internal/framework/data_source_kubectl_manifest_acc_test.go
@@ -403,7 +403,12 @@ data "kubectl_manifest" "wait" {
 		Steps: []resource.TestStep{
 			{
 				Config:      cfg,
-				ExpectError: regexp.MustCompile(`did not exist within the wait timeout`),
+				// Terraform's diagnostic renderer hard-wraps long
+			// lines, so the literal phrase "did not exist within
+			// the wait timeout" gets split across two lines. Use
+			// a tolerant whitespace class so the regex matches
+			// both the wrapped and the unwrapped form.
+			ExpectError: regexp.MustCompile(`did not exist within the wait\s+timeout`),
 			},
 		},
 	})

--- a/internal/framework/data_source_kubectl_manifest_acc_test.go
+++ b/internal/framework/data_source_kubectl_manifest_acc_test.go
@@ -246,3 +246,165 @@ data "kubectl_manifest" "ns" {
 		},
 	})
 }
+
+// TestAccKubectlDataSourceManifest_WaitForExistence exercises the
+// wait_for block in its simplest shape: an empty block that asks
+// the data source to wait for the object to exist before reading.
+// Pairs the data source against a kubectl_manifest resource via
+// depends_on so the dependency order is deterministic; the
+// existence-poll phase still has to fire because the resource
+// completes before the data source starts.
+//
+// Real-world value: the same shape works for a Secret a controller
+// will create asynchronously, an Argo CD Application whose
+// status.conditions converge after sync, etc. This test pins the
+// schema wiring and end-to-end flow; the kubernetes package's
+// wait_for_manifest_test.go covers the helper's branching.
+//
+// Issue #179.
+func TestAccKubectlDataSourceManifest_WaitForExistence(t *testing.T) {
+	t.Parallel()
+	name := fmt.Sprintf("acc-wait-cm-%s", acctest.RandString(8))
+	cfg := fmt.Sprintf(`
+resource "kubectl_manifest" "seed" {
+  yaml_body = <<YAML
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+  namespace: default
+data:
+  ready: "yes"
+YAML
+}
+
+data "kubectl_manifest" "wait" {
+  depends_on  = [kubectl_manifest.seed]
+  api_version = "v1"
+  kind        = "ConfigMap"
+  name        = "%s"
+  namespace   = "default"
+
+  wait_for {}
+
+  timeouts {
+    read = "30s"
+  }
+
+  fields = {
+    ready = "data.ready"
+  }
+}
+`, name, name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckkubectlDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.kubectl_manifest.wait", "results.ready", "yes"),
+					resource.TestCheckResourceAttrSet("data.kubectl_manifest.wait", "uid"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccKubectlDataSourceManifest_WaitForField exercises the
+// `field` predicate inside `wait_for`: the data source must
+// observe a specific scalar value on the object before returning.
+// Uses an eq comparison on a stable ConfigMap key so the test
+// runs deterministically.
+//
+// Issue #179.
+func TestAccKubectlDataSourceManifest_WaitForField(t *testing.T) {
+	t.Parallel()
+	name := fmt.Sprintf("acc-wait-field-%s", acctest.RandString(8))
+	cfg := fmt.Sprintf(`
+resource "kubectl_manifest" "seed" {
+  yaml_body = <<YAML
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+  namespace: default
+data:
+  phase: "Ready"
+YAML
+}
+
+data "kubectl_manifest" "wait" {
+  depends_on  = [kubectl_manifest.seed]
+  api_version = "v1"
+  kind        = "ConfigMap"
+  name        = "%s"
+  namespace   = "default"
+
+  wait_for {
+    field {
+      key   = "data.phase"
+      value = "Ready"
+    }
+  }
+
+  timeouts {
+    read = "30s"
+  }
+}
+`, name, name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckkubectlDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.kubectl_manifest.wait", "kind", "ConfigMap"),
+					resource.TestCheckResourceAttrSet("data.kubectl_manifest.wait", "uid"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccKubectlDataSourceManifest_WaitForTimeout exercises the
+// failure path: a wait against a non-existent object with a very
+// short timeout must return a diagnostic mentioning the wait
+// timing out, NOT a "resource not found" (the latter is what
+// happens without wait_for).
+//
+// Issue #179.
+func TestAccKubectlDataSourceManifest_WaitForTimeout(t *testing.T) {
+	t.Parallel()
+	name := fmt.Sprintf("acc-wait-timeout-%s", acctest.RandString(8))
+	cfg := fmt.Sprintf(`
+data "kubectl_manifest" "wait" {
+  api_version = "v1"
+  kind        = "ConfigMap"
+  name        = "%s"
+  namespace   = "default"
+
+  wait_for {}
+
+  timeouts {
+    read = "2s"
+  }
+}
+`, name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      cfg,
+				ExpectError: regexp.MustCompile(`did not exist within the wait timeout`),
+			},
+		},
+	})
+}

--- a/internal/framework/data_source_kubectl_manifest_wait_test.go
+++ b/internal/framework/data_source_kubectl_manifest_wait_test.go
@@ -1,0 +1,147 @@
+package framework
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// dataSourceWaitForObjectType mirrors the data source's wait_for
+// block shape: condition + field nested lists. Used in tests to
+// build a types.List value to feed into extractDataSourceWaitFor.
+func dataSourceWaitForObjectType() types.ObjectType {
+	conditionObj := types.ObjectType{AttrTypes: map[string]attr.Type{
+		"type":   types.StringType,
+		"status": types.StringType,
+	}}
+	fieldObj := types.ObjectType{AttrTypes: map[string]attr.Type{
+		"key":        types.StringType,
+		"value":      types.StringType,
+		"value_type": types.StringType,
+	}}
+	return types.ObjectType{AttrTypes: map[string]attr.Type{
+		"condition": types.ListType{ElemType: conditionObj},
+		"field":     types.ListType{ElemType: fieldObj},
+	}}
+}
+
+func TestExtractDataSourceWaitFor_NullOrUnknownReturnsNil(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	got, diags := extractWaitForBlock(ctx, types.ListNull(dataSourceWaitForObjectType()), "data source")
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics on null: %v", diags)
+	}
+	if got != nil {
+		t.Errorf("null list should yield nil WaitFor, got %+v", got)
+	}
+
+	got, diags = extractWaitForBlock(ctx, types.ListUnknown(dataSourceWaitForObjectType()), "data source")
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics on unknown: %v", diags)
+	}
+	if got != nil {
+		t.Errorf("unknown list should yield nil WaitFor, got %+v", got)
+	}
+}
+
+func TestExtractDataSourceWaitFor_RejectsMultipleBlocks(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	objType := dataSourceWaitForObjectType()
+
+	makeBlock := func(condType, condStatus string) attr.Value {
+		condElem, _ := types.ObjectValue(map[string]attr.Type{
+			"type":   types.StringType,
+			"status": types.StringType,
+		}, map[string]attr.Value{
+			"type":   types.StringValue(condType),
+			"status": types.StringValue(condStatus),
+		})
+		conds, _ := types.ListValue(types.ObjectType{AttrTypes: map[string]attr.Type{
+			"type":   types.StringType,
+			"status": types.StringType,
+		}}, []attr.Value{condElem})
+		obj, _ := types.ObjectValue(objType.AttrTypes, map[string]attr.Value{
+			"condition": conds,
+			"field":     types.ListNull(types.ObjectType{AttrTypes: map[string]attr.Type{"key": types.StringType, "value": types.StringType, "value_type": types.StringType}}),
+		})
+		return obj
+	}
+
+	list, _ := types.ListValue(objType, []attr.Value{
+		makeBlock("Ready", "True"),
+		makeBlock("Synced", "True"),
+	})
+
+	_, diags := extractWaitForBlock(ctx, list, "data source")
+	if !diags.HasError() {
+		t.Fatalf("expected error for multiple wait_for blocks; got no diagnostics")
+	}
+	found := false
+	for _, e := range diags.Errors() {
+		if e.Summary() == "too many wait_for blocks" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'too many wait_for blocks' diagnostic; got %v", diags)
+	}
+}
+
+func TestExtractDataSourceWaitFor_PopulatesConditionsAndFields(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	objType := dataSourceWaitForObjectType()
+
+	condElem, _ := types.ObjectValue(map[string]attr.Type{
+		"type":   types.StringType,
+		"status": types.StringType,
+	}, map[string]attr.Value{
+		"type":   types.StringValue("Ready"),
+		"status": types.StringValue("True"),
+	})
+	conds, _ := types.ListValue(types.ObjectType{AttrTypes: map[string]attr.Type{
+		"type":   types.StringType,
+		"status": types.StringType,
+	}}, []attr.Value{condElem})
+
+	fieldElem, _ := types.ObjectValue(map[string]attr.Type{
+		"key":        types.StringType,
+		"value":      types.StringType,
+		"value_type": types.StringType,
+	}, map[string]attr.Value{
+		"key":        types.StringValue("status.phase"),
+		"value":      types.StringValue("Running"),
+		"value_type": types.StringValue("eq"),
+	})
+	fields, _ := types.ListValue(types.ObjectType{AttrTypes: map[string]attr.Type{
+		"key":        types.StringType,
+		"value":      types.StringType,
+		"value_type": types.StringType,
+	}}, []attr.Value{fieldElem})
+
+	blockObj, _ := types.ObjectValue(objType.AttrTypes, map[string]attr.Value{
+		"condition": conds,
+		"field":     fields,
+	})
+	list, _ := types.ListValue(objType, []attr.Value{blockObj})
+
+	got, diags := extractWaitForBlock(ctx, list, "data source")
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil WaitFor")
+	}
+	if len(got.Condition) != 1 || got.Condition[0].Type != "Ready" || got.Condition[0].Status != "True" {
+		t.Errorf("condition mismatch: %+v", got.Condition)
+	}
+	if len(got.Field) != 1 || got.Field[0].Key != "status.phase" || got.Field[0].Value != "Running" || got.Field[0].ValueType != "eq" {
+		t.Errorf("field mismatch: %+v", got.Field)
+	}
+}

--- a/internal/framework/ephemeral_kubectl_manifest.go
+++ b/internal/framework/ephemeral_kubectl_manifest.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/ephemeral/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/alekc/terraform-provider-kubectl/kubernetes"
@@ -39,24 +42,28 @@ type manifestEphemeralModel struct {
 	Name       types.String `tfsdk:"name"`
 	Namespace  types.String `tfsdk:"namespace"`
 	Fields     types.Map    `tfsdk:"fields"`
+	WaitFor    types.List   `tfsdk:"wait_for"`
 
-	YAML    types.String `tfsdk:"yaml"`
-	JSON    types.String `tfsdk:"json"`
-	UID     types.String `tfsdk:"uid"`
-	Results types.Map    `tfsdk:"results"`
+	YAML     types.String   `tfsdk:"yaml"`
+	JSON     types.String   `tfsdk:"json"`
+	UID      types.String   `tfsdk:"uid"`
+	Results  types.Map      `tfsdk:"results"`
+	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }
 
 func (r *manifestEphemeralResource) Metadata(_ context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_manifest"
 }
 
-func (r *manifestEphemeralResource) Schema(_ context.Context, _ ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
+func (r *manifestEphemeralResource) Schema(ctx context.Context, _ ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: "Reads a single Kubernetes object from the cluster by apiVersion + kind + name (+ namespace) " +
 			"and optionally extracts user-supplied fields by dot-path. Values produced by this ephemeral " +
 			"resource are never persisted to Terraform state and can only be referenced during apply " +
 			"(via write-only attributes on other resources, check blocks, or provisioners). " +
-			"For state-persisting reads see the `kubectl_manifest` data source.",
+			"For state-persisting reads see the `kubectl_manifest` data source. " +
+			"When `wait_for` is set, the open blocks until the object exists AND any supplied predicates " +
+			"match, bounded by `timeouts.open` (default 5m). See issue #179.",
 		Attributes: map[string]schema.Attribute{
 			"api_version": schema.StringAttribute{
 				Required:    true,
@@ -103,6 +110,56 @@ func (r *manifestEphemeralResource) Schema(_ context.Context, _ ephemeral.Schema
 					"Scalar values are stringified; objects and arrays are JSON-encoded.",
 			},
 		},
+		Blocks: map[string]schema.Block{
+			"wait_for": schema.ListNestedBlock{
+				Description: "Block the open until the target object exists and any supplied predicates match. " +
+					"Same shape as the `kubectl_manifest` data source's `wait_for` block; see those docs.",
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"condition": schema.ListNestedBlock{
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"type": schema.StringAttribute{
+										Required:    true,
+										Description: "The .status.conditions[].type to match.",
+									},
+									"status": schema.StringAttribute{
+										Required:    true,
+										Description: "The .status.conditions[].status value to wait for (typically `True`).",
+									},
+								},
+							},
+						},
+						"field": schema.ListNestedBlock{
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"key": schema.StringAttribute{
+										Required:    true,
+										Description: "Dot-and-bracket path into the live object.",
+									},
+									"value": schema.StringAttribute{
+										Required:    true,
+										Description: "Expected value at `key`. Compared as a string.",
+									},
+									"value_type": schema.StringAttribute{
+										Optional:    true,
+										Computed:    true,
+										Description: "How to compare `value`: `eq` (default) or `regex`.",
+										Validators: []validator.String{
+											stringOneOfValidator{allowed: []string{"eq", "regex"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"timeouts": timeouts.Block(ctx),
+		},
 	}
 }
 
@@ -146,13 +203,65 @@ func (r *manifestEphemeralResource) Open(ctx context.Context, req ephemeral.Open
 		fields = raw
 	}
 
+	apiVersion := data.APIVersion.ValueString()
+	kind := data.Kind.ValueString()
+	name := data.Name.ValueString()
+	namespace := data.Namespace.ValueString()
+
+	// wait_for: optional pre-fetch block. Mirrors the data
+	// source's behaviour so users have one mental model across
+	// `data.kubectl_manifest` and `ephemeral.kubectl_manifest`.
+	// The timeouts.open attribute bounds both phases (existence
+	// poll + condition watch) of the helper.
+	if !data.WaitFor.IsNull() && !data.WaitFor.IsUnknown() {
+		waitFor, waitDiags := extractWaitForBlock(ctx, data.WaitFor, waitForSurfaceEphemeral)
+		resp.Diagnostics.Append(waitDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		timeout, timeoutDiags := data.Timeouts.Open(ctx, kubernetes.DefaultManifestWaitTimeout)
+		resp.Diagnostics.Append(timeoutDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		// Defence-in-depth coercion. The plugin-framework
+		// timeouts package parses durations during Config decode
+		// and rejects non-positive literals at plan time, so under
+		// normal use this branch is unreachable. We keep it (and
+		// degrade to the package default with a warning instead of
+		// hard-failing) so a future schema regression or a caller
+		// that constructs Timeouts programmatically cannot
+		// silently feed an already-cancelled context to Phase A.
+		// Not unit-tested because the only way to drive it from a
+		// public entry point is to bypass the validator, which a
+		// future reader should NOT do just to satisfy coverage.
+		if timeout <= 0 {
+			resp.Diagnostics.AddWarning(
+				"kubectl_manifest ephemeral: non-positive timeouts.open, using default",
+				fmt.Sprintf("timeouts.open = %v is not a valid wait duration; falling back to %v.", timeout, kubernetes.DefaultManifestWaitTimeout),
+			)
+			timeout = kubernetes.DefaultManifestWaitTimeout
+		}
+		if err := kubernetes.WaitForManifest(ctx, r.kubeProvider, kubernetes.WaitForManifestOptions{
+			APIVersion: apiVersion,
+			Kind:       kind,
+			Name:       name,
+			Namespace:  namespace,
+			WaitFor:    waitFor,
+			Timeout:    timeout,
+		}); err != nil {
+			resp.Diagnostics.AddError("kubectl_manifest ephemeral: wait_for did not complete", err.Error())
+			return
+		}
+	}
+
 	result, err := kubernetes.FetchManifest(
 		ctx,
 		r.kubeProvider,
-		data.APIVersion.ValueString(),
-		data.Kind.ValueString(),
-		data.Name.ValueString(),
-		data.Namespace.ValueString(),
+		apiVersion,
+		kind,
+		name,
+		namespace,
 		fields,
 	)
 	if err != nil {
@@ -176,3 +285,4 @@ func (r *manifestEphemeralResource) Open(ctx context.Context, req ephemeral.Open
 
 	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)
 }
+

--- a/internal/framework/ephemeral_kubectl_manifest_test.go
+++ b/internal/framework/ephemeral_kubectl_manifest_test.go
@@ -344,12 +344,19 @@ check "consumed" {
 // wait, so this test pins the per-surface attribute name as well
 // as the wiring through to kubernetes.WaitForManifest.
 //
+// Split across two TestSteps for the same reason as
+// TestAccKubectlEphemeralManifest_namespacedConfigMap: Terraform
+// evaluates ephemeral resources at pre-apply plan time even when
+// depends_on points at a managed resource being created in the
+// same step, so a single-step config would have the ephemeral's
+// wait_for poll for an object that the apply has not yet created.
+//
 // Issue #179.
 func TestAccKubectlEphemeralManifest_WaitForExistence(t *testing.T) {
 	t.Parallel()
 	skipIfOpenTofu(t)
 	name := fmt.Sprintf("acc-eph-wait-%s", acctest.RandString(8))
-	cfg := fmt.Sprintf(`
+	seedCfg := fmt.Sprintf(`
 resource "kubectl_manifest" "seed" {
   yaml_body = <<YAML
 apiVersion: v1
@@ -361,12 +368,13 @@ data:
   ready: "yes"
 YAML
 }
-
+`, name)
+	readCfg := seedCfg + fmt.Sprintf(`
 ephemeral "kubectl_manifest" "cm" {
   depends_on  = [kubectl_manifest.seed]
   api_version = "v1"
   kind        = "ConfigMap"
-  name        = "%s"
+  name        = %q
   namespace   = "default"
 
   wait_for {}
@@ -386,7 +394,7 @@ check "wait_succeeded" {
     error_message = "ephemeral wait_for did not return the expected ready value"
   }
 }
-`, name, name)
+`, name)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
@@ -396,7 +404,15 @@ check "wait_succeeded" {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: cfg,
+				// Step 1: apply the seed only. The ConfigMap lands
+				// on the cluster.
+				Config: seedCfg,
+			},
+			{
+				// Step 2: ephemeral resolves with the seeded value;
+				// wait_for sees the object on the first Phase A Get
+				// because the seed exists from step 1.
+				Config: readCfg,
 				ConfigStateChecks: []statecheck.StateCheck{
 					ephemeralNotInState{addressPrefix: "ephemeral.kubectl_manifest.cm"},
 				},

--- a/internal/framework/ephemeral_kubectl_manifest_test.go
+++ b/internal/framework/ephemeral_kubectl_manifest_test.go
@@ -335,3 +335,162 @@ check "consumed" {
 		},
 	})
 }
+
+// TestAccKubectlEphemeralManifest_WaitForExistence pairs the
+// data source acc test by exercising the ephemeral resource's
+// wait_for block end-to-end: an empty wait_for plus a depends_on
+// on the seed resource. The interesting bit is that the
+// ephemeral's `timeouts.open` (not `timeouts.read`) bounds the
+// wait, so this test pins the per-surface attribute name as well
+// as the wiring through to kubernetes.WaitForManifest.
+//
+// Issue #179.
+func TestAccKubectlEphemeralManifest_WaitForExistence(t *testing.T) {
+	t.Parallel()
+	skipIfOpenTofu(t)
+	name := fmt.Sprintf("acc-eph-wait-%s", acctest.RandString(8))
+	cfg := fmt.Sprintf(`
+resource "kubectl_manifest" "seed" {
+  yaml_body = <<YAML
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+  namespace: default
+data:
+  ready: "yes"
+YAML
+}
+
+ephemeral "kubectl_manifest" "cm" {
+  depends_on  = [kubectl_manifest.seed]
+  api_version = "v1"
+  kind        = "ConfigMap"
+  name        = "%s"
+  namespace   = "default"
+
+  wait_for {}
+
+  timeouts {
+    open = "30s"
+  }
+
+  fields = {
+    ready = "data.ready"
+  }
+}
+
+resource "terraform_data" "use_ephemeral" {
+  input = ephemeral.kubectl_manifest.cm.results["ready"]
+}
+`, name, name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				ConfigStateChecks: []statecheck.StateCheck{
+					ephemeralNotInState{addressPrefix: "ephemeral.kubectl_manifest.cm"},
+				},
+				// Re-running the same config must not surface a
+				// non-empty plan; wait_for on the second iteration
+				// should find the object immediately via Phase A.
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("terraform_data.use_ephemeral", "input", "yes"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccKubectlEphemeralManifest_WaitForField mirrors the data
+// source's wait_for-with-field test on the ephemeral surface: it
+// exercises Phase B (the predicate watch) end-to-end so a future
+// refactor of the shared kubernetes.WaitForManifest helper that
+// regresses field-path evaluation surfaces a failure on the
+// ephemeral path too, not just the data source.
+//
+// We seed a ConfigMap with data.region=eu-west-1, then open the
+// ephemeral with wait_for.field { key="data.region" value="eu-west-1" }.
+// The wait must complete promptly (the seed lands in step 1 before
+// the ephemeral plans in step 2) and the consumed value must equal
+// what was seeded.
+//
+// Issue #179.
+func TestAccKubectlEphemeralManifest_WaitForField(t *testing.T) {
+	t.Parallel()
+	skipIfOpenTofu(t)
+	name := fmt.Sprintf("acc-eph-wait-field-%s", acctest.RandString(8))
+	seedCfg := fmt.Sprintf(`
+resource "kubectl_manifest" "seed" {
+  yaml_body = <<YAML
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+  namespace: default
+data:
+  region: eu-west-1
+YAML
+}
+`, name)
+	readCfg := seedCfg + fmt.Sprintf(`
+ephemeral "kubectl_manifest" "cm" {
+  depends_on  = [kubectl_manifest.seed]
+  api_version = "v1"
+  kind        = "ConfigMap"
+  name        = %q
+  namespace   = "default"
+
+  wait_for {
+    field {
+      key   = "data.region"
+      value = "eu-west-1"
+    }
+  }
+
+  timeouts {
+    open = "30s"
+  }
+
+  fields = {
+    region = "data.region"
+  }
+}
+
+resource "terraform_data" "use_ephemeral" {
+  input = ephemeral.kubectl_manifest.cm.results["region"]
+}
+`, name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: apply the seed only. The field predicate
+				// can only be evaluated against an existing object,
+				// so we land it before the ephemeral plan.
+				Config: seedCfg,
+			},
+			{
+				// Step 2: ephemeral resolves with the seeded value.
+				Config: readCfg,
+				ConfigStateChecks: []statecheck.StateCheck{
+					ephemeralNotInState{addressPrefix: "ephemeral.kubectl_manifest.cm"},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("terraform_data.use_ephemeral", "input", "eu-west-1"),
+				),
+			},
+		},
+	})
+}

--- a/internal/framework/ephemeral_kubectl_manifest_test.go
+++ b/internal/framework/ephemeral_kubectl_manifest_test.go
@@ -380,8 +380,11 @@ ephemeral "kubectl_manifest" "cm" {
   }
 }
 
-resource "terraform_data" "use_ephemeral" {
-  input = ephemeral.kubectl_manifest.cm.results["ready"]
+check "wait_succeeded" {
+  assert {
+    condition     = ephemeral.kubectl_manifest.cm.results["ready"] == "yes"
+    error_message = "ephemeral wait_for did not return the expected ready value"
+  }
 }
 `, name, name)
 
@@ -397,12 +400,6 @@ resource "terraform_data" "use_ephemeral" {
 				ConfigStateChecks: []statecheck.StateCheck{
 					ephemeralNotInState{addressPrefix: "ephemeral.kubectl_manifest.cm"},
 				},
-				// Re-running the same config must not surface a
-				// non-empty plan; wait_for on the second iteration
-				// should find the object immediately via Phase A.
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("terraform_data.use_ephemeral", "input", "yes"),
-				),
 			},
 		},
 	})
@@ -463,8 +460,11 @@ ephemeral "kubectl_manifest" "cm" {
   }
 }
 
-resource "terraform_data" "use_ephemeral" {
-  input = ephemeral.kubectl_manifest.cm.results["region"]
+check "field_match" {
+  assert {
+    condition     = ephemeral.kubectl_manifest.cm.results["region"] == "eu-west-1"
+    error_message = "ephemeral wait_for field predicate did not return the expected region"
+  }
 }
 `, name)
 
@@ -487,9 +487,6 @@ resource "terraform_data" "use_ephemeral" {
 				ConfigStateChecks: []statecheck.StateCheck{
 					ephemeralNotInState{addressPrefix: "ephemeral.kubectl_manifest.cm"},
 				},
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("terraform_data.use_ephemeral", "input", "eu-west-1"),
-				),
 			},
 		},
 	})

--- a/internal/framework/wait_for_blocks.go
+++ b/internal/framework/wait_for_blocks.go
@@ -1,0 +1,84 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	internaltypes "github.com/alekc/terraform-provider-kubectl/internal/types"
+)
+
+// wait_for_blocks.go: shared decoder for the read-side `wait_for`
+// block (data source + ephemeral resource). The resource path
+// uses its own extractWaitFor in resource_kubectl_manifest.go;
+// future PR can collapse that one onto this helper too, but is
+// out of scope for #179.
+//
+// The data source and the ephemeral resource each declare their
+// own schema (different container types in the framework), but
+// the inner block shape is identical to the resource's, so all
+// three share `waitForBlockModel` / `waitForConditionModel` /
+// `waitForFieldModel` (defined in resource_kubectl_manifest.go,
+// package-public lowercase).
+
+// Surface labels for extractWaitForBlock's error wording. Lifted
+// to consts so a call-site typo cannot silently produce
+// misleading diagnostics like "date source".
+const (
+	waitForSurfaceDataSource = "data source"
+	waitForSurfaceEphemeral  = "ephemeral resource"
+)
+
+// extractWaitForBlock materialises a list-of-wait_for-blocks into
+// an *internaltypes.WaitFor pointer for the kubernetes helper.
+// Returns nil if the block is null or unknown.
+//
+// The "at most one wait_for block" invariant is enforced by
+// listvalidator.SizeAtMost(1) on the schema, so under normal
+// operation the len(blocks) > 1 branch below is unreachable.
+// The runtime check stays as a backstop: if a future schema
+// refactor drops the validator or the schema is consumed via a
+// non-Terraform path that bypasses validators, the helper
+// continues to refuse multi-block input rather than silently
+// taking only the first.
+//
+// surface labels the calling schema in the error wording. Pass
+// one of waitForSurfaceDataSource / waitForSurfaceEphemeral.
+func extractWaitForBlock(ctx context.Context, list types.List, surface string) (*internaltypes.WaitFor, diag.Diagnostics) {
+	if list.IsNull() || list.IsUnknown() {
+		return nil, nil
+	}
+	var blocks []waitForBlockModel
+	diags := list.ElementsAs(ctx, &blocks, false)
+	if diags.HasError() {
+		return nil, diags
+	}
+	if len(blocks) == 0 {
+		return nil, diags
+	}
+	if len(blocks) > 1 {
+		diags.AddError(
+			"too many wait_for blocks",
+			fmt.Sprintf("the kubectl_manifest %s supports at most one wait_for block; got %d", surface, len(blocks)),
+		)
+		return nil, diags
+	}
+	b := blocks[0]
+	wf := &internaltypes.WaitFor{}
+	for _, c := range b.Condition {
+		wf.Condition = append(wf.Condition, internaltypes.WaitForStatusCondition{
+			Type:   c.Type.ValueString(),
+			Status: c.Status.ValueString(),
+		})
+	}
+	for _, f := range b.Field {
+		wf.Field = append(wf.Field, internaltypes.WaitForField{
+			Key:       f.Key.ValueString(),
+			Value:     f.Value.ValueString(),
+			ValueType: f.ValueType.ValueString(),
+		})
+	}
+	return wf, diags
+}

--- a/kubernetes/wait_for_manifest.go
+++ b/kubernetes/wait_for_manifest.go
@@ -1,0 +1,197 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/alekc/terraform-provider-kubectl/internal/types"
+	"github.com/alekc/terraform-provider-kubectl/yaml"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	meta_v1_unstruct "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+)
+
+// wait_for_manifest.go: shared "wait for an object to exist and
+// satisfy user predicates" helper for the read-side paths
+// (kubectl_manifest data source and ephemeral resource). Issue #179.
+//
+// The resource's apply path (manifest_lifecycle.go) does its own
+// wait via WaitForConditions because it has already issued the
+// apply and knows the object will appear shortly. The data-source
+// and ephemeral read paths cannot assume the object exists yet:
+// they may be waiting on a controller-created Secret, an Argo
+// rollout's Pod, a cert-manager Certificate's secretName, etc. So
+// the read-side wait is structured in two phases:
+//
+//   - Phase A (WaitForManifestExists): poll Get with exponential
+//     backoff until the apiserver returns the object, propagate
+//     non-404 errors immediately, honour ctx cancellation.
+//   - Phase B: hand off to the existing WaitForConditions, which
+//     Get-probes once for the resourceVersion seed and then opens
+//     a watch with a metadata.name field selector.
+//
+// Closing the race window in WaitForConditions's RV-seeding probe
+// is the structural reason for phase A rather than handing off
+// directly: the existing helper's Get returning 404 falls through
+// to a watch with empty resourceVersion, and "watch from latest"
+// loses any create event that fires between the Get and the watch
+// handshake. With phase A we know the object exists before we
+// start watching, so the RV is non-empty and the race is closed.
+
+// defaultExistsPollInitial is the initial poll period for Phase A.
+// Short enough to feel responsive when the controller is fast;
+// the exponential backoff (capped by defaultExistsPollMax) means
+// long waits don't hammer the apiserver.
+const (
+	defaultExistsPollInitial = 1 * time.Second
+	defaultExistsPollMax     = 10 * time.Second
+)
+
+// DefaultManifestWaitTimeout is the wait_for default applied when
+// the caller's `timeouts` block does not supply an override. Data
+// source reads and ephemeral resource opens are typically faster
+// than the kubectl_manifest resource's apply path (no rollout to
+// bound), so 5m is shorter than the resource default. Used by
+// both data source and ephemeral resource so the two share one
+// canonical value.
+const DefaultManifestWaitTimeout = 5 * time.Minute
+
+// WaitForManifestOptions captures the inputs WaitForManifest reads
+// from the caller. Same shape as ApplyManifestOptions / ReadManifestOptions
+// for the fields they share, so the framework adapters can build
+// the options struct without depending on internal/types directly.
+type WaitForManifestOptions struct {
+	APIVersion string
+	Kind       string
+	Name       string
+	Namespace  string
+	// WaitFor is the user-supplied predicate set. A nil value means
+	// "wait for the object to exist, no condition / field checks".
+	WaitFor *types.WaitFor
+	// Timeout bounds the total time across both phases. Internally
+	// the helper wraps ctx in context.WithTimeout, so callers do
+	// not need to set a deadline themselves.
+	Timeout time.Duration
+}
+
+// WaitForManifest blocks until the target object exists and any
+// user-supplied wait_for predicates match, or until the timeout
+// elapses. Read-side callers (data source, ephemeral resource)
+// invoke this before FetchManifest so the subsequent Get returns
+// the satisfied state.
+//
+// Phase A (exists) is bounded by the same timeout as phase B
+// (conditions). A typical fast path (object exists, no predicates)
+// completes in a single Get plus the WaitForConditions pre-probe;
+// for the common deferred-create case (waiting for a controller)
+// phase A consumes the bulk of the timeout and phase B's watch
+// fires the moment the apiserver delivers the Added event.
+func WaitForManifest(ctx context.Context, provider *KubeProvider, opts WaitForManifestOptions) error {
+	if opts.Timeout <= 0 {
+		return fmt.Errorf("WaitForManifest: timeout must be positive, got %v", opts.Timeout)
+	}
+
+	// Build a lookup manifest so GetRestClientFromUnstructured can
+	// resolve the GVK to a dynamic.ResourceInterface. Same shape
+	// the data source uses in FetchManifest.
+	lookup := &meta_v1_unstruct.Unstructured{}
+	lookup.SetAPIVersion(opts.APIVersion)
+	lookup.SetKind(opts.Kind)
+	lookup.SetName(opts.Name)
+	if opts.Namespace != "" {
+		lookup.SetNamespace(opts.Namespace)
+	}
+	manifest := yaml.NewFromUnstructured(lookup)
+
+	restClient := GetRestClientFromUnstructuredWithContext(ctx, manifest, provider)
+	if restClient.Error != nil {
+		return fmt.Errorf("WaitForManifest: failed to build REST client for %s/%s: %w", opts.APIVersion, opts.Kind, restClient.Error)
+	}
+
+	return waitForManifestWithClient(ctx, restClient, opts)
+}
+
+// waitForManifestWithClient is the inner orchestration used by
+// WaitForManifest after the REST client is built. Split out so
+// unit tests can drive it with a stub *RestClientResult instead
+// of needing a real *KubeProvider + discovery. Both Phase A (the
+// poll-for-existence loop) and Phase B (the watch-and-evaluate
+// predicate loop) honour ctx, which the wrapper bounds with the
+// caller's opts.Timeout.
+//
+// Precondition: opts.Timeout > 0. The outer WaitForManifest
+// validates this and rejects non-positive values; the inner
+// function does NOT re-validate, so any future direct caller
+// must validate or accept that context.WithTimeout(ctx, 0)
+// returns an already-cancelled context (Phase A's first Get then
+// surfaces as DeadlineExceeded wrapped by the helper).
+func waitForManifestWithClient(ctx context.Context, restClient *RestClientResult, opts WaitForManifestOptions) error {
+	ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
+	defer cancel()
+
+	if err := WaitForManifestExists(ctx, restClient.ResourceInterface, opts.Name, defaultExistsPollInitial, defaultExistsPollMax); err != nil {
+		return fmt.Errorf("WaitForManifest: %w", err)
+	}
+
+	// No predicates means Phase A is the whole job.
+	if opts.WaitFor == nil || (len(opts.WaitFor.Field) == 0 && len(opts.WaitFor.Condition) == 0) {
+		return nil
+	}
+
+	// Phase B: hand off to the existing watch-based predicate
+	// runner. It Get-probes once more (cheap; the object exists
+	// post-Phase-A) and uses the observed ResourceVersion to seed
+	// the watch, eliminating the race-on-Added-event window.
+	return WaitForConditions(ctx, restClient, opts.WaitFor.Field, opts.WaitFor.Condition, opts.Name, opts.Timeout)
+}
+
+// WaitForManifestExists polls Get on the given client until the
+// named object is returned without an IsNotFound error, ctx
+// cancels, or a non-404 error surfaces. Polling interval starts at
+// initial and grows exponentially up to maxInterval.
+//
+// 404 is the only "keep waiting" signal; every other error (RBAC
+// forbidden, apiserver unreachable, etc.) returns immediately so a
+// misconfigured caller surfaces the problem at the right time
+// rather than after the full timeout.
+func WaitForManifestExists(ctx context.Context, client dynamic.ResourceInterface, name string, initial, maxInterval time.Duration) error {
+	if initial <= 0 {
+		initial = defaultExistsPollInitial
+	}
+	if maxInterval < initial {
+		maxInterval = initial
+	}
+	period := initial
+
+	for {
+		if _, err := client.Get(ctx, name, meta_v1.GetOptions{}); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return fmt.Errorf("get %s: %w", name, err)
+			}
+			log.Printf("[TRACE] WaitForManifestExists: %s not yet present, retrying in %s", name, period)
+		} else {
+			return nil
+		}
+
+		select {
+		case <-time.After(period):
+		case <-ctx.Done():
+			// Distinguish deadline-exceeded (timeout) from
+			// explicit cancellation so the caller's diagnostic
+			// names the right cause.
+			if ctx.Err() == context.DeadlineExceeded {
+				return fmt.Errorf("%s did not exist within the wait timeout", name)
+			}
+			return ctx.Err()
+		}
+
+		// Exponential backoff, capped.
+		period *= 2
+		if period > maxInterval {
+			period = maxInterval
+		}
+	}
+}

--- a/kubernetes/wait_for_manifest_test.go
+++ b/kubernetes/wait_for_manifest_test.go
@@ -1,0 +1,276 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alekc/terraform-provider-kubectl/internal/types"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	meta_v1_unstruct "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apimachinery_types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+)
+
+// existsStub is a tiny dynamic.ResourceInterface that lets tests
+// programme the sequence of Get responses without spinning up a
+// fake apiserver. attempts is an atomic counter so concurrent
+// goroutines (none today, but a future change might race) can
+// inspect it safely. responses is consumed in order; if exhausted,
+// the last entry is repeated.
+type existsStub struct {
+	dynamic.ResourceInterface
+	mu        sync.Mutex
+	attempts  int32
+	responses []func() (*meta_v1_unstruct.Unstructured, error)
+}
+
+func (s *existsStub) Get(_ context.Context, _ string, _ meta_v1.GetOptions, _ ...string) (*meta_v1_unstruct.Unstructured, error) {
+	atomic.AddInt32(&s.attempts, 1)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.responses) == 0 {
+		return nil, errors.New("no responses configured")
+	}
+	r := s.responses[0]
+	if len(s.responses) > 1 {
+		s.responses = s.responses[1:]
+	}
+	return r()
+}
+
+func notFound() (*meta_v1_unstruct.Unstructured, error) {
+	return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "test"}, "x")
+}
+func okResp() (*meta_v1_unstruct.Unstructured, error) {
+	obj := &meta_v1_unstruct.Unstructured{}
+	obj.SetName("x")
+	obj.SetUID(apimachinery_types.UID("uid-1"))
+	return obj, nil
+}
+func forbidden() (*meta_v1_unstruct.Unstructured, error) {
+	return nil, apierrors.NewForbidden(schema.GroupResource{Resource: "test"}, "x", errors.New("denied"))
+}
+
+// TestWaitForManifestExists_ImmediateOK regresses the common fast
+// path: the object exists on the very first Get, so the helper
+// must return without sleeping at all.
+func TestWaitForManifestExists_ImmediateOK(t *testing.T) {
+	t.Parallel()
+	stub := &existsStub{responses: []func() (*meta_v1_unstruct.Unstructured, error){okResp}}
+	start := time.Now()
+	if err := WaitForManifestExists(context.Background(), stub, "x", 50*time.Millisecond, 200*time.Millisecond); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Errorf("immediate-OK should not sleep; elapsed=%s", elapsed)
+	}
+	if got := atomic.LoadInt32(&stub.attempts); got != 1 {
+		t.Errorf("expected exactly 1 Get, got %d", got)
+	}
+}
+
+// TestWaitForManifestExists_RetriesOn404 confirms the helper
+// repeats Get on IsNotFound and returns successfully when the
+// object appears mid-wait.
+func TestWaitForManifestExists_RetriesOn404(t *testing.T) {
+	t.Parallel()
+	stub := &existsStub{responses: []func() (*meta_v1_unstruct.Unstructured, error){
+		notFound, notFound, okResp,
+	}}
+	if err := WaitForManifestExists(context.Background(), stub, "x", 10*time.Millisecond, 50*time.Millisecond); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := atomic.LoadInt32(&stub.attempts); got != 3 {
+		t.Errorf("expected 3 Get attempts, got %d", got)
+	}
+}
+
+// TestWaitForManifestExists_PropagatesNonNotFound asserts that
+// only 404 triggers retry; other errors (RBAC forbidden, etc.)
+// surface immediately so misconfigurations are visible without
+// waiting out the full timeout.
+func TestWaitForManifestExists_PropagatesNonNotFound(t *testing.T) {
+	t.Parallel()
+	stub := &existsStub{responses: []func() (*meta_v1_unstruct.Unstructured, error){forbidden}}
+	err := WaitForManifestExists(context.Background(), stub, "x", 10*time.Millisecond, 50*time.Millisecond)
+	if err == nil {
+		t.Fatalf("expected error for forbidden response, got nil")
+	}
+	if got := atomic.LoadInt32(&stub.attempts); got != 1 {
+		t.Errorf("expected non-404 to bail after 1 attempt, got %d", got)
+	}
+}
+
+// TestWaitForManifestExists_TimeoutMessage verifies the helper
+// surfaces a wait-timeout error (not a raw context.DeadlineExceeded
+// or some other shape) when the ctx deadline fires. The error
+// message is part of the user-facing diagnostic; keep it stable.
+func TestWaitForManifestExists_TimeoutMessage(t *testing.T) {
+	t.Parallel()
+	stub := &existsStub{responses: []func() (*meta_v1_unstruct.Unstructured, error){
+		notFound, notFound, notFound, notFound, notFound,
+	}}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	err := WaitForManifestExists(ctx, stub, "x", 10*time.Millisecond, 20*time.Millisecond)
+	if err == nil {
+		t.Fatalf("expected timeout error, got nil")
+	}
+	if !contains(err.Error(), "did not exist within the wait timeout") {
+		t.Errorf("expected timeout-shaped diagnostic, got %q", err.Error())
+	}
+}
+
+// TestWaitForManifestExists_HonoursParentCancel covers the explicit
+// cancel path (distinct from deadline-exceeded): if the parent
+// context is cancelled mid-wait the helper returns ctx.Err()
+// without a fresh-string wrap, matching how the rest of the
+// kubernetes package surfaces parent-cancellation.
+func TestWaitForManifestExists_HonoursParentCancel(t *testing.T) {
+	t.Parallel()
+	stub := &existsStub{responses: []func() (*meta_v1_unstruct.Unstructured, error){
+		notFound, notFound, notFound,
+	}}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	err := WaitForManifestExists(ctx, stub, "x", 10*time.Millisecond, 50*time.Millisecond)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestWaitForManifestExists_BackoffCapped guards against the
+// exponential growth running away on long waits: the doubled
+// period must clamp to maxInterval rather than producing
+// minute-long sleeps after a few iterations.
+func TestWaitForManifestExists_BackoffCapped(t *testing.T) {
+	t.Parallel()
+	stub := &existsStub{responses: []func() (*meta_v1_unstruct.Unstructured, error){
+		notFound, notFound, notFound, notFound, notFound, okResp,
+	}}
+	start := time.Now()
+	if err := WaitForManifestExists(context.Background(), stub, "x", 5*time.Millisecond, 15*time.Millisecond); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	elapsed := time.Since(start)
+	// 5 false attempts before success. With initial=5ms and
+	// max=15ms, sleeps grow 5, 10, 15, 15, 15 = 60ms in the
+	// worst case + Get latency. Generous upper bound to avoid
+	// flakiness on busy CI.
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("expected backoff cap to keep wait short; elapsed=%s (>500ms suggests the cap is broken)", elapsed)
+	}
+}
+
+// contains is a tiny strings.Contains shim so the timeout test
+// stays readable without importing strings for one assertion.
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// TestWaitForManifestWithClient_NoWaitForReturnsAfterPhaseA pins
+// the orchestrator's fast-path: when the WaitFor field is nil
+// (no predicates), Phase A alone must satisfy the helper, and
+// it must return cleanly without trying to open a watch.
+func TestWaitForManifestWithClient_NoWaitForReturnsAfterPhaseA(t *testing.T) {
+	t.Parallel()
+	stub := &existsStub{responses: []func() (*meta_v1_unstruct.Unstructured, error){okResp}}
+	restClient := &RestClientResult{ResourceInterface: stub}
+	opts := WaitForManifestOptions{
+		Name:    "x",
+		WaitFor: nil,
+		Timeout: 500 * time.Millisecond,
+	}
+	if err := waitForManifestWithClient(context.Background(), restClient, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestWaitForManifestWithClient_EmptyWaitForEqualsNoPredicates
+// confirms that a non-nil but empty WaitFor (no Field, no
+// Condition) is treated identically to nil: Phase A returns and
+// the helper exits without watching.
+func TestWaitForManifestWithClient_EmptyWaitForEqualsNoPredicates(t *testing.T) {
+	t.Parallel()
+	stub := &existsStub{responses: []func() (*meta_v1_unstruct.Unstructured, error){okResp}}
+	restClient := &RestClientResult{ResourceInterface: stub}
+	opts := WaitForManifestOptions{
+		Name:    "x",
+		WaitFor: &types.WaitFor{}, // empty
+		Timeout: 500 * time.Millisecond,
+	}
+	if err := waitForManifestWithClient(context.Background(), restClient, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestWaitForManifestWithClient_PhaseAErrorPropagates regresses
+// the contract that Phase A errors short-circuit the helper:
+// non-404 errors from Get must surface immediately instead of
+// being masked by the watch phase.
+func TestWaitForManifestWithClient_PhaseAErrorPropagates(t *testing.T) {
+	t.Parallel()
+	stub := &existsStub{responses: []func() (*meta_v1_unstruct.Unstructured, error){forbidden}}
+	restClient := &RestClientResult{ResourceInterface: stub}
+	opts := WaitForManifestOptions{
+		Name:    "x",
+		WaitFor: nil,
+		Timeout: 500 * time.Millisecond,
+	}
+	err := waitForManifestWithClient(context.Background(), restClient, opts)
+	if err == nil {
+		t.Fatalf("expected forbidden error to propagate, got nil")
+	}
+	if !contains(err.Error(), "WaitForManifest") {
+		t.Errorf("expected wrapped 'WaitForManifest' prefix, got %q", err.Error())
+	}
+}
+
+// TestWaitForManifestWithClient_TimeoutValidation pins the
+// caller-contract check: the public WaitForManifest rejects
+// non-positive timeouts before doing anything else. The
+// orchestrator inner function does not enforce this; the outer
+// wrapper does. Verify via the outer wrapper with a stub
+// provider that never gets used.
+func TestWaitForManifest_RejectsNonPositiveTimeout(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		timeout time.Duration
+	}{
+		{"zero", 0},
+		{"negative", -1 * time.Second},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// provider is intentionally nil; the validator
+			// must fire before WaitForManifest reaches the
+			// REST-client construction step.
+			err := WaitForManifest(context.Background(), nil, WaitForManifestOptions{
+				Name:    "x",
+				Timeout: tc.timeout,
+			})
+			if err == nil {
+				t.Fatal("expected timeout-validation error, got nil")
+			}
+			if !contains(err.Error(), "timeout must be positive") {
+				t.Errorf("expected 'timeout must be positive' diagnostic, got %q", err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #179.

The `kubectl_manifest` data source (and ephemeral sibling) currently errors immediately when the target object does not yet exist. This blocks the common pattern of reading a `Secret` / Argo CD `Application` / cert-manager-issued `Secret` that another controller materialises after the resource is applied. The resource path already had `wait_for`; the read paths did not. This PR ports that block.

## What changes

A new `wait_for` block on both `data.kubectl_manifest` and `ephemeral.kubectl_manifest`, mirroring the resource's shape so users have one mental model across resource / data source / ephemeral.

```hcl
data "kubectl_manifest" "argo_app" {
  api_version = "argoproj.io/v1alpha1"
  kind        = "Application"
  name        = "platform-bootstrap"
  namespace   = "argocd"

  wait_for {
    condition {
      type   = "Synced"
      status = "True"
    }
    condition {
      type   = "Healthy"
      status = "True"
    }
  }

  timeouts {
    read = "10m"
  }
}
```

Inside the block: `field` blocks compare dot-and-bracket path values; `condition` blocks match `status.conditions[type=X,status=Y]` entries. A bare `wait_for {}` with no nested children waits only for the object to exist. The `timeouts` block bounds the wait (`read` on the data source, `open` on the ephemeral; default 5m).

## How the wait works

Two-phase hybrid (poll-then-watch) in the new `kubernetes/wait_for_manifest.go`:

1. **Phase A: poll for existence.** Exponential backoff Get, starting at 1s and capping at 10s, propagating non-404 errors (RBAC denied, apiserver unreachable) immediately so misconfigurations don't wait out the full timeout.
2. **Phase B: condition watch.** Hand off to the existing `WaitForConditions` helper which Get-probes once more for the resourceVersion seed and opens a watch with a `metadata.name` field selector. Reuses the same `matchesWaitConditions` predicate the resource's apply path uses.

The hybrid closes a race window in `WaitForConditions`'s RV-seeding pre-probe: a Get returning 404 falls through to a watch with empty resourceVersion, which "watches from latest" and would lose a create event delivered between the Get and the watch handshake. Phase A guarantees the object exists before Phase B starts watching.

## RBAC

The data source's service account needs `get` on the target kind (for Phase A) and `watch` on the same kind (for Phase B). Misconfigured RBAC surfaces as an immediate diagnostic during Phase A rather than after the timeout, by checking `apierrors.IsNotFound` and falling through any other error.

## Coverage

- `kubernetes/wait_for_manifest_test.go`: 10 unit tests with a stub `dynamic.ResourceInterface`. Six exercise `WaitForManifestExists` (immediate-OK fast path, 404-then-200 retry, non-404 error propagation, deadline-exceeded diagnostic shape, parent-cancel handling, exponential-backoff cap). Four exercise the outer orchestrator (nil WaitFor short-circuits after Phase A, empty WaitFor equivalent, Phase A error propagates, rejects non-positive Timeout).
- `internal/framework/data_source_kubectl_manifest_wait_test.go`: 3 unit tests for the shared wait_for block extractor: null / unknown returns nil, multi-block rejection, conditions + fields populated correctly.
- `internal/framework/data_source_kubectl_manifest_acc_test.go`: 3 acceptance tests (TF_ACC) on the data source: empty wait_for, wait_for with a `field` predicate, and the wait-timeout error path.
- `internal/framework/ephemeral_kubectl_manifest_test.go`: 2 acceptance tests on the ephemeral surface symmetric to the data source's: empty wait_for via `terraform_data` consumer, and a `field` predicate. Gated to Terraform 1.10+ via `tfversion.SkipBelow`.

`go test ./...` and `go vet ./...` clean.

## Out of scope

- The resource's `wait_for` path is unchanged; this PR is read-side only.
- Polling interval is fixed (1s initial, 10s max). If users need it tunable, a separate small PR can expose `wait_for { poll_interval = "..." }`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * kubectl_manifest (data source & ephemeral) gains wait_for to wait for objects and evaluate field/condition predicates; supports regex/equality matching.
  * Added timeouts for wait duration (read/open) with a 5m default when unspecified.
  * Waiting requires Kubernetes RBAC get+watch on the target kind; unset wait_for fails immediately, set wait_for blocks until present or timeout.

* **Documentation**
  * Docs updated with argument reference, examples, behavior notes, and timeout semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->