### PR TITLE
docs(index): narrow the deferred-actions scope wording

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -222,7 +222,7 @@ Workarounds, in order of preference:
    ```
 
 On workflows that support [deferred actions](https://developer.hashicorp.com/terraform/language/stacks/use-cases)
-(Terraform Stacks, and `terraform plan`/`apply` runs that opt into deferral),
+(Terraform Stacks, and other deferral-aware Terraform clients),
 none of the workarounds above are needed. When the provider configuration is
 not yet fully known (for example `host`, `token`, or `cluster_ca_certificate`
 sourced from an EKS component that has not been applied yet), the provider


### PR DESCRIPTION
## What

Tightens one clause in the deferred-actions Troubleshooting note in `docs/index.md`.

## Why

`Configure` only returns a deferral when the client sets `DeferralAllowed`, so the previous wording "Terraform Stacks, and `terraform plan`/`apply` runs that opt into deferral" read too broadly and could imply that ordinary `plan` / `apply` runs now defer. This scopes it to deferral-aware clients (Terraform Stacks). Addresses a CodeRabbit review comment left on #355 (the deferred-actions PR that fixed #354); it was an "outside diff range" comment, so it was not applied at the time.

Docs-only, one line.

Refs: alekc/terraform-provider-kubectl#354


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the troubleshooting guidance for a RESTMapper/discovery client error.
  * Updated wording around deferred actions to use broader Terraform client terminology for easier understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->