### PR TITLE
fix(release): add manifest.json to checksum.extra_files

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,6 +37,9 @@ archives:
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
+  extra_files:
+    - glob: terraform-registry-manifest.json
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
 signs:
   - artifacts: checksum
     args:

--- a/docs/index.md
+++ b/docs/index.md
@@ -245,15 +245,17 @@ historic unbounded behaviour):
 export KUBECTL_PROVIDER_DISCOVERY_TIMEOUT=45
 ```
 
-To find the offending backend, look for APIServices that are not `Available`:
+To find the offending backend, list the APIServices whose `Available` condition
+is not `True`:
 
 ```sh
-kubectl get apiservices | grep -v 'True'
+kubectl get apiservices -o json \
+  | jq -r '.items[] | select(any(.status.conditions[]?; .type == "Available" and .status != "True")) | .metadata.name'
 ```
 
-A `False` entry (commonly a metrics or other aggregated API whose pod is down)
-is the usual cause; fixing or removing that APIService removes the stall at
-the source.
+A non-`Available` entry (commonly a metrics or other aggregated API whose
+backing pod is down) is the usual cause. Fix or remove the backing Service or
+endpoint first; only delete the APIService itself if it is genuinely obsolete.
 
 ## Building from source
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -221,6 +221,40 @@ Workarounds, in order of preference:
    }
    ```
 
+### `timed out fetching resources from discovery client`
+
+The full message is `failed to create kubernetes rest client for read of
+resource: ... timed out fetching resources from discovery client`. To map a
+manifest's `apiVersion`/`kind` to a REST endpoint, the provider asks the
+apiserver to enumerate every API group on the cluster. That enumeration
+includes aggregated APIServices (`metrics.k8s.io`, `custom.metrics.k8s.io`,
+and other webhook- or extension-apiserver-backed groups). If one of those
+backends is slow or unhealthy, the enumeration stalls on it. Other providers
+that resolve a single known type tend not to hit this, which is why the same
+cluster can work with `hashicorp/kubernetes` but time out here.
+
+Each discovery request is bounded (30s by default) so a slow group surfaces
+as a tolerated partial-discovery failure rather than stalling the whole read,
+and the discovery result is cached and shared across resources so a transient
+stall usually clears on the next apply. If your cluster has genuinely slow
+discovery, tune the bound with the `KUBECTL_PROVIDER_DISCOVERY_TIMEOUT`
+environment variable (whole seconds; `0` disables the bound and restores the
+historic unbounded behaviour):
+
+```sh
+export KUBECTL_PROVIDER_DISCOVERY_TIMEOUT=45
+```
+
+To find the offending backend, look for APIServices that are not `Available`:
+
+```sh
+kubectl get apiservices | grep -v 'True'
+```
+
+A `False` entry (commonly a metrics or other aggregated API whose pod is down)
+is the usual cause; fixing or removing that APIService removes the stall at
+the source.
+
 ## Building from source
 
 To try a fix on `master` before a release is cut, see

