### PR TITLE
ci(release): declare protocol 6.0 via terraform-registry-manifest.json

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,3 +50,11 @@ signs:
 release:
   draft: false
   prerelease: auto
+  # Upload the Terraform Registry manifest as a release asset. The
+  # registry reads metadata.protocol_versions from this file to learn the
+  # provider speaks plugin protocol 6.0 (terraform-plugin-framework). v3
+  # is framework-only, so without this asset the registry would fall back
+  # to advertising protocol 5.0 and mis-resolve for old Terraform clients.
+  extra_files:
+    - glob: terraform-registry-manifest.json
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The versions in the tables are the snapshot resolved at the time of writing; the
 
 ## Installation
 
-### Terraform 0.13+
+### Terraform 1.0+
 
 The provider can be installed and managed automatically by Terraform. Sample `versions.tf` file:
 
@@ -62,13 +62,13 @@ terraform {
   required_providers {
     kubectl = {
       source  = "alekc/kubectl"
-      version = "~> 2.3"
+      version = "~> 3.0"
     }
   }
 }
 ```
 
-The provider itself works back to Terraform 0.13. The example above pins `>= 1.0` because most users will be on a supported Terraform release; if you need to run older Terraform, you can drop the constraint to `>= 0.13`.
+v3 is built on the Terraform plugin framework and serves plugin protocol 6.0 only, so it requires Terraform 1.0+ (or a protocol-6 capable OpenTofu). If you must run older Terraform (0.13 to 0.15), stay on the v2.x line, which still serves protocol 5.0.
 
 If your configuration uses the `ephemeral "kubectl_manifest"` block (covered below), the floor moves up to **Terraform 1.10**, because ephemeral resources are a 1.10+ language feature regardless of the provider version. Bump `required_version` to `">= 1.10"` in that case.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,13 +57,17 @@ section.
 
 ## Installation
 
-### Terraform 0.13+
+### Terraform 1.0+
+
+v3 is built on the Terraform plugin framework and serves plugin protocol 6.0
+only, so it requires Terraform 1.0+ (or a protocol-6 capable OpenTofu). On v2.x,
+which still served protocol 5.0, older Terraform works.
 
 The provider can be installed and managed automatically by Terraform. Sample `versions.tf` file :
 
 ```hcl
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
 
   required_providers {
     kubectl = {

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "metadata": {
+    "protocol_versions": ["6.0"]
+  }
+}


### PR DESCRIPTION
Final v3 release-plumbing item from the release-readiness audit. v3 is the first framework-only release of this provider, and the registry metadata needs to reflect that before tagging.

## Problem

`main.go` serves the provider through `providerserver.Serve` (terraform-plugin-framework), which speaks plugin **protocol 6.0 only**, there is no SDK v2 mux to also serve protocol 5.0. The framework-only cutover (#318) has never shipped in a tag, so v3.0.0 is the first protocol-6-only release.

The Terraform Registry assumes **protocol 5.0** for any provider that publishes no `terraform-registry-manifest.json`. That was harmless for v2.x (a 5+6 mux), but for a 6-only v3 it is wrong metadata: the registry would advertise the version as compatible to protocol-5-only Terraform (<1.0) clients, which then fail the plugin handshake at runtime instead of cleanly skipping the version. Modern Terraform / OpenTofu negotiate protocol 6 at launch regardless, so this is about correct resolution and a clean error for old clients, not a runtime break on supported versions.

## Change

- Add `terraform-registry-manifest.json` declaring `metadata.protocol_versions = ["6.0"]`.
- Add a goreleaser `release.extra_files` entry that uploads it as the registry-expected `terraform-provider-kubectl_{{ .Version }}_manifest.json` release asset (the registry reads the manifest from that per-version asset, not from the repo tree).

## Doc-sync

Declaring protocol 6.0 formalizes a Terraform 1.0+ floor, so the install docs that still said otherwise are corrected in the same change:

- `docs/index.md` and `README.md`: heading `Terraform 0.13+` to `Terraform 1.0+`, example `required_version` to `>= 1.0`.
- `README.md`: bump the example provider pin from `~> 2.3` to `~> 3.0`, and replace the "works back to Terraform 0.13 / drop the constraint to >= 0.13" note (false for a protocol-6-only build) with guidance to stay on the v2.x protocol-5.0 line for older Terraform.

## Verification

`goreleaser check` passes against the updated config. The manifest is valid JSON with the schema the registry expects (`version: 1`, `metadata.protocol_versions`).

Once merged, `v3.0.0-rc1` is a clean dry run of the real v3 registry publish: the release job triggers on the `v*` tag, goreleaser marks it a pre-release via `prerelease: auto`, and the manifest asset lets the registry ingest it as a protocol-6 pre-release version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated v3 installation requirements: Terraform 1.0+ or a compatible OpenTofu build with protocol 6.0 support is now required
  * Clarified that v2.x line remains available for Terraform 0.13-0.15 users who need protocol 5.0 support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->