### PR TITLE
feat(provider): support deferred actions for unknown provider config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -221,6 +221,18 @@ Workarounds, in order of preference:
    }
    ```
 
+On workflows that support [deferred actions](https://developer.hashicorp.com/terraform/language/resources/terraform-data#deferred-actions)
+(Terraform Stacks, and `terraform plan`/`apply` runs that opt into deferral),
+none of the workarounds above are needed. When the provider configuration is
+not yet fully known (for example `host`, `token`, or `cluster_ca_certificate`
+sourced from an EKS component that has not been applied yet), the provider
+automatically returns a deferral instead of building a client from unknown
+values. Terraform then defers every `kubectl` resource and data source to a
+follow-up apply, once the upstream values are known, rather than failing with
+`Called ValidateResourceConfig on an unconfigured provider`. This is automatic
+and requires no provider configuration; see
+[#354](https://github.com/alekc/terraform-provider-kubectl/issues/354).
+
 ### `timed out fetching resources from discovery client`
 
 The full message is `failed to create kubernetes rest client for read of

--- a/docs/index.md
+++ b/docs/index.md
@@ -221,7 +221,7 @@ Workarounds, in order of preference:
    }
    ```
 
-On workflows that support [deferred actions](https://developer.hashicorp.com/terraform/language/resources/terraform-data#deferred-actions)
+On workflows that support [deferred actions](https://developer.hashicorp.com/terraform/language/stacks/use-cases)
 (Terraform Stacks, and `terraform plan`/`apply` runs that opt into deferral),
 none of the workarounds above are needed. When the provider configuration is
 not yet fully known (for example `host`, `token`, or `cluster_ca_certificate`

--- a/internal/framework/provider.go
+++ b/internal/framework/provider.go
@@ -195,6 +195,23 @@ func (p *kubectlFrameworkProvider) Schema(_ context.Context, _ provider.SchemaRe
 // it on each downstream-data field so resources and data sources read it
 // directly via Configure → req.ProviderData. Implements provider.Provider.
 func (p *kubectlFrameworkProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+	// Deferred actions (Terraform Stacks and other deferral-aware
+	// workflows): when the client allows deferral and the provider
+	// configuration is not yet fully known (e.g. host / token /
+	// cluster_ca_certificate sourced from a not-yet-applied component's
+	// outputs), defer rather than build a client from unknown values. The
+	// framework then automatically defers every resource and data source
+	// for this provider, so Terraform core no longer calls
+	// ValidateResourceConfig against an unconfigured provider (#354).
+	// This only fires under the experimental deferral client capability;
+	// the classic plan/apply flow and the lazy_load fallback are unaffected.
+	if req.ClientCapabilities.DeferralAllowed && !req.Config.Raw.IsFullyKnown() {
+		resp.Deferred = &provider.Deferred{
+			Reason: provider.DeferredReasonProviderConfigUnknown,
+		}
+		return
+	}
+
 	var data providerConfigModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -394,4 +411,3 @@ func (v int64AtLeastValidator) ValidateInt64(_ context.Context, req validator.In
 		)
 	}
 }
-

--- a/internal/framework/provider_deferred_test.go
+++ b/internal/framework/provider_deferred_test.go
@@ -1,0 +1,94 @@
+package framework
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// TestConfigureDeferredActions pins the deferred-actions behaviour added for
+// issue #354. When Terraform allows deferral (e.g. a Stacks workflow) and the
+// provider configuration is not fully known, Configure must return a
+// provider-level deferral so the framework defers every resource and data
+// source instead of letting core call ValidateResourceConfig against an
+// unconfigured provider. The capability is gated: an unknown config without
+// DeferralAllowed must NOT defer, and a fully-known config must never defer.
+func TestConfigureDeferredActions(t *testing.T) {
+	ctx := context.Background()
+	p := New("test")
+
+	var schemaResp provider.SchemaResponse
+	p.Schema(ctx, provider.SchemaRequest{}, &schemaResp)
+	cfgType, ok := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatalf("provider schema type is %T, want tftypes.Object", schemaResp.Schema.Type().TerraformType(ctx))
+	}
+
+	// allNull builds a known provider-config object whose attributes are all
+	// null (IsFullyKnown == true). partialUnknown overrides one attribute
+	// (host) with an unknown value, which is what Terraform sends when an
+	// argument is sourced from a not-yet-applied component's output.
+	allNull := func() map[string]tftypes.Value {
+		attrs := make(map[string]tftypes.Value, len(cfgType.AttributeTypes))
+		for name, at := range cfgType.AttributeTypes {
+			attrs[name] = tftypes.NewValue(at, nil)
+		}
+		return attrs
+	}
+
+	knownCfg := tftypes.NewValue(cfgType, allNull())
+
+	partial := allNull()
+	partial["host"] = tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+	unknownCfg := tftypes.NewValue(cfgType, partial)
+
+	cases := []struct {
+		name            string
+		raw             tftypes.Value
+		deferralAllowed bool
+		wantDeferred    bool
+	}{
+		{"unknown config with deferral allowed defers", unknownCfg, true, true},
+		{"unknown config without deferral allowed does not defer", unknownCfg, false, false},
+		{"known config with deferral allowed does not defer", knownCfg, true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := provider.ConfigureRequest{
+				Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: tc.raw},
+				ClientCapabilities: provider.ConfigureProviderClientCapabilities{
+					DeferralAllowed: tc.deferralAllowed,
+				},
+			}
+			resp := &provider.ConfigureResponse{}
+			p.Configure(ctx, req, resp)
+
+			if tc.wantDeferred {
+				if resp.Deferred == nil {
+					t.Fatalf("expected a deferred response, got none")
+				}
+				if resp.Deferred.Reason != provider.DeferredReasonProviderConfigUnknown {
+					t.Errorf("deferred reason = %s, want Provider Config Unknown", resp.Deferred.Reason)
+				}
+				// A deferral returns before building a client, so the
+				// configure step itself must not surface errors.
+				if resp.Diagnostics.HasError() {
+					t.Errorf("unexpected diagnostics on deferral: %s", resp.Diagnostics)
+				}
+				return
+			}
+
+			// Non-deferral cases fall through to normal configure. We only
+			// assert that no deferral was requested; whether building a
+			// client from null/empty config succeeds depends on the host
+			// environment and is not what this test pins.
+			if resp.Deferred != nil {
+				t.Fatalf("did not expect a deferred response, got reason %s", resp.Deferred.Reason)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds Terraform deferred-actions support at the provider-configuration level so the `kubectl` provider works in Terraform Stacks (and other deferral-aware workflows) when its connection arguments are not yet known at plan time.

## Why

In a Stacks workflow the provider's `host` / `token` / `cluster_ca_certificate` are commonly sourced from a component (for example an EKS cluster) that has not been applied yet, so those values are unknown when Terraform configures the provider. Because the provider did not participate in the deferred-actions protocol, Terraform core deferred the provider configuration but still called `ValidateResourceConfig` against it, tripping its own consistency check:

```
Error: Called ValidateResourceConfig on an unconfigured provider
Cannot validate resource configuration because this provider is not configured. This is a bug in Terraform - please report it.
```

HashiCorp support confirmed the root cause is the missing deferred-actions support and pointed the reporter here (see #354).

## How

`Configure` now checks `req.ClientCapabilities.DeferralAllowed` together with `req.Config.Raw.IsFullyKnown()`. When the client allows deferral and the provider config is not fully known, it returns a provider-level deferral with reason `DeferredReasonProviderConfigUnknown` and returns before building a client from unknown values. The framework then automatically defers every resource and data source for this provider until the upstream values are known, so core no longer validates resources against an unconfigured provider.

This path only fires under the experimental deferral client capability, so the classic `plan`/`apply` flow and the existing `lazy_load` fallback are unchanged. No dependency bumps are needed: `terraform-plugin-framework` v1.19.0 already exposes the API.

## Testing

`internal/framework/provider_deferred_test.go` calls `Configure` directly with a crafted config and asserts the three cases: deferral-allowed plus an unknown attribute defers with the right reason and no error; deferral-allowed with a fully-known config does not defer; an unknown attribute without the deferral capability does not defer (gating preserved).

```
go build ./...
go test ./internal/framework/ -run TestConfigureDeferredActions -race
make test   # full unit suite, green
```

## Docs

Added a Troubleshooting note in `docs/index.md` explaining that on deferral-aware workflows the manual two-stage / `lazy_load` workarounds are not needed, since the provider now defers automatically when its config is unknown.

Fixes: alekc/terraform-provider-kubectl#354


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for deferred Terraform workflows when Kubernetes provider settings aren’t fully known yet.
  * When deferral is allowed, resources and data sources are postponed to a later apply instead of failing during configuration.

* **Bug Fixes**
  * Improved behavior for incomplete connection settings to prevent “unconfigured provider” failures.

* **Documentation**
  * Added troubleshooting guidance for deferred-action scenarios under the existing “Failed to get RESTMapper client…” section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->