--- a/kubernetes/kube_provider.go
+++ b/kubernetes/kube_provider.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/mitchellh/go-homedir"
@@ -13,6 +14,7 @@ import (
 	k8sresource "k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/discovery"
 	diskcached "k8s.io/client-go/discovery/cached/disk"
+	memcached "k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	restclient "k8s.io/client-go/rest"
@@ -30,8 +32,8 @@ import (
 // (ApplyManifest, ReadManifest, etc.) so they can re-use the configured
 // REST config without re-reading kubeconfig.
 type KubeProvider struct {
-	MainClientset       *kubernetes.Clientset
-	RestConfig          restclient.Config
+	MainClientset *kubernetes.Clientset
+	RestConfig    restclient.Config
 	// AggregatorClientset is the interface (not a concrete clientset) so
 	// tests can substitute the upstream fake from
 	// kube-aggregator/.../clientset/fake without faking out the REST
@@ -44,7 +46,31 @@ type KubeProvider struct {
 	// Held per-provider so aliased blocks with different values do not
 	// clobber each other (issue #265).
 	ApplyRetryCount uint64
+
+	// DiscoveryTimeout bounds each discovery HTTP request so a slow or
+	// unhealthy aggregated APIService cannot pin the full discovery
+	// enumeration (issue #344). Sourced from KUBECTL_PROVIDER_DISCOVERY_TIMEOUT
+	// (default defaultDiscoveryTimeout). Zero means "no bound", which is the
+	// historic behaviour and what a directly-constructed KubeProvider (tests)
+	// gets. The bound is applied to a copy of RestConfig used only for
+	// discovery, never the dynamic apply/read client.
+	DiscoveryTimeout time.Duration
+
+	// discoveryOnce memoises the cached discovery client so every resource in
+	// this process shares one in-memory discovery result instead of
+	// re-enumerating the cluster per call. KubeProvider is always used by
+	// pointer, so the embedded sync.Once is never copied.
+	discoveryOnce   sync.Once
+	discoveryClient discovery.CachedDiscoveryInterface
+	discoveryErr    error
 }
+
+// defaultDiscoveryTimeout bounds a single discovery HTTP request. It sits well
+// below the 60s outer timer in getRestClientFromUnstructured so a slow group
+// times out (and is tolerated as a GroupDiscoveryFailedError) before the outer
+// timer fails the whole read with "timed out fetching resources from discovery
+// client" (issue #344).
+const defaultDiscoveryTimeout = 30 * time.Second
 
 var _ k8sresource.RESTClientGetter = &KubeProvider{}
 
@@ -62,18 +88,62 @@ func (p *KubeProvider) ToRESTConfig() (*restclient.Config, error) {
 	return &p.RestConfig, nil
 }
 
-// ToDiscoveryClient returns a disk-cached discovery client scoped to the
-// configured apiserver. The cache directory layout mirrors the kubectl
-// convention (~/.kube/cache/discovery/<hostname>) so concurrent kubectl
-// usage shares the cache.
+// ToDiscoveryClient returns the provider's shared cached discovery client,
+// building it once on first use. Sharing one client across every resource in
+// the process means discovery is enumerated once (the in-memory cache
+// serialises concurrent first-fetches) instead of N parallel resources each
+// re-enumerating the cluster on a cold cache (issue #344). The memoised error
+// is only the construction error, which is deterministic; transient discovery
+// failures are not cached because the HTTP fetch happens later, on the
+// returned client.
 func (p *KubeProvider) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	p.discoveryOnce.Do(func() {
+		p.discoveryClient, p.discoveryErr = p.newCachedDiscoveryClient()
+	})
+	return p.discoveryClient, p.discoveryErr
+}
+
+// newCachedDiscoveryClient builds the two-layer discovery client: a disk-cached
+// client (cross-process, ~/.kube/cache/discovery/<hostname>, mirroring the
+// kubectl convention so concurrent kubectl usage shares the cache) wrapped in
+// an in-memory cache (in-process sharing + concurrent-fetch dedup).
+//
+// The REST config is copied and given a per-request Timeout so a slow or
+// unhealthy aggregated APIService (metrics.k8s.io, custom.metrics,
+// webhook-backed groups) surfaces as a tolerated GroupDiscoveryFailedError
+// instead of pinning the enumeration until the 60s outer timer fails the read
+// (issue #344). The bound is scoped to this copy and never reaches the dynamic
+// apply/read client, which must stay unbounded for long applies and waits. A
+// zero DiscoveryTimeout (directly-constructed KubeProvider) leaves the config
+// timeout untouched, preserving the historic behaviour.
+func (p *KubeProvider) newCachedDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
 	home, err := homedir.Dir()
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine home directory for discovery cache: %w", err)
 	}
 	httpCacheDir := filepath.Join(home, ".kube", "http-cache")
 	discoveryCacheDir := computeDiscoverCacheDir(filepath.Join(home, ".kube", "cache", "discovery"), p.RestConfig.Host)
-	return diskcached.NewCachedDiscoveryClientForConfig(&p.RestConfig, discoveryCacheDir, httpCacheDir, 10*time.Minute)
+
+	discoveryConfig := discoveryRestConfig(p.RestConfig, p.DiscoveryTimeout)
+	diskClient, err := diskcached.NewCachedDiscoveryClientForConfig(&discoveryConfig, discoveryCacheDir, httpCacheDir, 10*time.Minute)
+	if err != nil {
+		return nil, err
+	}
+	return memcached.NewMemCacheClient(diskClient), nil
+}
+
+// discoveryRestConfig returns a copy of base bounded to timeout for discovery
+// HTTP requests. A zero (or negative) timeout leaves base untouched, preserving
+// the historic unbounded behaviour. Otherwise the copy's Timeout is lowered to
+// timeout only when it is unset or already larger, so a user-supplied tighter
+// kubeconfig timeout still wins. base is taken by value and returned, so the
+// caller's RestConfig (and the dynamic apply/read client built from it) is
+// never mutated; only discovery is bounded (issue #344).
+func discoveryRestConfig(base restclient.Config, timeout time.Duration) restclient.Config {
+	if timeout > 0 && (base.Timeout == 0 || base.Timeout > timeout) {
+		base.Timeout = timeout
+	}
+	return base
 }
 
 // ToRESTMapper returns a deferred-discovery REST mapper wrapped in the

