### PR TITLE
fix(release): add manifest.json to checksum.extra_files

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,6 +37,9 @@ archives:
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
+  extra_files:
+    - glob: terraform-registry-manifest.json
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
 signs:
   - artifacts: checksum
     args:


### PR DESCRIPTION
## Problem

The Terraform registry was rejecting `v3.0.0-beta1` with:

> missing SHA256 checksum for ["terraform-provider-kubectl_3.0.0-beta1_manifest.json"]

## Root cause

`release.extra_files` uploads a file to the GitHub release but does not add it to the SHA256SUMS file. GoReleaser only checksums extra files that are also listed under `checksum.extra_files`.

## Fix

Add the manifest glob to `checksum.extra_files` so GoReleaser includes its SHA256 entry in the SUMS file before signing.

## Next step

After this merges, tag `v3.0.0-beta2` to trigger a clean release and resync on the Terraform registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release package integrity by including manifest file checksums for downloadable releases, enabling improved verification during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->