### PR TITLE
refactor(apply): extract testable apply-retry helper and cover it

### DIFF
--- a/kubernetes/manifest_lifecycle.go
+++ b/kubernetes/manifest_lifecycle.go
@@ -101,6 +101,73 @@ type ApplyManifestResult struct {
 	Drift string
 }
 
+// Apply-retry backoff tuning. InitialInterval is the first inter-retry
+// sleep; MaxInterval is the hard ceiling (see newApplyBackoff for why it
+// is hard rather than jittered). Named so the docs and the unit tests
+// reference one source of truth rather than re-stating the literals.
+const (
+	applyRetryInitialInterval = 3 * time.Second
+	applyRetryMaxInterval     = 30 * time.Second
+)
+
+// newApplyBackoff builds the exponential backoff used between apply
+// retries. Two deliberate deviations from the library defaults:
+//
+//   - RandomizationFactor = 0 makes MaxInterval a hard ceiling. The
+//     default 0.5 jitter is applied AFTER MaxInterval clamps the base
+//     interval, so NextBackOff could otherwise return up to 1.5 *
+//     MaxInterval; users tuning apply_retry_count expect the documented
+//     30s ceiling to actually hold.
+//   - MaxElapsedTime = 0 disables the wall-clock stop condition so the
+//     WithMaxRetries wrapper is the sole loop bound. The default 15m
+//     would silently truncate retries on slow clusters with large N.
+func newApplyBackoff() *backoff.ExponentialBackOff {
+	exp := backoff.NewExponentialBackOff()
+	exp.InitialInterval = applyRetryInitialInterval
+	exp.MaxInterval = applyRetryMaxInterval
+	exp.RandomizationFactor = 0
+	exp.MaxElapsedTime = 0
+	return exp
+}
+
+// runWithApplyRetry runs op subject to the apply retry policy. When
+// retryCount == 0 it runs op exactly once with no backoff wrapper (issue
+// #228: avoid double-spending the rate-limit budget when retry is not
+// wanted). When retryCount > 0 it wraps op in exponential backoff bounded
+// by retryCount ADDITIONAL attempts (so worst case is retryCount + 1
+// total runs) and cancellable via ctx, so a Ctrl-C / resource timeout /
+// plan abort interrupts the inter-retry sleep instead of waiting out the
+// full backoff window.
+//
+// Extracted from ApplyManifest so the retry control flow (single-shot
+// short-circuit, attempt bound, ctx-cancel during sleep, 30s ceiling) is
+// unit-testable without a cluster: op is any func() error.
+func runWithApplyRetry(ctx context.Context, retryCount uint64, op func() error) error {
+	return runWithApplyRetryPolicy(ctx, retryCount, newApplyBackoff(), op)
+}
+
+// runWithApplyRetryPolicy is the testable core of runWithApplyRetry. It
+// takes the base backoff explicitly so unit tests can inject a
+// zero-interval policy and exercise the attempt bound and ctx-cancel
+// behaviour without sleeping for the production 3s..30s intervals. The
+// base argument is ignored when retryCount == 0 (single-shot path).
+func runWithApplyRetryPolicy(ctx context.Context, retryCount uint64, base backoff.BackOff, op func() error) error {
+	if retryCount == 0 {
+		return op()
+	}
+	policy := backoff.WithContext(
+		backoff.WithMaxRetries(base, retryCount),
+		ctx,
+	)
+	return backoff.Retry(func() error {
+		if err := op(); err != nil {
+			log.Printf("[ERROR] applying manifest failed: %+v", err)
+			return err
+		}
+		return nil
+	}, policy)
+}
+
 // ApplyManifest runs `kubectl apply` against the given manifest, optionally
 // waits for rollout / user-supplied conditions, and returns the final state
 // the caller should persist.
@@ -217,45 +284,11 @@ func ApplyManifest(ctx context.Context, provider *KubeProvider, opts ApplyManife
 		return nil
 	}
 