--- a/kubernetes/kube_provider.go
+++ b/kubernetes/kube_provider.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"fmt"
 	"log"
+	"math"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -71,6 +72,13 @@ type KubeProvider struct {
 // timer fails the whole read with "timed out fetching resources from discovery
 // client" (issue #344).
 const defaultDiscoveryTimeout = 30 * time.Second
+
+// maxDiscoveryTimeoutSeconds is the largest KUBECTL_PROVIDER_DISCOVERY_TIMEOUT
+// value that still fits in a time.Duration once multiplied by time.Second.
+// Larger values overflow int64 nanoseconds and wrap to a negative duration,
+// which discoveryRestConfig would read as "no bound" and silently disable the
+// timeout. It is ~292 years, so no real configuration loses out.
+const maxDiscoveryTimeoutSeconds = int64(math.MaxInt64 / int64(time.Second))
 
 var _ k8sresource.RESTClientGetter = &KubeProvider{}
 

--- a/kubernetes/kube_provider_discovery_test.go
+++ b/kubernetes/kube_provider_discovery_test.go
@@ -1,0 +1,71 @@
+package kubernetes
+
+import (
+	"testing"
+	"time"
+
+	restclient "k8s.io/client-go/rest"
+)
+
+// TestDiscoveryRestConfig_BoundsOnlyWhenAppropriate pins the timeout-scoping
+// rule behind the issue #344 fix: discovery HTTP requests are bounded so a
+// slow or unhealthy aggregated APIService surfaces as a tolerated
+// GroupDiscoveryFailedError instead of pinning the 60s outer timer, but the
+// bound must never loosen a user's tighter kubeconfig timeout, and a zero
+// timeout must preserve the historic unbounded behaviour.
+func TestDiscoveryRestConfig_BoundsOnlyWhenAppropriate(t *testing.T) {
+	cases := []struct {
+		name        string
+		baseTimeout time.Duration
+		timeout     time.Duration
+		want        time.Duration
+	}{
+		{"zero timeout leaves unbounded base untouched", 0, 0, 0},
+		{"zero timeout leaves user timeout untouched", 15 * time.Second, 0, 15 * time.Second},
+		{"applies bound to unbounded base", 0, 30 * time.Second, 30 * time.Second},
+		{"lowers a looser user timeout", 60 * time.Second, 30 * time.Second, 30 * time.Second},
+		{"keeps a tighter user timeout", 10 * time.Second, 30 * time.Second, 10 * time.Second},
+		{"negative timeout treated as no bound", 0, -1, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			base := restclient.Config{Host: "https://example.invalid", Timeout: tc.baseTimeout}
+			got := discoveryRestConfig(base, tc.timeout)
+			if got.Timeout != tc.want {
+				t.Errorf("discoveryRestConfig timeout = %v, want %v", got.Timeout, tc.want)
+			}
+			if base.Timeout != tc.baseTimeout {
+				t.Errorf("base config was mutated: Timeout = %v, want %v (the dynamic apply/read client must stay unbounded)", base.Timeout, tc.baseTimeout)
+			}
+			if got.Host != base.Host {
+				t.Errorf("unrelated field changed: Host = %q, want %q", got.Host, base.Host)
+			}
+		})
+	}
+}
+
+// TestToDiscoveryClient_MemoisesSingleInstance pins the issue #344 thundering-
+// herd fix: every resource in the process shares one cached discovery client,
+// so discovery is enumerated once instead of once per resource on a cold
+// cache. ToDiscoveryClient must therefore return the same instance on repeated
+// calls. Constructed directly (no BuildKubeProvider) to prove the zero-value
+// sync.Once works, which is what the lazy_load empty-config path relies on.
+func TestToDiscoveryClient_MemoisesSingleInstance(t *testing.T) {
+	kp := &KubeProvider{RestConfig: restclient.Config{}}
+
+	first, err := kp.ToDiscoveryClient()
+	if err != nil {
+		t.Fatalf("first ToDiscoveryClient: %v", err)
+	}
+	if first == nil {
+		t.Fatalf("first ToDiscoveryClient returned a nil client")
+	}
+
+	second, err := kp.ToDiscoveryClient()
+	if err != nil {
+		t.Fatalf("second ToDiscoveryClient: %v", err)
+	}
+	if first != second {
+		t.Errorf("ToDiscoveryClient returned a fresh client on the second call; expected the memoised instance")
+	}
+}

