### PR TITLE
feat(provider): defer resources and data sources on unknown config

### DIFF
--- a/internal/framework/data_source_deferred_test.go
+++ b/internal/framework/data_source_deferred_test.go
@@ -1,0 +1,74 @@
+package framework
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// TestDataSourceReadDeferredActions pins the resource-level deferred-actions
+// behaviour for issue #356 on the data sources that take config inputs. When
+// the client allows deferral and the data source configuration is not fully
+// known, Read must return a deferral instead of reading from unknown values.
+// The capability gate must keep the classic read path unchanged. The
+// input-less server_version data source is intentionally excluded: its config
+// can never be unknown, so it carries no deferral guard.
+func TestDataSourceReadDeferredActions(t *testing.T) {
+	ctx := context.Background()
+
+	factories := map[string]func() datasource.DataSource{
+		"filename_list":       NewFilenameListDataSource,
+		"file_documents":      NewFileDocumentsDataSource,
+		"path_documents":      NewPathDocumentsDataSource,
+		"kustomize_documents": NewKustomizeDocumentsDataSource,
+		"manifest":            NewManifestDataSource,
+	}
+
+	for name, newDS := range factories {
+		t.Run(name, func(t *testing.T) {
+			ds := newDS()
+
+			var schemaResp datasource.SchemaResponse
+			ds.Schema(ctx, datasource.SchemaRequest{}, &schemaResp)
+			cfgType := schemaResp.Schema.Type().TerraformType(ctx)
+
+			// A wholly-unknown config object is "not fully known". The
+			// deferral guard runs before req.Config.Get, so the value is
+			// never decoded; it stands in for any config attribute sourced
+			// from a not-yet-applied resource.
+			unknownCfg := tftypes.NewValue(cfgType, tftypes.UnknownValue)
+
+			// Deferral allowed + unknown config -> defer.
+			reqDefer := datasource.ReadRequest{
+				Config:             tfsdk.Config{Schema: schemaResp.Schema, Raw: unknownCfg},
+				ClientCapabilities: datasource.ReadClientCapabilities{DeferralAllowed: true},
+			}
+			respDefer := &datasource.ReadResponse{State: tfsdk.State{Schema: schemaResp.Schema}}
+			ds.Read(ctx, reqDefer, respDefer)
+
+			if respDefer.Deferred == nil {
+				t.Fatalf("expected a deferred read, got none")
+			}
+			if respDefer.Deferred.Reason != datasource.DeferredReasonDataSourceConfigUnknown {
+				t.Errorf("deferred reason = %s, want Data Source Config Unknown", respDefer.Deferred.Reason)
+			}
+
+			// Capability off + unknown config -> no defer (gate preserved).
+			// Read falls through; we assert only that no deferral was set,
+			// not on any diagnostics the unknown config may produce.
+			reqNoCap := datasource.ReadRequest{
+				Config:             tfsdk.Config{Schema: schemaResp.Schema, Raw: unknownCfg},
+				ClientCapabilities: datasource.ReadClientCapabilities{DeferralAllowed: false},
+			}
+			respNoCap := &datasource.ReadResponse{State: tfsdk.State{Schema: schemaResp.Schema}}
+			ds.Read(ctx, reqNoCap, respNoCap)
+
+			if respNoCap.Deferred != nil {
+				t.Errorf("did not expect a deferred read without the capability, got %s", respNoCap.Deferred.Reason)
+			}
+		})
+	}
+}