-	if provider.ApplyRetryCount == 0 {
-		if err := applyAndFetch(); err != nil {
-			return nil, err
-		}
-	} else {
-		exp := backoff.NewExponentialBackOff()
-		exp.InitialInterval = 3 * time.Second
-		exp.MaxInterval = 30 * time.Second
-		// RandomizationFactor = 0 makes MaxInterval a hard ceiling.
-		// Default 0.5 jitter is applied after MaxInterval clamps the
-		// base interval, so NextBackOff can return up to 1.5 *
-		// MaxInterval; users tuning apply_retry_count expect the
-		// documented 30s ceiling to actually hold.
-		exp.RandomizationFactor = 0
-		// MaxElapsedTime = 0 disables the wall-clock stop condition so
-		// WithMaxRetries below is the only thing bounding the loop.
-		// Default 15 minutes would silently truncate retries on slow
-		// clusters with large N.
-		exp.MaxElapsedTime = 0
-		// WithContext makes a cancelled ctx (Ctrl-C, resource timeout,
-		// parent plan abort) interrupt the inter-retry sleep instead
-		// of waiting out the full backoff window. Without this wrap,
-		// backoff.Retry's internal getContext falls back to
-		// context.Background() and a user who hits Ctrl-C during a
-		// 30s backoff would hang for the remainder of that sleep.
-		policy := backoff.WithContext(
-			backoff.WithMaxRetries(exp, provider.ApplyRetryCount),
-			ctx,
-		)
-		retryErr := backoff.Retry(func() error {
-			if err := applyAndFetch(); err != nil {
-				log.Printf("[ERROR] applying manifest failed: %+v", err)
-				return err
-			}
-			return nil
-		}, policy)
-		if retryErr != nil {
-			return nil, retryErr
-		}
+	// Retry orchestration (single-shot vs bounded exponential backoff,
+	// ctx-cancellable) lives in runWithApplyRetry so it is unit-testable
+	// without a cluster. applyAndFetch is the per-attempt operation.
+	if err := runWithApplyRetry(ctx, provider.ApplyRetryCount, applyAndFetch); err != nil {
+		return nil, err
 	}
 	response := yaml.NewFromUnstructured(rawResponse)
 

--- a/kubernetes/manifest_retry_test.go
+++ b/kubernetes/manifest_retry_test.go
@@ -1,0 +1,155 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	backoff "github.com/cenkalti/backoff/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// zeroBackoff returns a backoff that never sleeps, so the retry tests
+// below exercise the attempt-count and ctx-cancel control flow without
+// waiting for the production 3s..30s intervals.
+func zeroBackoff() backoff.BackOff { return backoff.NewConstantBackOff(0) }
+
+// TestNewApplyBackoff_Tuning locks in the two deliberate deviations from
+// the library defaults that the apply retry contract depends on: a hard
+// 30s ceiling (RandomizationFactor 0, so no jitter pushes a sleep past
+// MaxInterval) and no wall-clock stop (MaxElapsedTime 0, so WithMaxRetries
+// is the sole loop bound). A regression here silently changes documented
+// retry behaviour, so assert the fields directly.
+func TestNewApplyBackoff_Tuning(t *testing.T) {
+	b := newApplyBackoff()
+	assert.Equal(t, applyRetryInitialInterval, b.InitialInterval, "initial interval")
+	assert.Equal(t, applyRetryMaxInterval, b.MaxInterval, "max interval")
+	assert.Equal(t, 3*time.Second, b.InitialInterval, "initial interval literal")
+	assert.Equal(t, 30*time.Second, b.MaxInterval, "max interval literal")
+	assert.Zero(t, b.RandomizationFactor, "randomization factor must be 0 for a hard ceiling")
+	assert.Zero(t, b.MaxElapsedTime, "max elapsed time must be 0 so WithMaxRetries bounds the loop")
+}
+
+// TestNewApplyBackoff_HardCeiling drives NextBackOff far past the point
+// where the exponential base would exceed MaxInterval and asserts the
+// returned sleep never exceeds the 30s ceiling. With RandomizationFactor
+// 0 the cap is exact; the default 0.5 jitter would allow up to 1.5x.
+func TestNewApplyBackoff_HardCeiling(t *testing.T) {
+	b := newApplyBackoff()
+	b.Reset()
+	for i := 0; i < 50; i++ {
+		next := b.NextBackOff()
+		require.NotEqual(t, backoff.Stop, next, "MaxElapsedTime=0 must not stop the backoff")
+		assert.LessOrEqual(t, next, applyRetryMaxInterval, "sleep must never exceed the 30s ceiling")
+	}
+}
+
+// TestRunWithApplyRetry_ZeroCountSingleShotOnError is the issue #228
+// contract: retryCount 0 runs the operation exactly once and does NOT
+// retry, even when it fails. The single-shot path must not spend the
+// rate-limit budget on a retry the user disabled.
+func TestRunWithApplyRetry_ZeroCountSingleShotOnError(t *testing.T) {
+	wantErr := errors.New("apply boom")
+	calls := 0
+	op := func() error {
+		calls++
+		return wantErr
+	}
+
+	err := runWithApplyRetry(context.Background(), 0, op)
+
+	assert.Equal(t, 1, calls, "retryCount 0 must run op exactly once")
+	assert.ErrorIs(t, err, wantErr, "the single op error must be returned verbatim")
+}
+
+// TestRunWithApplyRetry_ZeroCountSuccess confirms the happy single-shot
+// path: one call, nil error.
+func TestRunWithApplyRetry_ZeroCountSuccess(t *testing.T) {
+	calls := 0
+	err := runWithApplyRetry(context.Background(), 0, func() error {
+		calls++
+		return nil
+	})
+	assert.Equal(t, 1, calls)
+	assert.NoError(t, err)
+}
+
+// TestRunWithApplyRetryPolicy_RetriesThenSucceeds verifies the attempt
+// bound: with retryCount 3 and an op that fails twice then succeeds, the
+// op runs exactly 3 times and the overall result is success.
+func TestRunWithApplyRetryPolicy_RetriesThenSucceeds(t *testing.T) {
+	calls := 0
+	op := func() error {
+		calls++
+		if calls < 3 {
+			return errors.New("transient")
+		}
+		return nil
+	}
+
+	err := runWithApplyRetryPolicy(context.Background(), 3, zeroBackoff(), op)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 3, calls, "should stop retrying once op succeeds")
+}
+
+// TestRunWithApplyRetryPolicy_ExhaustsRetries verifies the worst-case
+// bound: retryCount N runs the op N+1 times (initial + N retries) when it
+// always fails, then returns the last error.
+func TestRunWithApplyRetryPolicy_ExhaustsRetries(t *testing.T) {
+	wantErr := errors.New("always fails")
+	calls := 0
+	op := func() error {
+		calls++
+		return wantErr
+	}
+
+	err := runWithApplyRetryPolicy(context.Background(), 2, zeroBackoff(), op)
+
+	assert.ErrorIs(t, err, wantErr)
+	assert.Equal(t, 3, calls, "retryCount 2 must produce 1 + 2 = 3 total attempts")
+}
+
+// TestRunWithApplyRetryPolicy_CancelledCtxStopsBeforeRetry proves a ctx
+// already cancelled when the loop starts lets the first attempt run, then
+// stops rather than burning the full retry budget. op runs once.
+func TestRunWithApplyRetryPolicy_CancelledCtxStopsBeforeRetry(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	wantErr := errors.New("fail on cancelled ctx")
+	calls := 0
+	op := func() error {
+		calls++
+		return wantErr
+	}
+
+	err := runWithApplyRetryPolicy(ctx, 5, zeroBackoff(), op)
+
+	assert.Error(t, err)
+	assert.Equal(t, 1, calls, "a cancelled ctx must stop retries after the first attempt")
+}
+
+// TestRunWithApplyRetryPolicy_CancelDuringInterruptsLoop proves that a
+// cancellation happening mid-run (here, the op cancels on its first
+// failure) interrupts the retry loop instead of continuing to the
+// configured retry count. Contrast with ExhaustsRetries (same N=2, no
+// cancel) which runs 3 times; here it runs once.
+func TestRunWithApplyRetryPolicy_CancelDuringInterruptsLoop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	calls := 0
+	op := func() error {
+		calls++
+		cancel() // user hits Ctrl-C / resource timeout fires mid-apply
+		return errors.New("failed, and now cancelled")
+	}
+
+	err := runWithApplyRetryPolicy(ctx, 2, zeroBackoff(), op)
+
+	assert.Error(t, err)
+	assert.Equal(t, 1, calls, "cancellation during the run must cut the loop short")
+}