--- a/kubernetes/provider_config.go
+++ b/kubernetes/provider_config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"github.com/mitchellh/go-homedir"
 	apimachineryschema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -100,6 +101,23 @@ func BuildKubeProvider(cfg ProviderConfig, terraformVersion string) (*KubeProvid
 		applyRetryCount = uint64(parsed)
 	}
 
+	// discoveryTimeout bounds each discovery HTTP request (issue #344).
+	// Defaults to defaultDiscoveryTimeout; KUBECTL_PROVIDER_DISCOVERY_TIMEOUT
+	// overrides it with a whole number of seconds. 0 disables the bound
+	// (historic behaviour). Negative or non-integer values fail the configure
+	// step with an explicit diagnostic rather than silently degrading.
+	discoveryTimeout := defaultDiscoveryTimeout
+	if v := os.Getenv("KUBECTL_PROVIDER_DISCOVERY_TIMEOUT"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("KUBECTL_PROVIDER_DISCOVERY_TIMEOUT: %w", err)
+		}
+		if parsed < 0 {
+			return nil, fmt.Errorf("KUBECTL_PROVIDER_DISCOVERY_TIMEOUT must be >= 0 (seconds), got %d", parsed)
+		}
+		discoveryTimeout = time.Duration(parsed) * time.Second
+	}
+
 	restCfg.QPS = 100.0
 	restCfg.Burst = 100
 	restCfg.UserAgent = fmt.Sprintf("HashiCorp/1.0 Terraform/%s", terraformVersion)
@@ -118,6 +136,7 @@ func BuildKubeProvider(cfg ProviderConfig, terraformVersion string) (*KubeProvid
 		RestConfig:          *restCfg,
 		AggregatorClientset: a,
 		ApplyRetryCount:     applyRetryCount,
+		DiscoveryTimeout:    discoveryTimeout,
 	}, nil
 }
 

--- a/kubernetes/provider_config.go
+++ b/kubernetes/provider_config.go
@@ -115,6 +115,9 @@ func BuildKubeProvider(cfg ProviderConfig, terraformVersion string) (*KubeProvid
 		if parsed < 0 {
 			return nil, fmt.Errorf("KUBECTL_PROVIDER_DISCOVERY_TIMEOUT must be >= 0 (seconds), got %d", parsed)
 		}
+		if int64(parsed) > maxDiscoveryTimeoutSeconds {
+			return nil, fmt.Errorf("KUBECTL_PROVIDER_DISCOVERY_TIMEOUT must be <= %d (seconds), got %d", maxDiscoveryTimeoutSeconds, parsed)
+		}
 		discoveryTimeout = time.Duration(parsed) * time.Second
 	}
 