--- a/internal/framework/data_source_kubectl_file_documents.go
+++ b/internal/framework/data_source_kubectl_file_documents.go
@@ -65,15 +65,7 @@ func (d *fileDocumentsDataSource) Schema(_ context.Context, _ datasource.SchemaR
 }
 
 func (d *fileDocumentsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	// Deferred actions: defer this data source when the client allows
-	// deferral and its configuration is not yet fully known (e.g. an input
-	// interpolated from a not-yet-applied resource in a deferral-aware run).
-	// Gated on the deferral client capability so the classic read path is
-	// unchanged. See #356.
-	if req.ClientCapabilities.DeferralAllowed && !req.Config.Raw.IsFullyKnown() {
-		resp.Deferred = &datasource.Deferred{
-			Reason: datasource.DeferredReasonDataSourceConfigUnknown,
-		}
+	if deferIfConfigUnknown(req, resp) {
 		return
 	}
 

--- a/internal/framework/data_source_kubectl_file_documents.go
+++ b/internal/framework/data_source_kubectl_file_documents.go
@@ -65,6 +65,18 @@ func (d *fileDocumentsDataSource) Schema(_ context.Context, _ datasource.SchemaR
 }
 
 func (d *fileDocumentsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	// Deferred actions: defer this data source when the client allows
+	// deferral and its configuration is not yet fully known (e.g. an input
+	// interpolated from a not-yet-applied resource in a deferral-aware run).
+	// Gated on the deferral client capability so the classic read path is
+	// unchanged. See #356.
+	if req.ClientCapabilities.DeferralAllowed && !req.Config.Raw.IsFullyKnown() {
+		resp.Deferred = &datasource.Deferred{
+			Reason: datasource.DeferredReasonDataSourceConfigUnknown,
+		}
+		return
+	}
+
 	var data fileDocumentsModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/framework/data_source_kubectl_filename_list.go
+++ b/internal/framework/data_source_kubectl_filename_list.go
@@ -63,6 +63,18 @@ func (d *filenameListDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 }
 
 func (d *filenameListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	// Deferred actions: defer this data source when the client allows
+	// deferral and its configuration is not yet fully known (e.g. an input
+	// interpolated from a not-yet-applied resource in a deferral-aware run).
+	// Gated on the deferral client capability so the classic read path is
+	// unchanged. See #356.
+	if req.ClientCapabilities.DeferralAllowed && !req.Config.Raw.IsFullyKnown() {
+		resp.Deferred = &datasource.Deferred{
+			Reason: datasource.DeferredReasonDataSourceConfigUnknown,
+		}
+		return
+	}
+
 	var data filenameListModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/framework/data_source_kubectl_filename_list.go
+++ b/internal/framework/data_source_kubectl_filename_list.go
@@ -63,15 +63,7 @@ func (d *filenameListDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 }
 
 func (d *filenameListDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	// Deferred actions: defer this data source when the client allows
-	// deferral and its configuration is not yet fully known (e.g. an input
-	// interpolated from a not-yet-applied resource in a deferral-aware run).
-	// Gated on the deferral client capability so the classic read path is
-	// unchanged. See #356.
-	if req.ClientCapabilities.DeferralAllowed && !req.Config.Raw.IsFullyKnown() {
-		resp.Deferred = &datasource.Deferred{
-			Reason: datasource.DeferredReasonDataSourceConfigUnknown,
-		}
+	if deferIfConfigUnknown(req, resp) {
 		return
 	}
 

--- a/internal/framework/data_source_kubectl_kustomize_documents.go
+++ b/internal/framework/data_source_kubectl_kustomize_documents.go
@@ -87,15 +87,7 @@ func (d *kustomizeDocumentsDataSource) Schema(_ context.Context, _ datasource.Sc
 }
 
 func (d *kustomizeDocumentsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	// Deferred actions: defer this data source when the client allows
-	// deferral and its configuration is not yet fully known (e.g. an input
-	// interpolated from a not-yet-applied resource in a deferral-aware run).
-	// Gated on the deferral client capability so the classic read path is
-	// unchanged. See #356.
-	if req.ClientCapabilities.DeferralAllowed && !req.Config.Raw.IsFullyKnown() {
-		resp.Deferred = &datasource.Deferred{
-			Reason: datasource.DeferredReasonDataSourceConfigUnknown,
-		}
+	if deferIfConfigUnknown(req, resp) {
 		return
 	}
 

--- a/internal/framework/data_source_kubectl_kustomize_documents.go
+++ b/internal/framework/data_source_kubectl_kustomize_documents.go
@@ -87,6 +87,18 @@ func (d *kustomizeDocumentsDataSource) Schema(_ context.Context, _ datasource.Sc
 }
 
 func (d *kustomizeDocumentsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	// Deferred actions: defer this data source when the client allows
+	// deferral and its configuration is not yet fully known (e.g. an input
+	// interpolated from a not-yet-applied resource in a deferral-aware run).
+	// Gated on the deferral client capability so the classic read path is
+	// unchanged. See #356.
+	if req.ClientCapabilities.DeferralAllowed && !req.Config.Raw.IsFullyKnown() {
+		resp.Deferred = &datasource.Deferred{
+			Reason: datasource.DeferredReasonDataSourceConfigUnknown,
+		}
+		return
+	}
+
 	var data kustomizeDocumentsModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/framework/data_source_kubectl_manifest.go
+++ b/internal/framework/data_source_kubectl_manifest.go
@@ -205,6 +205,18 @@ func (d *manifestDataSource) Configure(_ context.Context, req datasource.Configu
 // distinct diagnostic so callers can pattern-match the "not found" case
 // without parsing free-form text. Implements datasource.DataSource.
 func (d *manifestDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	// Deferred actions: defer this data source when the client allows
+	// deferral and its configuration is not yet fully known (e.g. name or
+	// namespace interpolated from a not-yet-applied resource in a
+	// deferral-aware run). Gated on the deferral client capability so the
+	// classic read path is unchanged. See #356.
+	if req.ClientCapabilities.DeferralAllowed && !req.Config.Raw.IsFullyKnown() {
+		resp.Deferred = &datasource.Deferred{
+			Reason: datasource.DeferredReasonDataSourceConfigUnknown,
+		}
+		return
+	}
+
 	var data manifestDataModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/framework/data_source_kubectl_manifest.go
+++ b/internal/framework/data_source_kubectl_manifest.go
@@ -205,15 +205,7 @@ func (d *manifestDataSource) Configure(_ context.Context, req datasource.Configu
 // distinct diagnostic so callers can pattern-match the "not found" case
 // without parsing free-form text. Implements datasource.DataSource.
 func (d *manifestDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	// Deferred actions: defer this data source when the client allows
-	// deferral and its configuration is not yet fully known (e.g. name or
-	// namespace interpolated from a not-yet-applied resource in a
-	// deferral-aware run). Gated on the deferral client capability so the
-	// classic read path is unchanged. See #356.
-	if req.ClientCapabilities.DeferralAllowed && !req.Config.Raw.IsFullyKnown() {
-		resp.Deferred = &datasource.Deferred{
-			Reason: datasource.DeferredReasonDataSourceConfigUnknown,
-		}
+	if deferIfConfigUnknown(req, resp) {
 		return
 	}
 

--- a/internal/framework/data_source_kubectl_path_documents.go
+++ b/internal/framework/data_source_kubectl_path_documents.go
@@ -104,15 +104,7 @@ func (d *pathDocumentsDataSource) Schema(_ context.Context, _ datasource.SchemaR
 }
 
 func (d *pathDocumentsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	// Deferred actions: defer this data source when the client allows
-	// deferral and its configuration is not yet fully known (e.g. an input
-	// interpolated from a not-yet-applied resource in a deferral-aware run).
-	// Gated on the deferral client capability so the classic read path is
-	// unchanged. See #356.
-	if req.ClientCapabilities.DeferralAllowed && !req.Config.Raw.IsFullyKnown() {
-		resp.Deferred = &datasource.Deferred{
-			Reason: datasource.DeferredReasonDataSourceConfigUnknown,
-		}
+	if deferIfConfigUnknown(req, resp) {
 		return
 	}
 

--- a/internal/framework/data_source_kubectl_path_documents.go
+++ b/internal/framework/data_source_kubectl_path_documents.go
@@ -104,6 +104,18 @@ func (d *pathDocumentsDataSource) Schema(_ context.Context, _ datasource.SchemaR
 }
 
 func (d *pathDocumentsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	// Deferred actions: defer this data source when the client allows
+	// deferral and its configuration is not yet fully known (e.g. an input
+	// interpolated from a not-yet-applied resource in a deferral-aware run).
+	// Gated on the deferral client capability so the classic read path is
+	// unchanged. See #356.
+	if req.ClientCapabilities.DeferralAllowed && !req.Config.Raw.IsFullyKnown() {
+		resp.Deferred = &datasource.Deferred{
+			Reason: datasource.DeferredReasonDataSourceConfigUnknown,
+		}
+		return
+	}
+
 	var data pathDocumentsModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/framework/deferred.go
+++ b/internal/framework/deferred.go
@@ -1,0 +1,20 @@
+package framework
+
+import "github.com/hashicorp/terraform-plugin-framework/datasource"
+
+// deferIfConfigUnknown reports whether a data source read should be deferred
+// and, when so, records the deferral on resp. A read is deferred when the
+// Terraform client allows deferral (a deferral-aware workflow such as
+// Terraform Stacks) and the data source configuration is not yet fully known,
+// e.g. an input interpolated from a not-yet-applied resource. Callers must
+// return immediately when this returns true. Gated on the client capability
+// so the classic read path is unchanged. See #356.
+func deferIfConfigUnknown(req datasource.ReadRequest, resp *datasource.ReadResponse) bool {
+	if req.ClientCapabilities.DeferralAllowed && !req.Config.Raw.IsFullyKnown() {
+		resp.Deferred = &datasource.Deferred{
+			Reason: datasource.DeferredReasonDataSourceConfigUnknown,
+		}
+		return true
+	}
+	return false
+}

--- a/internal/framework/resource_kubectl_manifest.go
+++ b/internal/framework/resource_kubectl_manifest.go
@@ -771,6 +771,20 @@ func (r *manifestResource) ModifyPlan(ctx context.Context, req resource.ModifyPl
 		return
 	}
 
+	// Deferred actions: when the client allows deferral and the resource
+	// configuration is not yet fully known (e.g. yaml_body interpolates a
+	// value from a not-yet-applied resource in a deferral-aware run), defer
+	// this resource rather than plan it from unknown values. Gated on the
+	// deferral client capability so the classic plan/apply flow is
+	// unchanged; provider-config-unknown is handled separately in
+	// Configure (#354). See #356.
+	if req.ClientCapabilities.DeferralAllowed && !req.Config.Raw.IsFullyKnown() {
+		resp.Deferred = &resource.Deferred{
+			Reason: resource.DeferredReasonResourceConfigUnknown,
+		}
+		return
+	}
+
 	var plan manifestResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/framework/resource_kubectl_manifest_deferred_test.go
+++ b/internal/framework/resource_kubectl_manifest_deferred_test.go
@@ -1,0 +1,78 @@
+package framework
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// TestManifestResourceModifyPlanDeferredActions pins the resource-level
+// deferred-actions behaviour for issue #356 on kubectl_manifest. When the
+// client allows deferral and the resource configuration is not fully known
+// (e.g. yaml_body interpolates a not-yet-applied value), ModifyPlan must
+// return a deferral with DeferredReasonResourceConfigUnknown. The capability
+// gate must keep the classic plan path unchanged.
+func TestManifestResourceModifyPlanDeferredActions(t *testing.T) {
+	ctx := context.Background()
+	r := NewManifestResource()
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	objType, ok := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatalf("resource schema type is %T, want tftypes.Object", schemaResp.Schema.Type().TerraformType(ctx))
+	}
+
+	// Config wholly unknown -> not fully known; the deferral guard runs
+	// before the plan is decoded.
+	unknownCfg := tftypes.NewValue(objType, tftypes.UnknownValue)
+
+	// Plan: a known object (non-null, so it passes the destroy early-return)
+	// with yaml_body unknown, so the capability-off path returns cleanly at
+	// the existing "yaml_body is unknown" early-return rather than parsing.
+	planAttrs := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for n, at := range objType.AttributeTypes {
+		planAttrs[n] = tftypes.NewValue(at, nil)
+	}
+	planAttrs["yaml_body"] = tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+	planVal := tftypes.NewValue(objType, planAttrs)
+
+	nullState := tftypes.NewValue(objType, nil)
+
+	modifyPlan := func(deferralAllowed bool) *resource.ModifyPlanResponse {
+		req := resource.ModifyPlanRequest{
+			Config:             tfsdk.Config{Schema: schemaResp.Schema, Raw: unknownCfg},
+			Plan:               tfsdk.Plan{Schema: schemaResp.Schema, Raw: planVal},
+			State:              tfsdk.State{Schema: schemaResp.Schema, Raw: nullState},
+			ClientCapabilities: resource.ModifyPlanClientCapabilities{DeferralAllowed: deferralAllowed},
+		}
+		resp := &resource.ModifyPlanResponse{
+			Plan: tfsdk.Plan{Schema: schemaResp.Schema, Raw: planVal},
+		}
+		r.(resource.ResourceWithModifyPlan).ModifyPlan(ctx, req, resp)
+		return resp
+	}
+
+	t.Run("deferral allowed defers", func(t *testing.T) {
+		resp := modifyPlan(true)
+		if resp.Deferred == nil {
+			t.Fatalf("expected a deferred plan, got none")
+		}
+		if resp.Deferred.Reason != resource.DeferredReasonResourceConfigUnknown {
+			t.Errorf("deferred reason = %s, want Resource Config Unknown", resp.Deferred.Reason)
+		}
+		if resp.Diagnostics.HasError() {
+			t.Errorf("unexpected diagnostics on deferral: %s", resp.Diagnostics)
+		}
+	})
+
+	t.Run("capability off does not defer", func(t *testing.T) {
+		resp := modifyPlan(false)
+		if resp.Deferred != nil {
+			t.Errorf("did not expect a deferred plan without the capability, got %s", resp.Deferred.Reason)
+		}
+	})
+}

--- a/internal/framework/resource_kubectl_manifest_deferred_test.go
+++ b/internal/framework/resource_kubectl_manifest_deferred_test.go
@@ -18,6 +18,10 @@ import (
 func TestManifestResourceModifyPlanDeferredActions(t *testing.T) {
 	ctx := context.Background()
 	r := NewManifestResource()
+	rmp, ok := r.(resource.ResourceWithModifyPlan)
+	if !ok {
+		t.Fatalf("manifest resource does not implement ResourceWithModifyPlan")
+	}
 
 	var schemaResp resource.SchemaResponse
 	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
@@ -52,7 +56,7 @@ func TestManifestResourceModifyPlanDeferredActions(t *testing.T) {
 		resp := &resource.ModifyPlanResponse{
 			Plan: tfsdk.Plan{Schema: schemaResp.Schema, Raw: planVal},
 		}
-		r.(resource.ResourceWithModifyPlan).ModifyPlan(ctx, req, resp)
+		rmp.ModifyPlan(ctx, req, resp)
 		return resp
 	}
 


### PR DESCRIPTION
## What

Extends Terraform deferred-actions support from the provider level (added in #355) down to the resource and data-source level, so the provider also defers when a resource's or data source's own configuration is not yet known.

## Why

#355 covers the case where the provider configuration itself is unknown (e.g. `host` / `token` from a not-yet-applied EKS component in a Stacks run). It does not cover the case where the provider is fully configured but an individual resource or data source reads a value that is still unknown, for example a `kubectl_manifest` whose `yaml_body` interpolates an attribute produced by another resource in the same deferral-aware run, or a data source whose path / name comes from such a value. In that situation the provider would previously plan or read against unknown input rather than signalling a deferral.

## How

`kubectl_manifest` `ModifyPlan` now returns `resource.Deferred{Reason: DeferredReasonResourceConfigUnknown}` when `req.ClientCapabilities.DeferralAllowed` is true and `req.Config.Raw.IsFullyKnown()` is false, before any plan mutation. The guard sits after the destroy early-return, so destroys are never deferred.

The five config-driven data sources (`kubectl_filename_list`, `kubectl_file_documents`, `kubectl_path_documents`, `kubectl_kustomize_documents`, `kubectl_manifest`) apply the same guard at the top of `Read`, returning `datasource.Deferred{Reason: DeferredReasonDataSourceConfigUnknown}`. The input-less `kubectl_server_version` data source is intentionally left untouched: it has no configuration that can be unknown, so a guard there would be dead code.

Every guard is gated on the deferral client capability, so the classic `plan` / `apply` flow and the existing `lazy_load` path are unchanged. No dependency bump is required.

## Testing

`resource_kubectl_manifest_deferred_test.go` drives `ModifyPlan` with an unknown config and asserts the deferral (and that the capability gate suppresses it). `data_source_deferred_test.go` is table-driven across the five data sources, asserting each `Read` defers with the right reason when allowed and does not when the capability is off.

```
go build ./...
go test ./internal/framework/ -run Defer -race
make test   # full unit suite, green
make doc-coverage
```

Fixes: alekc/terraform-provider-kubectl#356


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terraform operations now defer data source reads and `kubectl_manifest` plan changes when deferral is supported and configuration isn’t fully known, improving smooth execution with unknown values.

* **Bug Fixes**
  * Data sources and the manifest resource now safely avoid processing incomplete inputs by returning deferred responses with clear reasons, while preserving the normal path when deferral isn’t allowed.

* **Tests**
  * Added coverage to confirm deferred behavior across supported data sources and the manifest resource.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->