### PR DESCRIPTION
Surfaced by a release-readiness audit of `v2.4.1..HEAD`: the apply retry orchestration was the one piece of new/restored v3 behavior with no unit coverage.

## Why

The apply retry control flow (single-shot short-circuit, exponential backoff, attempt bound, ctx cancellation, hard 30s ceiling) lived inline in `ApplyManifest`. Only an acceptance test proved that retry happens at all; nothing verified the bound, the ceiling, or the cancellation semantics. This matters because the retry loop was a v2-to-v3 regression fix (the loop was dropped in #318 and restored later), and the corrective work added subtle semantics (`RandomizationFactor = 0` for a hard ceiling, `MaxElapsedTime = 0` so `WithMaxRetries` is the sole bound, `WithContext` so a cancel interrupts the sleep) that no test pinned down.

## What changed

- Extracted the orchestration into `runWithApplyRetry` (production entry) and `runWithApplyRetryPolicy` (testable core that takes the backoff explicitly, so tests inject a zero-interval policy and avoid real 3s..30s sleeps), plus `newApplyBackoff` and named interval constants. This mirrors the existing `waitForManifestWithClient` testability split.
- `ApplyManifest` now calls the helper. Behaviour is unchanged: same single-shot path for `apply_retry_count = 0`, same backoff tuning, same ctx wiring.

## Tests added

- `TestNewApplyBackoff_Tuning` and `TestNewApplyBackoff_HardCeiling`: lock in the 3s initial / 30s hard ceiling (no jitter past `MaxInterval`) and that `MaxElapsedTime = 0` never stops the backoff early.
- `TestRunWithApplyRetry_ZeroCountSingleShotOnError` / `_ZeroCountSuccess`: the issue #228 contract that `retryCount = 0` runs exactly once and does not retry, even on failure.
- `TestRunWithApplyRetryPolicy_RetriesThenSucceeds`: stops retrying once the op succeeds.
- `TestRunWithApplyRetryPolicy_ExhaustsRetries`: `retryCount = N` produces `N + 1` total attempts, then returns the last error.
- `TestRunWithApplyRetryPolicy_CancelledCtxStopsBeforeRetry` and `_CancelDuringInterruptsLoop`: a cancelled context (before the run, or mid-run) cuts the loop short instead of burning the full retry budget.

`go build`, `go vet`, the full unit suite, and `go test -race` on the new tests all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kubernetes manifest application now supports configurable automatic retries with exponential backoff for improved resilience during transient deployment failures.

* **Tests**
  * Added comprehensive unit tests for manifest apply retry and backoff behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->