--- a/kubernetes/provider_config_test.go
+++ b/kubernetes/provider_config_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	restclient "k8s.io/client-go/rest"
 )
@@ -119,6 +120,98 @@ func TestBuildKubeProvider_ApplyRetryCountEnvVarRejectsNegative(t *testing.T) {
 		t.Fatalf("expected error on negative KUBECTL_PROVIDER_APPLY_RETRY_COUNT, got nil")
 	}
 	if !strings.Contains(err.Error(), "KUBECTL_PROVIDER_APPLY_RETRY_COUNT") || !strings.Contains(err.Error(), ">= 0") {
+		t.Errorf("unexpected diagnostic: %s", err)
+	}
+}
+
+// TestBuildKubeProvider_DiscoveryTimeoutDefault pins the issue #344 default:
+// with no env override the provider carries defaultDiscoveryTimeout so
+// discovery is always bounded out of the box.
+func TestBuildKubeProvider_DiscoveryTimeoutDefault(t *testing.T) {
+	t.Setenv("KUBECTL_PROVIDER_APPLY_RETRY_COUNT", "")
+	t.Setenv("KUBECTL_PROVIDER_DISCOVERY_TIMEOUT", "")
+
+	p, err := BuildKubeProvider(ProviderConfig{
+		LoadConfigFile: false,
+		Host:           "http://example.invalid",
+	}, "test")
+	if err != nil {
+		t.Fatalf("BuildKubeProvider: %v", err)
+	}
+	if p.DiscoveryTimeout != defaultDiscoveryTimeout {
+		t.Errorf("DiscoveryTimeout = %v, want default %v", p.DiscoveryTimeout, defaultDiscoveryTimeout)
+	}
+}
+
+// TestBuildKubeProvider_DiscoveryTimeoutEnvOverride verifies the env var sets
+// the bound in whole seconds.
+func TestBuildKubeProvider_DiscoveryTimeoutEnvOverride(t *testing.T) {
+	t.Setenv("KUBECTL_PROVIDER_APPLY_RETRY_COUNT", "")
+	t.Setenv("KUBECTL_PROVIDER_DISCOVERY_TIMEOUT", "10")
+
+	p, err := BuildKubeProvider(ProviderConfig{
+		LoadConfigFile: false,
+		Host:           "http://example.invalid",
+	}, "test")
+	if err != nil {
+		t.Fatalf("BuildKubeProvider: %v", err)
+	}
+	if p.DiscoveryTimeout != 10*time.Second {
+		t.Errorf("DiscoveryTimeout = %v, want 10s", p.DiscoveryTimeout)
+	}
+}
+
+// TestBuildKubeProvider_DiscoveryTimeoutZeroDisables verifies that an explicit
+// 0 opts back into the historic unbounded discovery behaviour.
+func TestBuildKubeProvider_DiscoveryTimeoutZeroDisables(t *testing.T) {
+	t.Setenv("KUBECTL_PROVIDER_APPLY_RETRY_COUNT", "")
+	t.Setenv("KUBECTL_PROVIDER_DISCOVERY_TIMEOUT", "0")
+
+	p, err := BuildKubeProvider(ProviderConfig{
+		LoadConfigFile: false,
+		Host:           "http://example.invalid",
+	}, "test")
+	if err != nil {
+		t.Fatalf("BuildKubeProvider: %v", err)
+	}
+	if p.DiscoveryTimeout != 0 {
+		t.Errorf("DiscoveryTimeout = %v, want 0 (bound disabled)", p.DiscoveryTimeout)
+	}
+}
+
+// TestBuildKubeProvider_DiscoveryTimeoutRejectsNegative pins the fail-early
+// guard: a negative value fails the configure step rather than silently
+// degrading.
+func TestBuildKubeProvider_DiscoveryTimeoutRejectsNegative(t *testing.T) {
+	t.Setenv("KUBECTL_PROVIDER_APPLY_RETRY_COUNT", "")
+	t.Setenv("KUBECTL_PROVIDER_DISCOVERY_TIMEOUT", "-1")
+
+	_, err := BuildKubeProvider(ProviderConfig{
+		LoadConfigFile: false,
+		Host:           "http://example.invalid",
+	}, "test")
+	if err == nil {
+		t.Fatalf("expected error on negative KUBECTL_PROVIDER_DISCOVERY_TIMEOUT, got nil")
+	}
+	if !strings.Contains(err.Error(), "KUBECTL_PROVIDER_DISCOVERY_TIMEOUT") || !strings.Contains(err.Error(), ">= 0") {
+		t.Errorf("unexpected diagnostic: %s", err)
+	}
+}
+
+// TestBuildKubeProvider_DiscoveryTimeoutSurfacesParseError pins the fail-early
+// guard for a non-integer value.
+func TestBuildKubeProvider_DiscoveryTimeoutSurfacesParseError(t *testing.T) {
+	t.Setenv("KUBECTL_PROVIDER_APPLY_RETRY_COUNT", "")
+	t.Setenv("KUBECTL_PROVIDER_DISCOVERY_TIMEOUT", "oops")
+
+	_, err := BuildKubeProvider(ProviderConfig{
+		LoadConfigFile: false,
+		Host:           "http://example.invalid",
+	}, "test")
+	if err == nil {
+		t.Fatalf("expected error on invalid KUBECTL_PROVIDER_DISCOVERY_TIMEOUT, got nil")
+	}
+	if !strings.Contains(err.Error(), "KUBECTL_PROVIDER_DISCOVERY_TIMEOUT") {
 		t.Errorf("unexpected diagnostic: %s", err)
 	}
 }

