### PR TITLE
docs: Add documentation for WaitFor type

### DIFF
--- a/internal/types/wait_for.go
+++ b/internal/types/wait_for.go
@@ -1,5 +1,6 @@
 package types
 
+// WaitFor represents a wait condition configuration.
 type WaitFor struct {
 	Field []WaitForField
 	Condition []WaitForStatusCondition


### PR DESCRIPTION
### 问题背景
WaitFor 是一个公共类型，但缺少文档注释。在 Go 语言中，文档注释对于代码可读性和 godoc 生成至关重要，尤其是在一个被 200+ 团队使用的仓库中。缺少注释可能导致开发者困惑或误解类型用途。

### 修改内容
- 为 `WaitFor` 结构添加了文档注释 `// WaitFor represents a wait condition configuration.`
- 原因：遵循 Go 文档最佳实践，提供清晰的类型描述，提升代码自文档化能力。
- 对代码质量的提升：增强可读性和可维护性，减少新开发者的学习曲线，无需改变现有代码逻辑或 API。

### 验证方式
- 由于只添加了注释，所有现有测试应继续通过（无代码逻辑变更）。
- 可以通过 `go build` 验证代码编译成功。
- 可以使用 `go doc types.WaitFor` 检查注释是否正确显示。
- 手动验证：确认注释内容准确描述了类型用途。

### 其他信息
- 无 breaking changes，不影响现有功能或 API。
- 此修改本身就是文档改进，无需额外更新外部文档。
- 无已知限制。