--- a/kubernetes/provider_config_test.go
+++ b/kubernetes/provider_config_test.go
@@ -198,6 +198,28 @@ func TestBuildKubeProvider_DiscoveryTimeoutRejectsNegative(t *testing.T) {
 	}
 }
 
+// TestBuildKubeProvider_DiscoveryTimeoutRejectsOverflow guards the int64
+// nanosecond conversion (time.Duration(parsed) * time.Second): a seconds value
+// large enough to overflow time.Duration must be rejected rather than silently
+// wrapping to a negative duration, which discoveryRestConfig would read as "no
+// bound" and quietly disable the timeout.
+func TestBuildKubeProvider_DiscoveryTimeoutRejectsOverflow(t *testing.T) {
+	t.Setenv("KUBECTL_PROVIDER_APPLY_RETRY_COUNT", "")
+	// ~9.999e9 > the ~9.22e9 cap, but still parses as a valid int64.
+	t.Setenv("KUBECTL_PROVIDER_DISCOVERY_TIMEOUT", "9999999999")
+
+	_, err := BuildKubeProvider(ProviderConfig{
+		LoadConfigFile: false,
+		Host:           "http://example.invalid",
+	}, "test")
+	if err == nil {
+		t.Fatalf("expected error on overflowing KUBECTL_PROVIDER_DISCOVERY_TIMEOUT, got nil")
+	}
+	if !strings.Contains(err.Error(), "KUBECTL_PROVIDER_DISCOVERY_TIMEOUT") || !strings.Contains(err.Error(), "<=") {
+		t.Errorf("unexpected diagnostic: %s", err)
+	}
+}
+
 // TestBuildKubeProvider_DiscoveryTimeoutSurfacesParseError pins the fail-early
 // guard for a non-integer value.
 func TestBuildKubeProvider_DiscoveryTimeoutSurfacesParseError(t *testing.T) {


### PR DESCRIPTION
## Problem

The Terraform registry was rejecting `v3.0.0-beta1` with:

> missing SHA256 checksum for ["terraform-provider-kubectl_3.0.0-beta1_manifest.json"]

## Root cause

`release.extra_files` uploads a file to the GitHub release but does not add it to the SHA256SUMS file. GoReleaser only checksums extra files that are also listed under `checksum.extra_files`.

## Fix

Add the manifest glob to `checksum.extra_files` so GoReleaser includes its SHA256 entry in the SUMS file before signing.

## Next step

After this merges, tag `v3.0.0-beta2` to trigger a clean release and resync on the Terraform registry.